### PR TITLE
Form Validation Refactor

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
@@ -1,5 +1,3 @@
-import { AbstractControl } from '@angular/forms/src/model';
-import { ValidationConstraint } from './../../shared/validationconstraints.enum';
 /**
  * @license
  * Copyright 2016-2018 the original author or authors.
@@ -26,6 +24,7 @@ import { ComponentTypes, ViewComponent } from '../../shared/param-annotations.en
 import { BaseElement } from './base-element.component';
 import { WebContentSvc } from './../../services/content-management.service';
 import { ValidationUtils } from './validators/ValidationUtils';
+import { AbstractControl } from '@angular/forms/src/model';
 
 var counter = 0;
 

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
@@ -156,7 +156,7 @@ export class FormElement extends BaseElement {
                 this.element.config.validation.constraints.forEach(validator => {
                     
                     // cycle through all of the supported validation errors and apply messages for those that are present.
-                    ValidationUtils.getAllEligibleErrorNames().forEach(validationName => {
+                    ValidationUtils.getAllValidationNames().forEach(validationName => {
 
                         if (this.hasErrors(control, validationName)) {
                             // prefer validation message from the server first

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
@@ -156,20 +156,13 @@ export class FormElement extends BaseElement {
                 this.element.config.validation.constraints.forEach(validator => {
                     
                     // cycle through all of the supported validation errors and apply messages for those that are present.
-                    ValidationUtils.getAllValidationNames().forEach(validationName => {
-
-                        if (this.hasErrors(control, validationName)) {
+                    ValidationUtils.getAllValidationNames()
+                        .filter(validationName => this.hasErrors(control, validationName))
+                        .forEach(validationName => {
+                            
                             // prefer validation message from the server first
-                            var errorMessage = validator.attribute.message;
-
                             // if unavailable, set the error message to the default for the particular type of error.
-                            if (!errorMessage) {
-                                errorMessage = ValidationUtils.getDefaultErrorMessage(validationName);
-                            }
-
-                            // add the error message for this error.
-                            this.addErrorMessages(errorMessage);
-                        }
+                            this.addErrorMessages(validator.attribute.message ? validator.attribute.message : ValidationUtils.getDefaultErrorMessage(validationName));
                     });
                 });
             }

--- a/nimbus-ui/nimbusui/src/app/components/platform/validators/ValidationUtils.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/validators/ValidationUtils.ts
@@ -148,7 +148,7 @@ export class ValidationUtils {
     /**
      * Retrieve all of the error names that validation rules are applied for.
      */
-    public static getAllEligibleErrorNames(): string[] {
+    public static getAllValidationNames(): string[] {
         return Object.keys(ServiceConstants.ERROR_MESSAGE_DEFAULTS);
     }
 }

--- a/nimbus-ui/nimbusui/src/app/components/platform/validators/ValidationUtils.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/validators/ValidationUtils.ts
@@ -1,3 +1,4 @@
+import { ServiceConstants } from './../../../services/service.constants';
 /**
  * @license
  * Copyright 2016-2018 the original author or authors.
@@ -136,6 +137,18 @@ export class ValidationUtils {
         return requiredCss;
     }
 
-
+    /**
+     * Retrieve the default error message for a given errorType.
+     * @param validationName the errorType for which to retrieve an error message
+     */
+    public static getDefaultErrorMessage(validationName: string): string {
+        return ServiceConstants.ERROR_MESSAGE_DEFAULTS[validationName];
+    }
     
+    /**
+     * Retrieve all of the error names that validation rules are applied for.
+     */
+    public static getAllEligibleErrorNames(): string[] {
+        return Object.keys(ServiceConstants.ERROR_MESSAGE_DEFAULTS);
+    }
 }

--- a/nimbus-ui/nimbusui/src/app/services/service.constants.ts
+++ b/nimbus-ui/nimbusui/src/app/services/service.constants.ts
@@ -106,4 +106,14 @@ export class ServiceConstants {
     //     obj['defaultAjaxUrl'] = 'htpp://localhost:8000/log';
     //     return obj;
     // }
+
+    // TODO Move this to server-side configuration.
+    public static get ERROR_MESSAGE_DEFAULTS(): any {
+        return {
+            required: 'Field is required.',
+            pattern: 'Field does not match the required pattern.',
+            minMaxSelection: 'Field does not meet min/max requirement.',
+            isNumber: 'Value must be a number.'
+        };
+    }
 }


### PR DESCRIPTION
# Overview of Changes
* Removed copy/paste if statements and replaced with a lookup of default validation error messages.
* Hard coded defaults have been moved out of `form-element.components.ts` to `service.constants.ts`.
* The hope is that this should make adding new validators on the client side less of a burden and to make the logic more readable.