### PR TITLE
NIM-17256: Signature component behaves inconsistently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,17 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*/nimbus-ui-app/node
+*/nimbus-ui-app/node_modules
+*/nimbus-ui-app/dist
+*/nimbusui/node
+*/nimbusui/node_modules
+*/nimbusui/dist
+*/nimbusui/etc
+/nimbus-ui-app/dist
+/nimbus-ui-app/etc
+/nimbus-ui-app/node
+/nimbus-ui-app/node_modules 
 
 # Runtime data
 pids

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -1403,9 +1403,6 @@ public class ViewConfig {
 	 * <p><b>Expected Field Structure</b>
 	 * 
 	 * <p>Radio will be rendered when annotating a field nested under one of the following components:
-	 * <ul>
-	 * <li>{@link Form}</li>
-	 * </ul>
 	 * 
 	 * <p>Radio should decorate a field having a simple type.
 	 * 
@@ -1472,6 +1469,9 @@ public class ViewConfig {
 	}
 	
 	/**
+	 * <p>The Signature component is used to capture a user's signature using user input in the form of
+	 * a <a href="https://www.ietf.org/rfc/rfc2397.txt">Data URL</a>.
+	 * 
 	 * <p><b>Expected Field Structure</b>
 	 * 
 	 * <p>Signature will be rendered when annotating a field nested under one of the following components:
@@ -1480,6 +1480,11 @@ public class ViewConfig {
 	 * </ul>
 	 * 
 	 * <p>Signature should decorate a field having a simple type.
+	 * <p><b>Sample Usage:</b>
+	 * <pre>
+	 * &#64;Signature
+	 * private String userSignature;
+	 * </pre>
 	 * 
 	 * @since 1.0
 	 * @author Rakesh Patel
@@ -1488,44 +1493,72 @@ public class ViewConfig {
 	@Retention(RetentionPolicy.RUNTIME) 
 	@Target({ElementType.FIELD}) 
 	@ViewStyle 
-	public @interface Signature { 
+	public @interface Signature {
 		
 		/**
-		 * The strategy for how the signature drawing should be captured on the UI.
+		 * <p>The strategy for how the signature drawing should be captured on the UI.
 		 */
 		public enum CaptureType {
 			
 			/**
-			 * Signature data is captured in between the mouse down and mouse up events.
+			 * <p>Signature data is captured in between the mouse down and mouse up events.
 			 */
 			DEFAULT,
 			
 			/**
-			 * Signature data is captured upon the click event. Capturing will continue until the click 
+			 * <p>Signature data is captured upon the click event. Capturing will continue until the click 
 			 * event is invoked a second time.
 			 */
 			ON_CLICK;
 		}
 		
+		/**
+		 * <p>The label value displayed on the "save" button.
+		 */
 		String acceptLabel() default "Save";
+		/**
+		 * <p>To be used by the client as a unique identifier for this component.
+		 * <p><b>THIS VALUE SHOULD NOT BE CHANGED!
+		 */
 		String alias() default "Signature"; 
 		/**
-		 * Controls how the signature drawing will be captured.
+		 * <p>Control how the signature drawing will be captured.
 		 * @see com.antheminc.oss.nimbus.domain.defn.ViewConfig.Signature.CaptureType
 		 */
-		CaptureType captureType() default CaptureType.DEFAULT; 
-		String clearLabel() default "Clear"; 
-		String controlId() default "";
-		String height() default "60"; 
-		String help() default "";
-		boolean hidden() default false;
-		String labelClass() default "anthem-label";
-		boolean postEventOnChange() default false;
-		String type() default "signature";
+		CaptureType captureType() default CaptureType.DEFAULT;
+		/**
+		 * <p>The label value displayed on the "clear" button.
+		 */
+		String clearLabel() default "Clear";
+		/**
+		 * <p>CSS classes added here will be added to the container element surrounding this component.
+		 * <p>This can be used to apply additional styling, if necessary.
+		 */
 		String cssClass() default "";
+		/**
+		 * <p>The width of the signature canvas. 
+		 */
+		String height() default "60";
+		/**
+		 * <p>When {@code true}, the the label and help text will be hidden for this component.
+		 */
+		boolean hidden() default false;
+		/**
+		 * <p>When {@code true} and the value of this component is changed on the client, the updated 
+		 * value will be sent to the server.
+		 */
+		boolean postEventOnChange() default false;
+		/**
+		 * <p>To be used by the client as a unique identifier for this component.
+		 * <p><b>THIS VALUE SHOULD NOT BE CHANGED!
+		 */
+		String type() default "signature";
+		/**
+		 * <p>The width of the signature canvas. 
+		 */
 		String width() default "345";
 	}
-	
+
 	/**
 	 * <p><b>Expected Field Structure</b>
 	 * 

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
@@ -55,7 +55,7 @@ export abstract class BaseControl<T> extends BaseControlValueAccessor<T> {
     validationChangeSubscriber: Subscription;
     onChangeSubscriber: Subscription;
 
-    constructor(private controlService: ControlSubscribers, private wcs: WebContentSvc, private cd: ChangeDetectorRef) {
+    constructor(protected controlService: ControlSubscribers, private wcs: WebContentSvc, private cd: ChangeDetectorRef) {
         super();
     }
 

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/signature.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/signature.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 'use strict';
-import { NgModel, NG_VALUE_ACCESSOR, ControlValueAccessor, FormGroup } from '@angular/forms';
+import { NgModel, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Component, ViewChild, ElementRef, forwardRef, Input, ChangeDetectorRef } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
@@ -26,9 +26,9 @@ import 'rxjs/add/operator/switchMap';
 
 import { WebContentSvc } from '../../../../services/content-management.service';
 import { BaseControl } from './base-control.component';
-import { PageService } from '../../../../services/page.service';
 import { Param } from '../../../../shared/param-state';
 import { ControlSubscribers } from '../../../../services/control-subscribers.service';
+import { LoggerService } from './../../../../services/logger.service';
 
 export const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -56,57 +56,59 @@ export const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR: any = {
                 [helpText]='helpText'>
             </nm-tooltip>
         </label>
+        <canvas #canvas 
+            [id]="element.config?.code" 
+            class="form-control" ngDefaultControl>
+        </canvas>
         <ng-template [ngIf]="!disabled">
-            <canvas #canvas
-                [id]="element.config?.code" 
-                class="form-control" ngDefaultControl>
-            </canvas>
             <div class="text-sm-center buttonGroup signatureCtrls" [style.width.px]="width">
-                <ng-template [ngIf]="save">
-                    <button (click)="acceptSignature()" type="button" class="btn btn-secondary post-btn">
+                <ng-template [ngIf]="!isSaved">
+                    <button (click)="save()" type="button" class="btn btn-secondary post-btn">
                         {{element.config?.uiStyles?.attributes?.acceptLabel}}
                     </button>
                 </ng-template>
-                <button (click)="clearSignature()" type="button" class="btn btn-secondary post-btn">
+                <button (click)="clear()" type="button" class="btn btn-secondary post-btn">
                     {{element.config?.uiStyles?.attributes?.clearLabel}}
                 </button>
                 <button class="btn btn-plain" (click)="zoomCanvas()" *ngIf="zoomFactor==1"><i class="fa fa-fw fa-plus-square" aria-hidden="true"></i>Zoom In</button>
                 <button class="btn btn-plain" (click)="shrinkCanvas()" *ngIf="zoomFactor==2"><i class="fa fa-fw fa-minus-square" aria-hidden="true"></i>Zoom Out</button>
             </div>
-            <img #img [src]="value != null || value != '' ? value : defaultEmptyImage" (load)="onImgLoad()" style='display: none;' />
-        </ng-template>
-        <ng-template [ngIf]="disabled">
-            <img #img src="{{value}}" />
         </ng-template>
     </div>
    `
 })
-export class Signature extends BaseControl<String> {
-    @ViewChild(NgModel) model: NgModel;
+export class Signature extends BaseControl<string> {
     
-    @ViewChild('canvas') canvas: ElementRef;
-    canvasEl: HTMLCanvasElement;
-    cx: CanvasRenderingContext2D;
-
-    @ViewChild('img') img: ElementRef;
-    imgElement: HTMLImageElement;
-    
-    @Input() element: Param;
-    
-    width: number;
-    height: number;
-    save: boolean = true;
-    zoomClass: string = '';
-    zoomFactor: number = 1;
-    defaultEmptyImage: string = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAVkAAAA8CAYAAADMvMmGAAAB+klEQVR4Xu3UsQ0AAAjDMPr/01yRzRzQwULZOQIECBDIBJYtGyZAgACBE1lPQIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBB41fMAPZcifoIAAAAASUVORK5CYII=";
-    
-    isCapturing: boolean = false;
-    
-    constructor(wcs: WebContentSvc, controlService: ControlSubscribers, cd:ChangeDetectorRef) {
-        super(controlService, wcs, cd);
+    public static readonly EVENT_NAMES = {
+        CLICK: 'click',
+        MOUSE_DOWN: 'mousedown',
+        MOUSE_MOVE: 'mousemove',
+        MOUSE_UP: 'mouseup',
     }
 
-    ngOnInit() {
+    @ViewChild('canvas') canvas: ElementRef;
+    @Input() element: Param;
+    @ViewChild(NgModel) model: NgModel;
+
+    canvasEl: HTMLCanvasElement;
+    defaultEmptyImage: string = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAVkAAAA8CAYAAADMvMmGAAAB+klEQVR4Xu3UsQ0AAAjDMPr/01yRzRzQwULZOQIECBDIBJYtGyZAgACBE1lPQIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBAQWT9AgACBUEBkQ1zTBAgQEFk/QIAAgVBAZENc0wQIEBBZP0CAAIFQQGRDXNMECBB41fMAPZcifoIAAAAASUVORK5CYII=";
+    height: number;
+    isCapturing: boolean = false;
+    isSaved: boolean = false;
+    width: number;
+    zoomClass: string = '';
+    zoomFactor: number = 1;
+    
+    constructor(
+        wcs: WebContentSvc, 
+        controlService: ControlSubscribers, 
+        cd: ChangeDetectorRef, 
+        private logger: LoggerService) {
+        
+            super(controlService, wcs, cd);
+    }
+
+    public ngOnInit() {
         super.ngOnInit();
         if(this.element.config !== undefined) {
             this.width = Number(this.element.config.uiStyles.attributes.width);
@@ -114,162 +116,173 @@ export class Signature extends BaseControl<String> {
         }
     }
 
-    ngAfterViewInit() {
+    public ngAfterViewInit() {
         super.ngAfterViewInit();
-        if(this.img !== undefined) {
-            this.imgElement = this.img.nativeElement;
-        }
-        if(this.element.enabled) {
-            this.initCanvasElement();
-            this.captureEvents(this.canvasEl);
-        }
+        this.initCanvasElement();
+
+        // If the disabled property changes, ensure the canvas size is restored.
+        this.controlService.onEnabledUpdateSubscriber(this, undefined, () => {
+            this.shrinkCanvas();
+        });
     }
 
-    initCanvasElement() {
+    /**
+     * Initialize the canvas element including applying any default rules and subscription registrations
+     * that should occur.
+     */
+    private initCanvasElement() {
         this.canvasEl = this.canvas.nativeElement;
-        this.cx = this.canvasEl.getContext('2d');
-
         this.canvasEl.width = this.width;
         this.canvasEl.height = this.height;
 
-        this.cx.lineWidth = 3;
-        this.cx.lineCap = 'round';
-        this.cx.strokeStyle = '#000';
+        this.applyContextRules();
+        this.renderExistingSignature();
+        this.registerCaptureEvents();
      }
     
      /**
-      * Provided <tt>canvasEl</tt>, performs subscriptions that should occur related to "capturing"
-      * user input on an HTML canvas element, using the usual observer/subscriber pattern.
-      * 
-      * @param canvasEl the HTML Canvas element to register subscribers with
+      * Render the existing signature (if signature data exists)
       */
-    captureEvents(canvasEl: HTMLCanvasElement) {
+     private renderExistingSignature() {
+        if(this.value) {
+            this.logger.debug(`Found exsiting signature data to render: ${this.value}`);
+            var img = new Image();
+            var self = this;
+            img.onload = () => self.canvasEl.getContext('2d').drawImage(img, 0, 0, self.width, self.height);
+            img.src = this.value;
+        }
+     }
+
+     /**
+      * Apply styling rules to the canvas, such as brush size, line width, etc.
+      * @param cx the canvas context object
+      */
+     private applyContextRules(): CanvasRenderingContext2D {
+        let cx = this.canvasEl.getContext('2d');
+        cx.lineWidth = 3;
+        cx.lineCap = 'round';
+        cx.strokeStyle = '#000';
+        return cx;
+     }
+
+     /**
+      * Register subscriptions that should occur related to "capturing"
+      * user input on an HTML canvas element, using the usual observer/subscriber pattern.
+      * The capturing event type registered will be selected based on the server-side configuration 
+      * of captureType.
+      */
+    private registerCaptureEvents() {
         switch (this.captureType) {
             case 'DEFAULT': {
-                this.registerDefaultCapture(canvasEl);
+                this.registerCaptureOnEvent(Signature.EVENT_NAMES.MOUSE_DOWN, Signature.EVENT_NAMES.MOUSE_UP);
                 break;
             }
             case 'ON_CLICK': {
-                this.registerOnClickCapture(canvasEl);
+                this.registerCaptureOnEvent(Signature.EVENT_NAMES.CLICK, Signature.EVENT_NAMES.CLICK);
                 break;
             }
         }
     }
 
-    onImgLoad() {
-        if(this.element.enabled) {
-            this.initCanvasElement();
-        }
-        this.cx.clearRect(0, 0, this.width, this.height);
-        if(this.img.nativeElement.src != this.defaultEmptyImage ){
-            this.cx.drawImage(this.imgElement, 0, 0, this.width, this.height);
-            this.toggleSave(false);
-        }
-    }
-
-    clearSignature() {
-        this.cx.clearRect(0, 0, this.width, this.height);
+    /**
+     * Clear the signature canvas data and essentially reset the component to its initial state.
+     */
+    public clear() {
+        this.canvasEl.getContext('2d').clearRect(0, 0, this.width, this.height);
         this.value = '';
-        this.imgElement.src = "";
         super.emitValueChangedEvent(this, '');
-        this.toggleSave(true);
+        this.isSaved = false;
     }
 
-    acceptSignature() {
+    /**
+     * Save the signature canvas data into this instances value property as a data URL string.
+     */
+    public save() {
         var imageData: string = this.canvasEl.toDataURL();
         if(imageData == this.defaultEmptyImage) {
-            this.clearSignature();
-        }
-        else {
+            this.clear();
+        } else {
             this.value = imageData;
-            this.imgElement.src = imageData;
             super.emitValueChangedEvent(this, this.value);
-            this.toggleSave(false);
+            this.isSaved = true;
         }
         this.shrinkCanvas();
     }
 
-    toggleSave(mode: boolean) {
-        this.save = mode;
-    }
-
-    zoomCanvas() {
+    /**
+     * Zoom in the canvas to a zoomed in size.
+     */
+    public zoomCanvas() {
         this.zoomFactor = 2;
         this.zoomClass = 'zoom';
     }
 
-    shrinkCanvas() {
+    /**
+     * Zoom out the canvas to regular size.
+     */
+    public shrinkCanvas() {
         this.zoomFactor = 1;
         this.zoomClass = '';
     }
 
-    get captureType() {
+    /**
+     * Return the capture type as defined by the server.
+     */
+    public get captureType() {
         return this.element.config.uiStyles.attributes.captureType;
     }
 
     /**
-     * Uses the subscriber pattern to capture user input on an HTML canvas element.
-     * 
-     * Applies a capture strategy of <tt>ON_CLICK</tt>, where user input is captured when the user clicks on <tt>canvasEl</tt>, and continues to 
-     * capture until the user clicks on <tt>canvasEl</tt> again.
-     *  
-     * @param canvasEl the HTML Canvas element to register subscribers with
+     * Register the signature capture to start after the event related to startEventName is triggered and
+     * end when the event related to endEventName is triggered.
+     * @param startEventName the name of the event to start capturing
+     * @param endEventName the name of the event to end capturing
      */
-    private registerOnClickCapture(canvasEl: HTMLCanvasElement) {
-        const canvasElClick = Observable.fromEvent(canvasEl, 'click');
-        
-        canvasElClick.subscribe((e) => this.isCapturing = !this.isCapturing);
-        
-        canvasElClick
-            .switchMap((e) => {
-                return Observable
-                    .fromEvent(canvasEl, 'mousemove')
-                    .takeUntil(Observable
-                        .fromEvent(canvasEl, 'click')
-                    )
-                    .pairwise()
-            })
-            .subscribe((res: [MouseEvent, MouseEvent]) => {
-                if (this.isCapturing) {
-                    this.drawOnCanvas(canvasEl, res[0], res[1]);
-                }
+    private registerCaptureOnEvent(startEventName: string, endEventName: string) {
+        const $startEvent = Observable.fromEvent(this.canvasEl, startEventName);
+        const $endEvent = Observable.fromEvent(this.canvasEl, endEventName)
+
+        if (startEventName === endEventName) {
+            $startEvent.subscribe((e) => this.setIsCapturing(!this.isCapturing));
+        } else {
+            $startEvent.subscribe((e) => this.setIsCapturing(true));
+            $endEvent.subscribe((e) => this.setIsCapturing(false));
+        }
+
+        $startEvent.switchMap((e) => {
+            return Observable
+                .fromEvent(this.canvasEl, Signature.EVENT_NAMES.MOUSE_MOVE)
+                .takeUntil($endEvent)
+                .pairwise()
+        }).subscribe((res: [MouseEvent, MouseEvent]) => {
+            if (this.isEditable() && this.isCapturing) {
+                this.drawOnCanvas(res[0], res[1]);
             }
-        );
+        });
     }
 
     /**
-     * Uses the subscriber pattern to capture user input on an HTML canvas element.
-     * 
-     * Applies a capture strategy of <tt>DEFAULT</tt>, where user input is captured when the user clicks within <tt>canvasEl</tt> 
-     * and holds the left mouse button down, and continues to capture until the left mouse button is released within <tt>canvasEl</tt>.
-     *  
-     * @param canvasEl the HTML Canvas element to register subscribers with
+     * Set the value of isCapturing if this signature component is not disabled or in a saved status.
+     * @param isCapturing the value to set to isCapturing
      */
-    private registerDefaultCapture(canvasEl: HTMLCanvasElement) {
-        Observable
-            .fromEvent(canvasEl, 'mousedown')
-            .switchMap((e) => {
-                return Observable
-                    .fromEvent(canvasEl, 'mousemove')
-                    .takeUntil(Observable.fromEvent(canvasEl, 'mouseup'))
-                    .pairwise()
-            })
-            .subscribe((res: [MouseEvent, MouseEvent]) => {
-                this.drawOnCanvas(canvasEl, res[0], res[1]);
-            }
-        );
+    private setIsCapturing(isCapturing: boolean) {
+        if (this.isEditable()) {
+            this.isCapturing = isCapturing;
+            this.logger.debug(`Signature component is currently ${this.isCapturing ? '' : 'not '}capturing.`);
+        }
+    }
+
+    private isEditable(): boolean {
+        return !this.disabled && !this.isSaved;
     }
 
     /**
-     * Given a previous and current mouse event containing position information, draws a stroke between those two mouse
-     * points to render the pattern the user is moving with the mouse.
-     * 
-     * @param canvasEl the HTML canvas element
+     * Draw a stroke between two mouse points to render the pattern the user is moving with the mouse.
      * @param prevEvent the previous mouse event, containing position information
      * @param currentEvent the current mouse event, containing position information
      */
-    private drawOnCanvas(canvasEl: HTMLCanvasElement, prevEvent: MouseEvent, currentEvent: MouseEvent) {
-        const rect = canvasEl.getBoundingClientRect();
+    private drawOnCanvas(prevEvent: MouseEvent, currentEvent: MouseEvent) {
+        const rect = this.canvasEl.getBoundingClientRect();
         
         const prevPos = {
             x: (prevEvent.clientX - rect.left) / this.zoomFactor,
@@ -281,15 +294,16 @@ export class Signature extends BaseControl<String> {
             y: (currentEvent.clientY - rect.top) / this.zoomFactor
         };
         
-        if (!this.cx) {
+        let cx = this.canvasEl.getContext('2d');
+        if (!cx) {
             return;
         }
-        this.cx.beginPath();
+        cx.beginPath();
 
         if (prevPos) {
-            this.cx.moveTo(prevPos.x, prevPos.y); // from
-            this.cx.lineTo(currentPos.x, currentPos.y);
-            this.cx.stroke();
+            cx.moveTo(prevPos.x, prevPos.y);
+            cx.lineTo(currentPos.x, currentPos.y);
+            cx.stroke();
         }
     }
 }


### PR DESCRIPTION
**Note: This pull request is a cherry-pick, representing the same PR from #105 -- except to 1.1.x**

# Overview of Changes
* Removed signature's underlying ```<img>``` tag and added control for the ```canvas``` element to be the primary display of signature data
* Added control subscriber to monitor enabled property for form controls. Currently only signature.component.ts is subscribing to it in ```ngOnit```
* Refactored ```signature.component.ts``` for code cleanup
* Added Javadocs for ```Signature``` in View Config
* Added documentation to ```signature.component.ts```

# Description of Issue
The issue was that the underyling ```<canvas>``` HTML element was being removed due to the ```ngIf``` re-rendering when the signature components ```disabled``` property changed. This was causing the existing configurations for the ```<canvas>``` element to be lost after something like ```EnableConditional``` or ```ActivateConditional``` affected the ```disabled``` property.

# Solution
Moved the ```<canvas>``` element out of the ```<ng-template>``` and left it as always displayed, replacing the existing logic to display an ```<img>``` tag containing the signature data in the ```src``` attribute via Data URL.