### PR TITLE
label for global nav menu

### DIFF
--- a/nimbus-ui/nimbusui/src/app/services/layout.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/layout.service.ts
@@ -246,7 +246,7 @@ export class LayoutService {
                                 subMenuLinks.push(paramLink)
                             }
                         })
-                        menuItems.set(param.config.code, subMenuLinks);
+                        menuItems.set(this.wcs.findLabelContent(param).text, subMenuLinks);
                         subBarItems['menuItems'] = menuItems;
                     }
                     if (param.config.uiStyles.attributes.alias === 'ComboBox') {


### PR DESCRIPTION
# Description - The param's code shows up instead of the configured label in the global nav menu title. The links inside of the menu show the correct link labels.

Fixes # Called the method to resolve the label for a param

## Overview of Changes
- The global nav menu title will also have the capability to show a label that is configured

## UI framework change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Additional Notes

Please add any additional notes regarding this pull request here.
