### PR TITLE
NIM-17698: Combobox Issue

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EvalExprWithCrudDefaults.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EvalExprWithCrudDefaults.java
@@ -150,11 +150,6 @@ public abstract class EvalExprWithCrudDefaults<A extends Annotation> extends Eva
 
 		handleInternal(onChangeParam, targetPath, targetParam -> {
 
-			// if the target param is not enabled, skip the processing
-			if (!targetParam.isEnabled()) {
-				return;
-			}
-
 			final boolean shouldExecuteDefault = !this.executeConditional(configuredAnnotation, onChangeParam,
 					targetParam);
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandler.java
@@ -83,6 +83,14 @@ public class ValuesConditionalStateEventHandler extends EvalExprWithCrudDefaults
 	 * @param targetParam the entity to set the values within
 	 */
 	protected void afterExecute(Param<?> targetParam) {
+
+		// If the target param is not enabled, skip the state processing. In
+		// other words, we don't want ValuesConditional to affect the state of
+		// the targetParam when it is not in an "enabled" state.
+		if (!targetParam.isEnabled()) {
+			return;
+		}
+
 		if (isResetOnChange()) {
 			targetParam.setState(null);
 		} else {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
@@ -73,7 +73,8 @@ public class ValuesConditionalStateEventHandlerTest {
 		@Override
 		public List<ParamValue> getValues(String paramCode) {
 			final List<ParamValue> values = new ArrayList<>();
-			values.add(new ParamValue("foo", "bar"));
+			values.add(new ParamValue("foo", "foo"));
+			values.add(new ParamValue("bar", "bar"));
 			return values;
 		}
 	}
@@ -283,22 +284,26 @@ public class ValuesConditionalStateEventHandlerTest {
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
-		
+		targetParam.setState("bar");
 		targetParam.setEnabled(false);
 		((MockParamConfig) targetParam.getConfig()).setValues(defaultValues);
-		
 		decoratedParam.putParam(targetParam, "../targetParam");
+		
+		List<ParamValue> expectedValues = new SAMPLE_VALUES().getValues(null);
 		
 		Mockito.when(event.getAction()).thenReturn(Action._update);
 		Mockito.when(event.getParam()).thenReturn((Param) decoratedParam);
 		Mockito.when(this.expressionEvaluator.getValue(Mockito.eq("condition1expr"), Mockito.isA(ParamStateHolder.class), Mockito.eq(Boolean.class))).thenReturn(true);
-		Mockito.when(this.defaultParamValuesHandler.buildParamValues(defaultValues, decoratedParam, targetParam)).thenReturn(null);
+		Mockito.when(this.defaultParamValuesHandler.buildParamValues(condition1.then(), decoratedParam, targetParam)).thenReturn(expectedValues);
 		
 		this.testee.onStateChange(configuredAnnotation, null, event);
 		
 		Mockito.verify(event).getParam();
 		
-		Assert.assertNull(targetParam.getValues());
+		// Validate values are still as expected
+		Assert.assertEquals(expectedValues, targetParam.getValues());
+		// Validate state is preserved
+		Assert.assertEquals("bar", targetParam.getLeafState());
 	}
 	
 	private Condition createCondition(String when, Values then) {


### PR DESCRIPTION
# Description
Fixed an issue where param values were not coming back when that param was disabled.

Fixes NIM-17698

 ## Overview of Changes
- Refactored location of disabled handling to allow for the propagation of Values processing
- ValuesConditional still stops the state reset when the associated targetParam is disabled.

 ## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] `ValuesConditionalStateEventHandlerTest.t8_useDefault_targetParamDisabled()`

 # Additional Notes
The issue was occurring when the response from the server was sending the combobox param's state but not sending the values array. Since in `combobox.component.ts` the `value` is being set, but the `options` is not being set (as `element.values` is not coming back from the server), the underling PrimeNG component is not rendering the saved state on the UI.