### PR TITLE
1.1.0.m2 func handler segregation

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreBuilderConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreBuilderConfig.java
@@ -33,6 +33,7 @@ import org.springframework.core.env.PropertyResolver;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.context.DefaultBeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.FunctionExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.ParamUpdateEventListener;
 import com.antheminc.oss.nimbus.domain.config.builder.AnnotationAttributeHandler;
 import com.antheminc.oss.nimbus.domain.config.builder.AnnotationConfigHandler;
@@ -90,6 +91,11 @@ public class DefaultCoreBuilderConfig {
 	@Bean
 	public DomainConfigBuilder domainConfigBuilder(EntityConfigBuilder configBuilder){
 		return new DomainConfigBuilder(configBuilder, basePackages);
+	}
+	
+	@Bean
+	public FunctionExecutor<?,?> functionExecutor(BeanResolverStrategy beanResolver){
+		return new FunctionExecutor<>(beanResolver);
 	}
 	
 //	@Bean

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreExecutorConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreExecutorConfig.java
@@ -28,6 +28,7 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContextLoader;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContextPathVariableResolver;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultActionExecutorConfig;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultActionExecutorDelete;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.FunctionExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultActionExecutorGet;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultActionExecutorNav;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultActionExecutorNew;
@@ -105,11 +106,6 @@ public class DefaultCoreExecutorConfig {
 		return new DefaultActionExecutorProcess<>(beanResolver);
 	}
 	
-	@Bean(name="default._search$execute")
-	public CommandExecutor<?> defaultActionExecutorSearch(BeanResolverStrategy beanResolver){
-		return new DefaultActionExecutorSearch<>(beanResolver);
-	}
-	
 	@Bean(name="default._update$execute")
 	public CommandExecutor<?> defaultActionExecutorUpdate(BeanResolverStrategy beanResolver){
 		return new DefaultActionExecutorUpdate(beanResolver);
@@ -155,5 +151,10 @@ public class DefaultCoreExecutorConfig {
 	public DBSearch searchByQuery(BeanResolverStrategy beanResolver) {
 		return new MongoSearchByQuery(beanResolver);
 	}
+
+	@Bean(name="default._search$execute")
+	public CommandExecutor<?> defaultActionExecutorSearch(BeanResolverStrategy beanResolver){
+		return new DefaultActionExecutorSearch<>(beanResolver);
+	}	
 	
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/Action.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/Action.java
@@ -43,6 +43,7 @@ public enum Action {
 	
 	/* navigation */
 	_nav
+	
 	;
 
 	public static final Action DEFAULT = _get;

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/Command.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/Command.java
@@ -414,4 +414,8 @@ public class Command implements Serializable {
 	public String getRawPayload() {
 		return getFirstParameterValue("rawPayload");
 	}
+	
+	public boolean containsFunction() {
+		return requestParams != null && requestParams.containsKey(Constants.KEY_FUNCTION.code);
+	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
@@ -25,12 +25,11 @@ import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
-import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractFunctionCommandExecutor;
+import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractCommandExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
-import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
 import com.antheminc.oss.nimbus.domain.config.builder.DomainConfigBuilder;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.model.config.ModelConfig;
@@ -50,7 +49,7 @@ import lombok.Getter;
  */
 @EnableLoggingInterceptor
 @Getter(value=AccessLevel.PROTECTED)
-public class DefaultActionExecutorGet extends AbstractFunctionCommandExecutor<Param<Object>, Object> {
+public class DefaultActionExecutorGet extends AbstractCommandExecutor<Object> {
 
 	private CommandExecutorGateway commandGateway;
 	
@@ -64,22 +63,11 @@ public class DefaultActionExecutorGet extends AbstractFunctionCommandExecutor<Pa
 	}
 	
 
-	@SuppressWarnings("unchecked")
 	@Override
 	protected final Output<Object> executeInternal(Input input) {
 		ExecutionContext eCtx = handleGetDomainRoot(input.getContext());
-	
 		Param<?> p = findParamByCommandOrThrowEx(eCtx);
-		
-		final Object outcome;
-		if(containsFunctionHandler(input)) {
-			outcome = executeFunctionHanlder(input, FunctionHandler.class);
-			
-		} else {
-			outcome = p;
-		}
-		
-		return Output.instantiate(input, eCtx, outcome);
+		return Output.instantiate(input, eCtx, p);
 	}
 	
 	protected ExecutionContext handleGetDomainRoot(ExecutionContext eCtx) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNav.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNav.java
@@ -16,12 +16,10 @@
 package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
-import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
-import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractFunctionCommandExecutor;
+import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractCommandExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
-import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
-import com.antheminc.oss.nimbus.domain.cmd.exec.internal.nav.NavigationHandler;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 /**
@@ -29,26 +27,16 @@ import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
  *
  */
 @EnableLoggingInterceptor
-public class DefaultActionExecutorNav<T> extends AbstractFunctionCommandExecutor<T,String> {
+public class DefaultActionExecutorNav<T> extends AbstractCommandExecutor<String> {
 	
 	public DefaultActionExecutorNav(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected Output<String> executeInternal(Input input) {
-		String pageId = (String)executeFunctionHanlder(input, NavigationHandler.class);
+		String pageId = input.getContext().getCommandMessage().getCommand().getFirstParameterValue(Constants.KEY_NAV_ARG_PAGE_ID.code);
 		return Output.instantiate(input, input.getContext(), pageId);		
-	}
-	
-	@Override
-	protected <F extends FunctionHandler<?, ?>> F getHandler(CommandMessage commandMessage, Class<F> handlerClass) {
-		F handler = super.getHandler(commandMessage, handlerClass);
-		if(handler == null){
-			handler = super.getHandler("default._nav$execute?fn=default",handlerClass);
-		}
-		return handler;
 	}
 	
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNew.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNew.java
@@ -26,12 +26,11 @@ import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
-import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractFunctionCommandExecutor;
+import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractCommandExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
-import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
 import com.antheminc.oss.nimbus.domain.config.builder.DomainConfigBuilder;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.model.config.ModelConfig;
@@ -53,7 +52,7 @@ import lombok.Getter;
  */
 @EnableLoggingInterceptor
 @Getter(value=AccessLevel.PROTECTED)
-public class DefaultActionExecutorNew extends AbstractFunctionCommandExecutor<Object, Param<?>> {
+public class DefaultActionExecutorNew extends AbstractCommandExecutor<Param<?>> {
 
 	private BPMGateway bpmGateway;
 	
@@ -81,17 +80,9 @@ public class DefaultActionExecutorNew extends AbstractFunctionCommandExecutor<Ob
 	@Override
 	protected Output<Param<?>> executeInternal(Input input) {
 		ExecutionContext eCtx = handleNewDomainRoot(input.getContext());
-	
 		Param<Object> actionParam = findParamByCommandOrThrowEx(eCtx);
-		
-		final Param<?> outputParam;
-		if(containsFunctionHandler(input)) {
-			outputParam = executeFunctionHanlder(input, FunctionHandler.class);
-		} else { 
-			setStateNew(eCtx, input.getContext().getCommandMessage(), actionParam);
-			outputParam = actionParam;
-		}
-		return Output.instantiate(input, eCtx, outputParam);
+		setStateNew(eCtx, input.getContext().getCommandMessage(), actionParam);
+		return Output.instantiate(input, eCtx, actionParam);
 	}
 
 	protected void setStateNew(ExecutionContext eCtx, CommandMessage cmdMsg, Param<Object> p) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorProcess.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorProcess.java
@@ -17,11 +17,10 @@ package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.bpm.BPMGateway;
-import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractFunctionCommandExecutor;
+import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractCommandExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
-import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
@@ -34,7 +33,7 @@ import lombok.Getter;
  */
 @EnableLoggingInterceptor
 @Getter(value=AccessLevel.PROTECTED)
-public class DefaultActionExecutorProcess<T,R> extends AbstractFunctionCommandExecutor<T,R> {
+public class DefaultActionExecutorProcess<R> extends AbstractCommandExecutor<R> {
 	
 	private BPMGateway bpmGateway;
 	
@@ -44,14 +43,13 @@ public class DefaultActionExecutorProcess<T,R> extends AbstractFunctionCommandEx
 	}
 	
 	@Override
-	@SuppressWarnings("unchecked")
 	protected Output<R> executeInternal(Input input) {
-		R response = containsFunctionHandler(input) ? (R)executeFunctionHanlder(input, FunctionHandler.class) : continueBusinessProcessExceution(input.getContext());
+		R response = continueBusinessProcessExecution(input.getContext());
 		return Output.instantiate(input, input.getContext(), response);
 	}
 	
 	@SuppressWarnings("unchecked")
-	private R continueBusinessProcessExceution(ExecutionContext eCtx){
+	private R continueBusinessProcessExecution(ExecutionContext eCtx){
 		QuadModel<?,?> quadModel = getQuadModel(eCtx);
 		String processExecutionId = quadModel.getFlow().getProcessExecutionId();
 		return (R)getBpmGateway().continueBusinessProcessExecution(eCtx.getRootModel().getAssociatedParam(), processExecutionId);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearch.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearch.java
@@ -17,11 +17,10 @@ package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
-import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractFunctionCommandExecutor;
+import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractCommandExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
-import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
 
 
 /**
@@ -29,17 +28,19 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
  *
  */
 @EnableLoggingInterceptor
-public class DefaultActionExecutorSearch<T, R> extends AbstractFunctionCommandExecutor<T, R> {
+public class DefaultActionExecutorSearch<R> extends AbstractCommandExecutor<R> {
+	
+	private FunctionExecutor<?, ?> functionExecutor;
 	
 	public DefaultActionExecutorSearch(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
+		this.functionExecutor = beanResolver.find(FunctionExecutor.class);
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	protected Output<R> executeInternal(Input input) {
-		R response = (R)executeFunctionHanlder(input, FunctionHandler.class);
-		return Output.instantiate(input, input.getContext(), response);
+		return (Output<R>)functionExecutor.execute(input);
 	}
 
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandExecutorGateway.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandExecutorGateway.java
@@ -107,8 +107,8 @@ public class DefaultCommandExecutorGateway extends BaseCommandExecutorStrategies
 	
 	public DefaultCommandExecutorGateway(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
-		
 		this.executors = new HashMap<>();
+		
 	}
 	
 	@PostConstruct
@@ -471,6 +471,9 @@ public class DefaultCommandExecutorGateway extends BaseCommandExecutorStrategies
 	}
 	
 	protected CommandExecutor<?> lookupExecutor(Command cmd, Behavior b) {
+		if(b == Behavior.$execute && cmd.containsFunction()) {
+			return getBeanResolver().find(FunctionExecutor.class);
+		}
 		return lookupBeanOrThrowEx(CommandExecutor.class, getExecutors(), cmd.getAction(), b);
 	}
 	

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/FunctionExecutor.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/FunctionExecutor.java
@@ -13,28 +13,36 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.antheminc.oss.nimbus.domain.cmd.exec;
+package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.Behavior;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
+import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractCommandExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
+import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
+import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 /**
  * @author Jayant Chaudhuri
  *
  */
-public abstract class AbstractFunctionCommandExecutor<T,R> extends AbstractCommandExecutor<R> {
+@EnableLoggingInterceptor
+public class FunctionExecutor<T,R> extends AbstractCommandExecutor<R> {
 
-	public AbstractFunctionCommandExecutor(BeanResolverStrategy beanResolver) {
+	public FunctionExecutor(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
 	}
 	
-	protected boolean containsFunctionHandler(Input input){
-		String functionName = input.getContext().getCommandMessage().getCommand().getFirstParameterValue(Constants.KEY_FUNCTION.code);
-		return (functionName != null);
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Output<R> executeInternal(Input input) {
+		R response =  (R)executeFunctionHanlder(input, FunctionHandler.class);
+		return Output.instantiate(input, input.getContext(), response);		
 	}
 	
 	protected <H extends FunctionHandler<T, R>> R executeFunctionHanlder(Input input, Class<H> handlerClass) {

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s11/core/FuncHandlerTestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s11/core/FuncHandlerTestModel.java
@@ -1,0 +1,25 @@
+package com.antheminc.oss.nimbus.test.scenarios.s11.core;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.defn.extension.ConfigConditional;
+import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Domain(value="sample_functest", includeListeners={ListenerType.persistence})
+@Repo(Database.rep_mongodb)
+@Getter @Setter
+public class FuncHandlerTestModel extends IdLong{
+	private static final long serialVersionUID = 1L;
+	@ConfigConditional(config= {
+			@Config(url="/parameter2/_replace?rawPayload=\"Value\"")
+	})
+	private String parameter1;
+	private String parameter2;
+	
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultBehaviorExecutorStateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultBehaviorExecutorStateTest.java
@@ -102,7 +102,7 @@ public class DefaultBehaviorExecutorStateTest extends AbstractFrameworkIngeratio
 		Object home_newResp = controller.handleGet(home_newReq, null);
 		assertNotNull(home_newResp);
 		
-		Object actual = ExtractResponseOutputUtils.extractOutput(home_newResp, 1);
+		Object actual = ExtractResponseOutputUtils.extractOutput(home_newResp, 2);
 		assertNotNull(actual);
 		assertTrue(VRSampleViewRootEntity.class.isInstance(actual));
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/changelog/ChangeLogTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/changelog/ChangeLogTest.java
@@ -68,7 +68,9 @@ public class ChangeLogTest extends AbstractFrameworkIntegrationTests {
 		assertThat(cmdEntry).isNotNull();
 		
 		ChangeLogEntry valueEntry_NestedEntityB = mongo.findOne(new Query(Criteria.where("value").is("Test_Nested_Status_B")), ChangeLogEntry.class, "changelog");
-		assertThat(valueEntry_NestedEntityB).isNull();
+		
+		// Changing from isNull to isNotNull. Init Enity is a function handler. Any change to state caused by the function handler should be processed by the corresponding state change handlers
+		assertThat(valueEntry_NestedEntityB).isNotNull();
 		
 	}
 	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s11/FunctionExecutorTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s11/FunctionExecutorTests.java
@@ -40,7 +40,7 @@ import com.antheminc.oss.nimbus.test.scenarios.s11.core.FuncHandlerTestModel;
  *
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class FunctionHandlerTests extends AbstractFrameworkIngerationPersistableTests {
+public class FunctionExecutorTests extends AbstractFrameworkIngerationPersistableTests {
 
 	protected static final String BPM_ERR_DOMAIN_ALIAS = "testbpmfailmodel";
 	protected static final String BPM_ERR_PARAM_ROOT = PLATFORM_ROOT + "/" + BPM_ERR_DOMAIN_ALIAS;	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s11/FunctionExecutorTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s11/FunctionExecutorTests.java
@@ -88,7 +88,7 @@ public class FunctionExecutorTests extends AbstractFrameworkIngerationPersistabl
 	
 	@Test
 	@SuppressWarnings("unchecked")
-	public void t02_search_example() {
+	public void t03_search_example() {
 		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest")
 					.addAction(Action._new)
 					.getMock();
@@ -114,7 +114,7 @@ public class FunctionExecutorTests extends AbstractFrameworkIngerationPersistabl
 	
 	@Test
 	@SuppressWarnings("unchecked")
-	public void t02_search_query() {
+	public void t04_search_query() {
 		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest")
 					.addAction(Action._new)
 					.getMock();
@@ -139,6 +139,25 @@ public class FunctionExecutorTests extends AbstractFrameworkIngerationPersistabl
 		assertTrue(obj.size() > 0);
 	}
 	
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void t05_nav() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest")
+					.addAction(Action._new)
+					.getMock();
+		Holder<MultiOutput> holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		Long domainRoot_refId  = ExtractResponseOutputUtils.extractDomainRootRefId(holder);
+		
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest:"+domainRoot_refId+"/parameter1")
+				.addAction(Action._nav)
+				.addParam("pageId", "page1")
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		
+		Object pageId = holder.getState().getSingleResult();
+		assertEquals("page1", pageId);
+	}
 
 }
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s11/FunctionHandlerTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s11/FunctionHandlerTests.java
@@ -1,0 +1,146 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s11;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.scenarios.s11.core.FuncHandlerTestModel;
+
+/**
+ * @author Jayant Chaudhuri
+ *
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class FunctionHandlerTests extends AbstractFrameworkIngerationPersistableTests {
+
+	protected static final String BPM_ERR_DOMAIN_ALIAS = "testbpmfailmodel";
+	protected static final String BPM_ERR_PARAM_ROOT = PLATFORM_ROOT + "/" + BPM_ERR_DOMAIN_ALIAS;	
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void t01_initEntity() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest")
+					.addAction(Action._new)
+					.addParam("fn", "_initEntity")
+					.addParam("target", "parameter1")
+					.addParam("json", "\"Test\"")
+					.getMock();
+		
+		Holder<MultiOutput> holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		Param param = (Param)holder.getState().getSingleResult();
+		assertEquals("Value", param.findStateByPath("/parameter2"));
+	}
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void t02_set_functionHandler() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest")
+					.addAction(Action._new)
+					.getMock();
+		Holder<MultiOutput> holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		Long domainRoot_refId  = ExtractResponseOutputUtils.extractDomainRootRefId(holder);
+		
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest:"+domainRoot_refId+"/parameter2")
+				.addAction(Action._process)
+				.addParam("fn", "_set")
+				.addParam("value", "Value")
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest:"+domainRoot_refId)
+				.addAction(Action._get)
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+
+		Param param = (Param)holder.getState().getSingleResult();
+		assertNull(param.findStateByPath("/parameter1"));
+		assertEquals("Value", param.findStateByPath("/parameter2"));
+	}
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void t02_search_example() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest")
+					.addAction(Action._new)
+					.getMock();
+		Holder<MultiOutput> holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		Long domainRoot_refId  = ExtractResponseOutputUtils.extractDomainRootRefId(holder);
+		
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest:"+domainRoot_refId+"/parameter1")
+				.addAction(Action._process)
+				.addParam("fn", "_set")
+				.addParam("value", "New-Value")
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest:"+domainRoot_refId)
+				.addAction(Action._search)
+				.addParam("fn", "example")
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+
+		List<FuncHandlerTestModel> obj = (List<FuncHandlerTestModel>)holder.getState().getSingleResult();
+		assertTrue(obj.size() > 0);
+	}
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void t02_search_query() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest")
+					.addAction(Action._new)
+					.getMock();
+		Holder<MultiOutput> holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		Long domainRoot_refId  = ExtractResponseOutputUtils.extractDomainRootRefId(holder);
+		
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest:"+domainRoot_refId+"/parameter1")
+				.addAction(Action._process)
+				.addParam("fn", "_set")
+				.addParam("value", "New-Value")
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sample_functest:"+domainRoot_refId)
+				.addAction(Action._search)
+				.addParam("fn", "query")
+				.addParam("where", "sample_functest.parameter1.eq('New-Value')")
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+
+		List<FuncHandlerTestModel> obj = (List<FuncHandlerTestModel>)holder.getState().getSingleResult();
+		assertTrue(obj.size() > 0);
+	}
+	
+
+}
+		
+	
+

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s2/S2_ValidateColElemConfigTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s2/S2_ValidateColElemConfigTest.java
@@ -26,8 +26,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
-import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
-import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutor;
+import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.search.DefaultSearchFunctionHandlerExample;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.search.DefaultSearchFunctionHandlerQuery;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.ParamEvent;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
@@ -45,8 +46,14 @@ public class S2_ValidateColElemConfigTest extends AbstractFrameworkIntegrationTe
 	
 	private static final String K_URI_VR = PLATFORM_ROOT + "/s2v_main";
 	
-	@MockBean(name="default._search$execute")
-	CommandExecutor<?> defaultActionExecutorSearch;
+	//@MockBean(name="default._search$execute")
+	//CommandExecutor<?> defaultActionExecutorSearch;
+	
+	@MockBean(name="default._search$execute?fn=query")
+	DefaultSearchFunctionHandlerQuery<?,?> defaultSearchFunctionHandlerQuery;
+	
+	@MockBean(name="default._search$execute?fn=exmaple")
+	DefaultSearchFunctionHandlerExample<?,?> defaultSearchFunctionHandlerExample;
 	
 	private static final List<S2C_Row> db_rows;
 	private static final List<S2C_LineItemB> db_rows_nestedRowBodyLineItems;
@@ -67,19 +74,27 @@ public class S2_ValidateColElemConfigTest extends AbstractFrameworkIntegrationTe
 	@Override
 	public void before() {
 		super.before();
-		
-		Mockito.when(defaultActionExecutorSearch.execute(any())).thenAnswer(new Answer<Output<Object>>() {
-			
+		Mockito.when(defaultSearchFunctionHandlerQuery.execute(any(),any())).thenAnswer(new Answer<Object>() {
 			@Override
-			public Output<Object> answer(InvocationOnMock invocation) throws Throwable {
-				Input input = invocation.getArgumentAt(0, Input.class);
-
-				if(input.getInputCommandUri().contains("s2c_row"))
-					return Output.instantiate(input, input.getContext(), db_rows);
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				ExecutionContext input = invocation.getArgumentAt(0, ExecutionContext.class);
+				if(input.getCommandMessage().getCommand().getAbsoluteUri().contains("s2c_row"))
+					return db_rows;
 				else
-					return Output.instantiate(input, input.getContext(), db_rows_nestedRowBodyLineItems);					
+					return db_rows_nestedRowBodyLineItems;					
 			}
 		});
+		Mockito.when(defaultSearchFunctionHandlerExample.execute(any(),any())).thenAnswer(new Answer<Object>() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				ExecutionContext input = invocation.getArgumentAt(0, ExecutionContext.class);
+				if(input.getCommandMessage().getCommand().getAbsoluteUri().contains("s2c_row"))
+					return db_rows;
+				else
+					return db_rows_nestedRowBodyLineItems;					
+			}
+		});
+
 	}
 	
 	@Test


### PR DESCRIPTION
# Description
Segregate execution of Default Command Executors and Function Handlers. Currently they are co-mingled and causing errors in certain scenarios

Fixes #
1. Renamed AbstractFunctionCommandExecutor to FunctionExecutor. This will no longer be an abstract class and will process all function handlers.
2. Update DefaultAtionExecutorNew, Get, Process, Nav and Search and made them independent of function handler execution
3. Updated DefaultCommandExecutorGateway to delegate all calls to FunctionExecutor once the execution context loads and the command contains a function handler 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Junit: FunctionExecutorTests

