### PR TITLE
Support for targetPath in message conditional

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/MessageConditional.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/MessageConditional.java
@@ -93,4 +93,9 @@ public @interface MessageConditional {
 	 * <p>To retain the message when {@link #when()} evaluates to {@code false}.
 	 */
 	boolean whenElseRetainMessage() default false;
+	
+	/**
+	 * <p>Path of param on which the messages are to be set
+	 */
+	String[] targetPath() default { };
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalHandler.java
@@ -1,9 +1,11 @@
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.defn.extension.MessageConditional;
@@ -27,43 +29,70 @@ public class MessageConditionalHandler extends EvalExprWithCrudActions<MessageCo
 		// Evaluate the msg as a spel expression
 		String evaluatedMessage = expressionEvaluator.getValue(configuredAnnotation.message(), new ParamStateHolder<>(onChangeParam), String.class);
 		
+		String[] targetPaths = configuredAnnotation.targetPath();
+		
 		if(isValid) {
-			// The unevaluated msg is considered unique as we dont want to show the same msg twice in different contexts or Types
-			// TODO: The same msg should not be added accross two Message Conditionals -Add a static validation for it in future
-			Message msg = new Message(configuredAnnotation.message(), evaluatedMessage, configuredAnnotation.messageType(), configuredAnnotation.context(),configuredAnnotation.cssClass());
-
-			Set<Message> newMsgs = new HashSet<>();
-			if(!CollectionUtils.isEmpty(onChangeParam.getMessages())) 
-				newMsgs.addAll(onChangeParam.getMessages());
-			
-			//  - if an existing msg with the same Key(when condition is present - then the new msg doesnt get added in a HashSet
-			// -  We want to replace the old value with the new value for the same key
-			if(!newMsgs.add(msg)) {
-				newMsgs.remove(msg);
-				
-			 }
-			newMsgs.add(msg);
-			onChangeParam.setMessages(newMsgs);
-			
+			if(StringUtils.isAllEmpty(targetPaths)) {
+				addMessageToParam(onChangeParam, evaluatedMessage, configuredAnnotation);
+			} else {
+				Arrays.asList(targetPaths).stream()
+				.forEach(targetPath -> {
+					Param<?> targetParam = retrieveParamByPath(onChangeParam, targetPath);
+					addMessageToParam(targetParam, evaluatedMessage, configuredAnnotation);
+				});
+			}
 		}
 		else if(!configuredAnnotation.whenElseRetainMessage()) {
-			if(CollectionUtils.isEmpty(onChangeParam.getMessages())) 
-				return;
+			if(StringUtils.isAllEmpty(targetPaths)) {
+				if(CollectionUtils.isEmpty(onChangeParam.getMessages())) 
+					return;
+				
+				removeMessageFromParam(onChangeParam, configuredAnnotation);
+			} else {
+				Arrays.asList(targetPaths).stream()
+				.forEach(targetPath -> {
+					Param<?> targetParam = retrieveParamByPath(onChangeParam, targetPath);
+					if(CollectionUtils.isNotEmpty(targetParam.getMessages())) {
+						removeMessageFromParam(targetParam, configuredAnnotation);
+					}
+				});
+			}
 			
-			Set<Message> oldMsgs = new HashSet<>(onChangeParam.getMessages());
 			
-			// Remove this msg
-			
-			oldMsgs.removeIf(msg -> msg.getUniqueId().equals(configuredAnnotation.message()));
-			if(CollectionUtils.isEmpty(oldMsgs))
-				onChangeParam.setMessages(null);
-			else
-				onChangeParam.setMessages(oldMsgs);
 		}
 		
 		
 	}
 	
+	private void addMessageToParam(Param<?> param, String message, MessageConditional configuredAnnotation) {
+		// The unevaluated msg is considered unique as we dont want to show the same msg twice in different contexts or Types
+		// TODO: The same msg should not be added accross two Message Conditionals -Add a static validation for it in future
+		Message msg = new Message(configuredAnnotation.message(), message, configuredAnnotation.messageType(), configuredAnnotation.context(),configuredAnnotation.cssClass());
+
+		Set<Message> newMsgs = new HashSet<>();
+		if(!CollectionUtils.isEmpty(param.getMessages())) 
+			newMsgs.addAll(param.getMessages());
+		
+		//  - if an existing msg with the same Key(when condition is present - then the new msg doesnt get added in a HashSet
+		// -  We want to replace the old value with the new value for the same key
+		if(!newMsgs.add(msg)) {
+			newMsgs.remove(msg);
+			
+		 }
+		newMsgs.add(msg);
+		param.setMessages(newMsgs);
+	}
+	
+	private void removeMessageFromParam(Param<?> param, MessageConditional configuredAnnotation) {
+		Set<Message> oldMsgs = new HashSet<>(param.getMessages());
+		
+		// Remove this msg
+		oldMsgs.removeIf(msg -> msg.getUniqueId().equals(configuredAnnotation.message()));
+		if(CollectionUtils.isEmpty(oldMsgs))
+			param.setMessages(null);
+		else
+			param.setMessages(oldMsgs);
+	}
 	
 
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageAqua.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageAqua.java
@@ -92,5 +92,10 @@ public class VPSampleViewPageAqua {
 			})
 			private int p6_nonExclusive;
 			
+			@MessageConditional(when="state =='Set'", targetPath="/../p8_message", message="'Message is set on p8_message'")
+			private String p7_messagetest;
+			
+			private String p8_message;
+			
 		}
 	}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalEventHandlerTest.java
@@ -225,4 +225,24 @@ public class MessageConditionalEventHandlerTest extends AbstractStateEventHandle
 		
 	}
 	
+	@Test
+	public void t05_message_targetpath() {
+		Param<String> inputParam = _q.getRoot().findParamByPath("/sample_view/page_aqua/vtAqua/vsSampleForm/vfSampleForm/p7_messagetest");
+		
+		Assert.assertNull(inputParam.getMessages());
+		assertFalse(inputParam.hasContextStateChanged());
+		inputParam.setState("Set");
+		
+		Param<String> messageParam = _q.getRoot().findParamByPath("/sample_view/page_aqua/vtAqua/vsSampleForm/vfSampleForm/p8_message");
+		assertNotNull(messageParam.getMessages());
+		assertEquals(1, messageParam.getMessages().size());
+		assertEquals("Message is set on p8_message", messageParam.getMessages().iterator().next().getText());
+		assertTrue(messageParam.hasContextStateChanged());
+		
+		inputParam.setState("Reset");
+		assertNull(messageParam.getMessages());
+		assertTrue(messageParam.hasContextStateChanged());
+		
+		
+	}
 }

--- a/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
@@ -175,7 +175,8 @@ export class ParamUtils {
 
             // Check for collectionElement and add elementId to leafstate 
             if (x_param && x_param.collectionElem) { 
-                transformed[x]['elemId'] = x_param.elemId; 
+                if(transformed[x] instanceof Object)
+                    transformed[x]['elemId'] = x_param.elemId; 
             }
 
             if (x_param ) {


### PR DESCRIPTION
# Description

When there are interdependent conditions written on message conditionals, there needs to be a way through which messages can be re-evaluated on a parameter where state change has not occurred. 

Fixes # 18085

## Overview of Changes
- Introduced targetpath on messageconditional so that messages of a different parameter can be set.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Junit

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Additional Notes

Please add any additional notes regarding this pull request here.
