### PR TITLE
NIM-17237: Sonar Bug Fixes

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandElementLinked.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandElementLinked.java
@@ -110,7 +110,7 @@ public class CommandElementLinked extends CommandElement implements Serializable
 		
 		int order = elem.getType().compareTo(getType());
 		
-		if(order == -1) throw new IllegalArgumentException();
+		if(order < 0) throw new IllegalArgumentException();
 		
 		if (order == 0 && !Type.allowedRecursive.contains(getType()))
 			throw new IllegalArgumentException(

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/AbstractCommandExecutor.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/AbstractCommandExecutor.java
@@ -19,9 +19,11 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
+import com.antheminc.oss.nimbus.domain.cmd.CommandElementLinked;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessageConverter;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
@@ -87,7 +89,7 @@ public abstract class AbstractCommandExecutor<R> extends BaseCommandExecutorStra
 		if(cmd.isRootDomainOnly()) 
 			return domainConfig;
 		
-		String path = cmd.buildAlias(cmd.getElement(Type.DomainAlias).get().next());
+		String path = cmd.buildAlias(cmd.getElementSafely(Type.DomainAlias).next());
 		
 		ParamConfig<?> nestedParamConfig = domainConfig.findParamByPath(path);
 		return nestedParamConfig;

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/BaseCommandExecutorStrategies.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/BaseCommandExecutorStrategies.java
@@ -79,7 +79,7 @@ public class BaseCommandExecutorStrategies {
 		if(cmd.isRootDomainOnly()) 
 			return (Param<T>)getQuadModelOrThrowEx(eCtx).getView().getAssociatedParam();
 		
-		String path = cmd.buildAlias(cmd.getElement(Type.DomainAlias).get().next());
+		String path = cmd.buildAlias(cmd.getElementSafely(Type.DomainAlias).next());
 		
 		return getQuadModelOrThrowEx(eCtx).getView().findParamByPath(path);
 	}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/ExecutionContext.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/ExecutionContext.java
@@ -17,6 +17,8 @@ package com.antheminc.oss.nimbus.domain.cmd.exec;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang3.StringUtils;
 
 import com.antheminc.oss.nimbus.domain.cmd.Command;
@@ -74,6 +76,7 @@ public class ExecutionContext implements Serializable {
 		return getRootModel().findStateByPath(path);
 	}
 	
+	
 	@Override
 	public boolean equals(Object other) {
 		if(other==null)
@@ -84,10 +87,16 @@ public class ExecutionContext implements Serializable {
 		
 		ExecutionContext otherCtx = (ExecutionContext)other;
 		
-		String thisDomainRootUri = getId();
-		String otherDomainRootUri = otherCtx.getId();
-		
-		return thisDomainRootUri.equals(otherDomainRootUri);
+		EqualsBuilder builder = new EqualsBuilder();
+		builder.append(getId(), otherCtx.getId());		
+		return builder.isEquals();
+	}
+	
+	@Override
+	public int hashCode() {
+		HashCodeBuilder builder = new HashCodeBuilder();
+		builder.append(getId());
+		return builder.hashCode();
 	}
 	
 	@Override

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdate.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdate.java
@@ -109,7 +109,11 @@ public class DefaultActionExecutorUpdate extends AbstractCommandExecutor<Boolean
 			// iterate over the json string and essentially retrieve the key/value pairs 
 			JsonNode tree = getConverter().toJsonNodeTree(json);
 			
-			if (!tree.isArray()) {
+			if (null == tree) {
+				// nothing to parse
+				return;
+				
+			} else if (!tree.isArray()) {
 				// traverse and update nested params with the provided json
 				tree.fields().forEachRemaining(entry -> {
 					Param<Object> pNested = p.findParamByPath(Constants.SEPARATOR_URI.code + entry.getKey());

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
@@ -132,7 +132,7 @@ public class DefaultCommandPathVariableResolver implements CommandPathVariableRe
 			return String.valueOf(id);
 		}
 		
-		return param.getRootExecution().getRootCommand().getElement(Type.ClientAlias).get().getAlias();
+		return param.getRootExecution().getRootCommand().getElementSafely(Type.ClientAlias).getAlias();
 	}
 	
 	protected String mapEnvironment(Param<?> param, String pathToResolve) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultExecutionContextPathVariableResolver.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultExecutionContextPathVariableResolver.java
@@ -210,8 +210,8 @@ public class DefaultExecutionContextPathVariableResolver implements ExecutionCon
 
 	private void buildDateCriteria(StringBuilder builder, final String alias, String paramPath, String value ) {
 		LocalDate dateValue = getLocalDate(value);
-		LocalDate nextDateValue = dateValue.plusDays(1);
 		if(dateValue != null) {
+			LocalDate nextDateValue = dateValue.plusDays(1);
 			int year = dateValue.getYear();
 		    int month = dateValue.getMonthValue();
 		    int day = dateValue.getDayOfMonth();

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProvider.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProvider.java
@@ -75,7 +75,7 @@ public class ParamCodeValueProvider implements HierarchyMatch, CommandExecutor<L
 	public Output<List<ParamValue>> execute(Input input) {
 		CommandMessage cmdMsg = input.getContext().getCommandMessage();
 		final List<ParamValue> codeValues;
-		if(StringUtils.equalsIgnoreCase(cmdMsg.getCommand().getElement(Type.DomainAlias).get().getAlias(),"staticCodeValue")) {
+		if(StringUtils.equalsIgnoreCase(cmdMsg.getCommand().getElementSafely(Type.DomainAlias).getAlias(),"staticCodeValue")) {
 			codeValues = getStaticCodeValue(input);
 		}
 		else{

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
@@ -52,7 +52,7 @@ public class DefaultSearchFunctionHandlerLookup<T, R> extends DefaultSearchFunct
 		List<?> searchResult = (List<?>)super.execute(executionContext, actionParameter);
 				
 		Command cmd = executionContext.getCommandMessage().getCommand();
-		if(StringUtils.equalsIgnoreCase(cmd.getElement(Type.DomainAlias).get().getAlias(), "staticCodeValue")) {
+		if(StringUtils.equalsIgnoreCase(cmd.getElementSafely(Type.DomainAlias).getAlias(), "staticCodeValue")) {
 			return getStaticParamValues((List<StaticCodeValue>)searchResult, cmd);
 		}
 		LookupSearchCriteria lookupSearchCriteria = createSearchCriteria(executionContext, mConfig, actionParameter);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/extension/LabelConfigEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/extension/LabelConfigEventHandler.java
@@ -20,10 +20,10 @@ package com.antheminc.oss.nimbus.domain.model.config.extension;
 
 import java.util.ArrayList;
 import java.util.Locale;
-import java.util.Optional;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.domain.defn.extension.Content;
 import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
@@ -31,7 +31,6 @@ import com.antheminc.oss.nimbus.domain.model.config.ParamConfig;
 import com.antheminc.oss.nimbus.domain.model.config.ParamConfig.LabelConfig;
 import com.antheminc.oss.nimbus.domain.model.config.event.ConfigEventHandlers.OnParamCreateHandler;
 import com.antheminc.oss.nimbus.domain.model.config.internal.DefaultParamConfig;
-import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 /**
  * @author Soham Chakravarti
@@ -47,10 +46,13 @@ public class LabelConfigEventHandler extends AbstractConfigEventHandler<Label> i
 		
 		DefaultParamConfig<?> paramConfig = castOrEx(DefaultParamConfig.class, param);
 		
-		Optional.ofNullable(paramConfig.getLabelConfigs()).orElseGet(()->{
+		if (null == paramConfig) {
+			throw new FrameworkRuntimeException("Retrieved paramConfig for " + param + " was null.");
+		}
+		
+		if (null == paramConfig.getLabelConfigs()) {
 			paramConfig.setLabelConfigs(new ArrayList<>());
-			return paramConfig.getLabelConfigs();
-		});
+		}
 		
 		validateAndAdd(paramConfig, convert(configuredAnnotation));
 	}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AuditStateChangeHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AuditStateChangeHandler.java
@@ -126,10 +126,11 @@ public class AuditStateChangeHandler implements OnStateChangeHandler<Audit> {
 		ModelRepository db = getRepositoryFactory().get(repo);
 		
 		// autogenerate id
-		Long id = getIdSequenceRepo().getNextSequenceId(repo != null && StringUtils.isNotBlank(repo.alias())?repo.alias():auditHistoryAlias);
+		String repoAlias = StringUtils.isNotBlank(repo.alias()) ? repo.alias() : auditHistoryAlias;
+		Long id = getIdSequenceRepo().getNextSequenceId(repoAlias);
 		ae.setId(id);
 		
-		db._save(StringUtils.isNotBlank(repo.alias()) ? repo.alias() :auditHistoryAlias, ae);
+		db._save(repoAlias, ae);
 	}
 	
 	private String findAuditHistoryAlias(ModelConfig<?> auditConfig, Audit configuredAnnotation) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ConfigConditionalStateChangeHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ConfigConditionalStateChangeHandler.java
@@ -75,7 +75,9 @@ public class ConfigConditionalStateChangeHandler extends AbstractConditionalStat
 			return;
 		
 		Config[] configs = configuredAnnotation.config();
-		Optional.ofNullable(configs).filter(ArrayUtils::isNotEmpty).orElseThrow(()->new InvalidConfigException("No @Config found to execute conditionnaly on param: "+event.getParam()));
+		if (ArrayUtils.isEmpty(configs)) {
+			throw new InvalidConfigException("No @Config found to execute conditionally on param: " + event.getParam());
+		}
 		
 		Command rootCmd = event.getParam().getRootExecution().getRootCommand();
 		ExecutionContext eCtx = getContextLoader().load(rootCmd);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/AbstractEntityState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/AbstractEntityState.java
@@ -148,10 +148,9 @@ public abstract class AbstractEntityState<T> implements EntityState<T> {
 		} finally {
 			if(execRt.isLocked(lockId)) {
 				execRt.awaitNotificationsCompletion();
-				
-				boolean b = execRt.tryUnlock(lockId);
-				if(!b)
-					throw new FrameworkRuntimeException("Failed to release lock acquired during initState of: "+getPath()+" with acquired lockId: "+lockId);
+				if(!execRt.tryUnlock(lockId)) {
+					logit.error(() -> "Failed to release lock acquired during txn execution of runtime: "+this+" with acquired lockId: "+lockId);
+				}
 			}
 		}
 	}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/AbstractEntityState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/AbstractEntityState.java
@@ -47,6 +47,7 @@ import com.antheminc.oss.nimbus.support.JustLogit;
 import com.antheminc.oss.nimbus.support.pojo.LockTemplate;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -58,9 +59,11 @@ import lombok.Setter;
 @Getter @Setter
 public abstract class AbstractEntityState<T> implements EntityState<T> {
 
-	final private EntityConfig<T> config;
+	@Setter(AccessLevel.NONE)
+	private EntityConfig<T> config;
 	
-	@JsonIgnore final private EntityStateAspectHandlers aspectHandlers;
+	@Setter(AccessLevel.NONE)
+	@JsonIgnore private EntityStateAspectHandlers aspectHandlers;
 	
 	@JsonIgnore final protected LockTemplate lockTemplate = new LockTemplate();
 	
@@ -69,6 +72,11 @@ public abstract class AbstractEntityState<T> implements EntityState<T> {
 	@JsonIgnore private RulesRuntime rulesRuntime;
 	
 	@JsonIgnore private boolean stateInitialized;
+	
+	public AbstractEntityState() {
+		this.config = null;
+		this.aspectHandlers = null;
+	}
 	
 	public AbstractEntityState(EntityConfig<T> config, EntityStateAspectHandlers aspectHandlers) {
 		Objects.requireNonNull(config, ()->"Config must not be null while instantiating StateAndConfig.");

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultExecutionTxnContext.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultExecutionTxnContext.java
@@ -22,11 +22,11 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.domain.model.state.ExecutionTxnContext;
 import com.antheminc.oss.nimbus.domain.model.state.InvalidStateException;
 import com.antheminc.oss.nimbus.domain.model.state.Notification;
 import com.antheminc.oss.nimbus.domain.model.state.ParamEvent;
+import com.antheminc.oss.nimbus.support.JustLogit;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -42,15 +42,16 @@ public class DefaultExecutionTxnContext implements ExecutionTxnContext {
 	private String id;
 
 	private final BlockingQueue<Notification<Object>> notifications = new LinkedBlockingQueue<>();
-	
 	private final List<ParamEvent> events = new ArrayList<>();
+	private final static JustLogit LOG = new JustLogit();
 	
 	@Override
 	public void addNotification(Notification<Object> notification) {
 		try {
 			getNotifications().put(notification);
 		} catch (InterruptedException ex) {
-			throw new FrameworkRuntimeException("Failed to place notification event on queue with value: "+notification, ex);
+			LOG.error(() -> "Failed to place notification event on queue with value: " + notification, ex);
+			Thread.currentThread().interrupt();
 		}	
 	}
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultModelState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultModelState.java
@@ -51,11 +51,16 @@ public class DefaultModelState<T> extends AbstractEntityState<T> implements Mode
 	
     private static final long serialVersionUID = 1L;
 
-    @JsonIgnore final private Param<T> associatedParam;
+    @Setter(AccessLevel.NONE)
+    @JsonIgnore private Param<T> associatedParam;
     
     private List<Param<? extends Object>> params;
 
 	@JsonIgnore private transient ValidationResult validationResult;
+	
+	public DefaultModelState() {
+		this.associatedParam = null;
+	}
 	
 	public DefaultModelState(Param<T> associatedParam, ModelConfig<T> config, EntityStateAspectHandlers provider/*, Model<?> backingCoreModel*/) {
 		super(config, provider);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/client/Client.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/client/Client.java
@@ -15,8 +15,6 @@
  */
 package com.antheminc.oss.nimbus.entity.client;
 
-import javax.validation.constraints.NotNull;
-
 import com.antheminc.oss.nimbus.domain.defn.Domain;
 import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
@@ -38,17 +36,11 @@ public class Client extends ClientEntity {
 
 	private static final long serialVersionUID = 1L;
 	
-	
 	public Client() {
 		super.setType(ClientEntity.Type.CLIENT);
 	}
 	
-
-	@NotNull
 	private String fedTaxID;
-	
-    @NotNull
-	//@Model.Param.Values(Values.BusinessType.class)
-	@Getter @Setter private String businessType;
+	private String businessType;
 	
 }


### PR DESCRIPTION
# Overview of Changes
Addresses 25 "Bugs" from Sonar.

# Issues Fixed
## src/.../oss/nimbus/domain/cmd/Command.java
* The return value of "orElseThrow" must be used.
  * L86
* The return value of "orElseThrow" must be used.
  * L87
* The return value of "orElseThrow" must be used.
  * L88
* The return value of "orElseThrow" must be used.
  * L89
* Call "Optional#isPresent()" before accessing the value.
  * L204

## src/.../oss/nimbus/domain/cmd/CommandElementLinked.java
* Only the sign of the result should be examined.
  * L113

## src/.../oss/nimbus/domain/cmd/CommandMessageConverter.java
* A "NullPointerException" could be thrown; "tree" is nullable here.
  * L77

## src/.../oss/nimbus/domain/cmd/exec/AbstractCommandExecutor.java
* Call "Optional#isPresent()" before accessing the value.
  * L90

## src/.../oss/nimbus/domain/cmd/exec/BaseCommandExecutorStrategies.java
* Call "Optional#isPresent()" before accessing the value.
  * L83

## src/.../oss/nimbus/domain/cmd/exec/ExecutionContext.java
* This class overrides "equals()" and should therefore also override "hashCode()".
  * L78

## src/.../domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
* Call "Optional#isPresent()" before accessing the value.
** L130

## src/.../domain/cmd/exec/internal/ParamCodeValueProvider.java
* Call "Optional#isPresent()" before accessing the value.
  * L78

## src/.../cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
* Call "Optional#isPresent()" before accessing the value.
** L54

## src/.../domain/model/config/extension/LabelConfigEventHandler.java
* The return value of "orElseGet" must be used.
  * L48

## src/.../oss/nimbus/domain/model/state/EntityState.java
* This class overrides "equals()" and should therefore also override "hashCode()".
  * L254

## src/.../domain/model/state/extension/AuditStateChangeHandler.java
* A "NullPointerException" could be thrown; "repo" is nullable here.
  * L116

## src/.../domain/model/state/extension/ConfigConditionalStateChangeHandler.java
* The return value of "orElseThrow" must be used.
  * L70

## src/.../domain/model/state/internal/AbstractEntityState.java
* Remove this throw statement from this finally block.
  * L145

## src/.../domain/model/state/internal/DefaultExecutionRuntime.java
* Remove this throw statement from this finally block.
  * L158
* Remove this throw statement from this finally block.
  * L173

## src/.../domain/model/state/internal/DefaultExecutionTxnContext.java
* Either re-interrupt this method or rethrow the "InterruptedException".
  * L52

## src/.../domain/model/state/internal/DefaultListParamState.java
* Call "Optional#isPresent()" before accessing the value.
  * L121

## src/.../domain/model/state/internal/DefaultModelState.java
* Add a no-arg constructor to "AbstractEntityState".
  * L198

## src/.../domain/model/state/internal/DefaultParamState.java
* Add a no-arg constructor to "AbstractEntityState".
  * L910

## src/.../oss/nimbus/entity/client/Client.java
* "fedTaxID" is marked "javax.validation.constraints.NotNull" but is not initialized in this constructor.
  * L44