### PR TITLE
NIM-17256: Signature component behaves inconsistently

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -580,51 +580,6 @@ public class ViewConfig {
 		boolean postEventOnChange() default false; 
 		String controlId() default ""; 
 	}
-	
-	@Retention(RetentionPolicy.RUNTIME) 
-	@Target({ElementType.FIELD}) 
-	@ViewStyle 
-	public @interface Signature { 
-		String alias() default "Signature";
-		
-		/**
-		 * Controls how the signature drawing will be captured.
-		 * 
-		 * @see com.antheminc.oss.nimbus.domain.defn.ViewConfig.Signature.CaptureType
-		 * @return the capture type
-		 */
-		CaptureType captureType() default CaptureType.DEFAULT;
-		boolean hidden() default false; 
-		String help() default ""; 
-		String labelClass() default "anthem-label"; 
-		String type() default "signature";
-		boolean postEventOnChange() default false; 
-		String controlId() default "";
-		String clearLabel() default "Clear";
-		String acceptLabel() default "Save";
-		String width() default "345";
-		String height() default "60";
-		
-		/**
-		 * The strategy for how the signature drawing should be captured on the UI.
-		 * 
-		 * @author Tony Lopez
-		 *
-		 */
-		public enum CaptureType {
-			
-			/**
-			 * Signature data is captured in between the mouse down and mouse up events.
-			 */
-			DEFAULT,
-			
-			/**
-			 * Signature data is captured upon the click event. Capturing will continue until the click 
-			 * event is invoked a second time.
-			 */
-			ON_CLICK;
-		}
-	}
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ElementType.FIELD})
@@ -855,6 +810,97 @@ public class ViewConfig {
 		String sourceHeader() default "SourceList";
 		String targetHeader() default "TargetList";
 		String help() default "";
+	}
+	
+	/**
+	 * <p>The Signature component is used to capture a user's signature using user input in the form of
+	 * a <a href="https://www.ietf.org/rfc/rfc2397.txt">Data URL</a>.
+	 * 
+	 * <p><b>Expected Field Structure</b>
+	 * 
+	 * <p>Signature will be rendered when annotating a field nested under one of the following components:
+	 * <ul>
+	 * <li>{@link Form}</li>
+	 * </ul>
+	 * 
+	 * <p>Signature should decorate a field having a simple type.
+	 * <p><b>Sample Usage:</b>
+	 * <pre>
+	 * &#64;Signature
+	 * private String userSignature;
+	 * </pre>
+	 * 
+	 * @since 1.0
+	 * @author Rakesh Patel
+	 * @author Tony Lopez
+	 */
+	@Retention(RetentionPolicy.RUNTIME) 
+	@Target({ElementType.FIELD}) 
+	@ViewStyle 
+	public @interface Signature {
+		
+		/**
+		 * <p>The strategy for how the signature drawing should be captured on the UI.
+		 */
+		public enum CaptureType {
+			
+			/**
+			 * <p>Signature data is captured in between the mouse down and mouse up events.
+			 */
+			DEFAULT,
+			
+			/**
+			 * <p>Signature data is captured upon the click event. Capturing will continue until the click 
+			 * event is invoked a second time.
+			 */
+			ON_CLICK;
+		}
+		
+		/**
+		 * <p>The label value displayed on the "save" button.
+		 */
+		String acceptLabel() default "Save";
+		/**
+		 * <p>To be used by the client as a unique identifier for this component.
+		 * <p><b>THIS VALUE SHOULD NOT BE CHANGED!
+		 */
+		String alias() default "Signature"; 
+		/**
+		 * <p>Control how the signature drawing will be captured.
+		 * @see com.antheminc.oss.nimbus.domain.defn.ViewConfig.Signature.CaptureType
+		 */
+		CaptureType captureType() default CaptureType.DEFAULT;
+		/**
+		 * <p>The label value displayed on the "clear" button.
+		 */
+		String clearLabel() default "Clear";
+		/**
+		 * <p>CSS classes added here will be added to the container element surrounding this component.
+		 * <p>This can be used to apply additional styling, if necessary.
+		 */
+		String cssClass() default "";
+		/**
+		 * <p>The width of the signature canvas. 
+		 */
+		String height() default "60";
+		/**
+		 * <p>When {@code true}, the the label and help text will be hidden for this component.
+		 */
+		boolean hidden() default false;
+		/**
+		 * <p>When {@code true} and the value of this component is changed on the client, the updated 
+		 * value will be sent to the server.
+		 */
+		boolean postEventOnChange() default false;
+		/**
+		 * <p>To be used by the client as a unique identifier for this component.
+		 * <p><b>THIS VALUE SHOULD NOT BE CHANGED!
+		 */
+		String type() default "signature";
+		/**
+		 * <p>The width of the signature canvas. 
+		 */
+		String width() default "345";
 	}
 	
 	@Retention(RetentionPolicy.RUNTIME)

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
@@ -54,7 +54,7 @@ export abstract class BaseControl<T> extends BaseControlValueAccessor<T> {
     validationChangeSubscriber: Subscription;
     onChangeSubscriber: Subscription;
 
-    constructor(private controlService: ControlSubscribers, private wcs: WebContentSvc, private cd: ChangeDetectorRef) {
+    constructor(protected controlService: ControlSubscribers, private wcs: WebContentSvc, private cd: ChangeDetectorRef) {
         super();
     }
 


### PR DESCRIPTION
# Overview of Changes
* Removed signature's underlying ```<img>``` tag and added control for the ```canvas``` element to be the primary display of signature data
* Added control subscriber to monitor enabled property for form controls. Currently only signature.component.ts is subscribing to it in ```ngOnit```
* Refactored ```signature.component.ts``` for code cleanup
* Added Javadocs for ```Signature``` in View Config
* Added documentation to ```signature.component.ts```

# Description of Issue
The issue was that the underyling ```<canvas>``` HTML element was being removed due to the ```ngIf``` re-rendering when the signature components ```disabled``` property changed. This was causing the existing configurations for the ```<canvas>``` element to be lost after something like ```EnableConditional``` or ```ActivateConditional``` affected the ```disabled``` property.

# Solution
Moved the ```<canvas>``` element out of the ```<ng-template>``` and left it as always displayed, replacing the existing logic to display an ```<img>``` tag containing the signature data in the ```src``` attribute via Data URL.