### PR TITLE
ApplyStyles Bugfix for boolean values: Handling datatypes other than string for applying styles

### DIFF
--- a/nimbus-ui/nimbusui/src/app/directives/display-value.directive.ts
+++ b/nimbus-ui/nimbusui/src/app/directives/display-value.directive.ts
@@ -17,7 +17,6 @@
 'use strict';
 import { Directive, ElementRef, Renderer2, Input, SimpleChanges } from '@angular/core';
 import { ParamConfig } from '../shared/param-config';
-import { ServiceConstants } from '../services/service.constants';
 /**
  * \@author Dinakar.Meda
  * \@whatItDoes 
@@ -44,7 +43,8 @@ export class DisplayValueDirective {
         if (this.config && this.config.uiStyles.attributes.applyValueStyles) {
             this.renderer.addClass(this.el.nativeElement, this.config.code); // Field Name
 
-            if (this.displayValue !== undefined) {
+            if (this.displayValue && ((this.displayValue instanceof String && this.displayValue.trim() !== '')
+                                || this.displayValue === '')) {
                 this.renderer.addClass(this.el.nativeElement, this.getValue(this.displayValue)); // Field Value
             } else {
                 this.renderer.addClass(this.el.nativeElement, DisplayValueDirective.placeholder); // placeholder Value
@@ -64,7 +64,9 @@ export class DisplayValueDirective {
                 this.renderer.removeClass(this.el.nativeElement, this.getValue(changes.displayValue.previousValue));
             }
             // Add current value styles
-            if (changes.displayValue.currentValue === undefined) {
+            if (changes.displayValue.currentValue === undefined || changes.displayValue.currentValue === '' ||
+                (changes.displayValue.currentValue instanceof String && changes.displayValue.currentValue.trim() === '') ||
+                changes.displayValue.currentValue === null) {
                 this.renderer.addClass(this.el.nativeElement, DisplayValueDirective.placeholder);
             } else {
                 this.renderer.addClass(this.el.nativeElement, this.getValue(changes.displayValue.currentValue));
@@ -75,24 +77,12 @@ export class DisplayValueDirective {
      /*
         Remove spaces from value since style class cannot take spaces
      */
-    getAbsoluteStringValue(str: string): string {
-        var re = / /gi; 
-        return str.replace(re, "");
-    }
-
-    getValue(value: any): string {
-        if (typeof value === 'string' && value.trim() !== '') {
-                return this.getAbsoluteStringValue(value);
-        } else if (typeof this.displayValue === 'boolean') {
-            if (value) {
-                return 'true';
-            } else {
-                return 'false';
-            }
-        } else if (typeof value === 'number') {
-            return ServiceConstants.INTEGER_CLASS_PREFIX + value.toString();
+    getValue(val: any): any {
+        var re = / /gi;
+        if (val instanceof String) {
+            return val.replace(re, "");
         } else {
-            return DisplayValueDirective.placeholder;
+            return val;
         }
     }
 }

--- a/nimbus-ui/nimbusui/src/app/directives/display-value.directive.ts
+++ b/nimbus-ui/nimbusui/src/app/directives/display-value.directive.ts
@@ -17,6 +17,7 @@
 'use strict';
 import { Directive, ElementRef, Renderer2, Input, SimpleChanges } from '@angular/core';
 import { ParamConfig } from '../shared/param-config';
+import { ServiceConstants } from '../services/service.constants';
 /**
  * \@author Dinakar.Meda
  * \@whatItDoes 
@@ -42,7 +43,8 @@ export class DisplayValueDirective {
     ngOnInit() {
         if (this.config && this.config.uiStyles.attributes.applyValueStyles) {
             this.renderer.addClass(this.el.nativeElement, this.config.code); // Field Name
-            if (this.displayValue && this.displayValue.trim() != '') {
+
+            if (this.displayValue !== undefined) {
                 this.renderer.addClass(this.el.nativeElement, this.getValue(this.displayValue)); // Field Value
             } else {
                 this.renderer.addClass(this.el.nativeElement, DisplayValueDirective.placeholder); // placeholder Value
@@ -62,7 +64,7 @@ export class DisplayValueDirective {
                 this.renderer.removeClass(this.el.nativeElement, this.getValue(changes.displayValue.previousValue));
             }
             // Add current value styles
-            if (changes.displayValue.currentValue === undefined || changes.displayValue.currentValue.trim() === '') {
+            if (changes.displayValue.currentValue === undefined) {
                 this.renderer.addClass(this.el.nativeElement, DisplayValueDirective.placeholder);
             } else {
                 this.renderer.addClass(this.el.nativeElement, this.getValue(changes.displayValue.currentValue));
@@ -70,11 +72,27 @@ export class DisplayValueDirective {
         }
     }
 
-    /*
+     /*
         Remove spaces from value since style class cannot take spaces
      */
-    getValue(str: string): string {
+    getAbsoluteStringValue(str: string): string {
         var re = / /gi; 
-        return str.replace(re, ""); 
+        return str.replace(re, "");
+    }
+
+    getValue(value: any): string {
+        if (typeof value === 'string' && value.trim() !== '') {
+                return this.getAbsoluteStringValue(value);
+        } else if (typeof this.displayValue === 'boolean') {
+            if (value) {
+                return 'true';
+            } else {
+                return 'false';
+            }
+        } else if (typeof value === 'number') {
+            return ServiceConstants.INTEGER_CLASS_PREFIX + value.toString();
+        } else {
+            return DisplayValueDirective.placeholder;
+        }
     }
 }

--- a/nimbus-ui/nimbusui/src/app/services/service.constants.ts
+++ b/nimbus-ui/nimbusui/src/app/services/service.constants.ts
@@ -39,7 +39,6 @@ export class ServiceConstants {
     public static get WS_SUBSCRIBE_Q(): string { return '/user/queue/updates'; }
     public static get LOCALE_LANGUAGE() : string { return this.locale;}
     public static set LOCALE_LANGUAGE(locale : string ) {this.locale = locale;}
-    public static get INTEGER_CLASS_PREFIX(): string { return '_'; }
 
     /* Enable for stopgap server */
     public static get BASE_URL(): string    { return this.APP_HOST_URL+this.WEB_CONTENT_PORT; }

--- a/nimbus-ui/nimbusui/src/app/services/service.constants.ts
+++ b/nimbus-ui/nimbusui/src/app/services/service.constants.ts
@@ -39,6 +39,7 @@ export class ServiceConstants {
     public static get WS_SUBSCRIBE_Q(): string { return '/user/queue/updates'; }
     public static get LOCALE_LANGUAGE() : string { return this.locale;}
     public static set LOCALE_LANGUAGE(locale : string ) {this.locale = locale;}
+    public static get INTEGER_CLASS_PREFIX(): string { return '_'; }
 
     /* Enable for stopgap server */
     public static get BASE_URL(): string    { return this.APP_HOST_URL+this.WEB_CONTENT_PORT; }


### PR DESCRIPTION
# Description

Change made to display-value directive to handle css class additions for datatypes other than String. 

Fixes # (issue)
NIM-19190

## Overview of Changes
- Remove the blanket displayValue.trim() which causes error if display value is not of type string
- Do a type check before adding the value to the element class

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Functional Testing

# Additional Notes

Please add any additional notes regarding this pull request here.
