### PR TITLE
Modal dialog close icon issue

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.html
@@ -1,5 +1,5 @@
 <ng-template [ngIf]="type == componentTypes.dialog.toString()">
-    <p-dialog [(visible)]="visible" 
+    <p-dialog [(visible)]="display" 
     [closable]="closable" 
     (onHide)="closeDialog($event)" 
     [closeOnEscape]="false" 
@@ -7,9 +7,7 @@
     [width]="width" 
     appendTo="body" 
     [responsive]="true" 
-    [blockScroll]="true" 
-    [contentStyle]=""
-    >
+    [blockScroll]="true">
         <p-header *ngIf="label">
             {{label}}
             <nm-tooltip *ngIf="helpText" [helpText]='helpText'></nm-tooltip>

--- a/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.ts
@@ -52,9 +52,9 @@ export class Modal extends BaseElement implements OnInit, OnDestroy {
     public _width: string;
     // closable to indicate whether modal window can be closed
     public _closable: boolean;
-
+    display: boolean = false;
     private _resizable: boolean;
-    privateelementCss: string;
+    private elementCss: string;
     viewComponent = ViewComponent;
     componentTypes = ComponentTypes;
     
@@ -65,6 +65,13 @@ export class Modal extends BaseElement implements OnInit, OnDestroy {
     ngOnDestroy() {
     }
 
+    ngAfterViewInit() {
+        this.pageSvc.eventUpdate$.subscribe(event => {
+            if(event.path == this.element.path) {
+                this.display = event.visible;
+            }
+        });    
+    }
     /**
      * Closable attribute. Can the Modal window be closed?
      */
@@ -90,12 +97,12 @@ export class Modal extends BaseElement implements OnInit, OnDestroy {
         }
         
     }
-    
+
     /**
      * Close diaglog function.
      */
     public closeDialog(event: any) {
-        if (this.visible) {
+        if (!this.display) {
             this.pageSvc.processEvent(this.element.path+'/closeModal', Behavior.execute.value, new GenericDomain(), HttpMethod.GET.value);
         }
     }


### PR DESCRIPTION
# Description

Modal component's close icon is not functioning right. 

Fixes # (issue)

## Overview of Changes
- Changed the binding of the visible property to a local property instead of param.visible. The primeNg logic of firing the callback changed and hence the rework on this component and the issue.

## Type of change
UI component refactor to accomodate primeng upgrade

Please delete options that are not relevant.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Additional Notes

Please add any additional notes regarding this pull request here.
