### PR TITLE
NIM-17212: Adding StyleConditional and UI Support for GridColumn

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultFrameworkExtensionsConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultFrameworkExtensionsConfig.java
@@ -40,6 +40,7 @@ import com.antheminc.oss.nimbus.domain.model.state.extension.ParamValuesOnLoadHa
 import com.antheminc.oss.nimbus.domain.model.state.extension.RuleStateEventHandler;
 import com.antheminc.oss.nimbus.domain.model.state.extension.ScriptStateLoadNewHandler;
 import com.antheminc.oss.nimbus.domain.model.state.extension.StaticCodeValueBasedCodeToLabelConverter;
+import com.antheminc.oss.nimbus.domain.model.state.extension.StyleConditionalStateEventHandler;
 import com.antheminc.oss.nimbus.domain.model.state.extension.ValidateConditionalStateEventHandler;
 import com.antheminc.oss.nimbus.domain.model.state.extension.ValidateConditionalStateEventHandler.ValidationAssignmentStrategy;
 import com.antheminc.oss.nimbus.domain.model.state.extension.ValuesConditionalStateEventHandler;
@@ -113,6 +114,11 @@ public class DefaultFrameworkExtensionsConfig {
 	@Bean
 	public LabelConditionalStateEventHandler extensionLabelConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
 		return new LabelConditionalStateEventHandler(beanResolver);
+	}
+	
+	@Bean
+	public StyleConditionalStateEventHandler extensionStyleConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
+		return new StyleConditionalStateEventHandler(beanResolver);
 	}
 	
 	@Bean

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/StyleConditional.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/StyleConditional.java
@@ -1,0 +1,154 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.defn.extension;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.antheminc.oss.nimbus.domain.Event;
+import com.antheminc.oss.nimbus.domain.RepeatContainer;
+import com.antheminc.oss.nimbus.domain.defn.event.StateEvent.OnStateChange;
+import com.antheminc.oss.nimbus.domain.defn.event.StateEvent.OnStateLoad;
+
+/**
+ * <p> {@link StyleConditional} is an extension capability provided by the
+ * framework. The annotation is used to conditionally set the style property on
+ * the param represented by the decorated field based on a SpEL condition. The
+ * Framework provides default event handling for this annotation during the
+ * {@link OnStateLoad} and {@link OnStateChange} events.
+ * 
+ * <p> The following sample code shows how to configure a field using
+ * {@link StyleConditional} by setting the style property of the param
+ * represented by {@code nickname} based on the state of
+ * {@code shouldUseNickname}.
+ * 
+ * <pre>
+ * &#64;GridColumn
+ * &#64;Path
+ * private String nickname;
+ * 
+ * &#64;GridColumn(hidden = true)
+ * &#64;Path
+ * &#64;StyleConditional(targetPath = "/../nickname", condition = {
+ * 		&#64;StyleConditional.Condition(when = "state == true", then = &#64;Style(cssClass = "preferred")) })
+ * private boolean shouldUseNickname;
+ * </pre>
+ * 
+ * <p>In this scenario, when {@code shouldUseNickname} is {@code true},
+ * {@code nickname} will have the css class "preferred" added in the final HTML
+ * rendering of the &#64;GridColumn component. For example, assume the value of
+ * {@code shouldUseNickname} is {@code true} and the state of {@code nickname}
+ * is {@code "Bob"}, then something similar the following would be rendered:
+ * 
+ * <pre>
+ * &lt;span title="Bob" class="ng-star-inserted"&gt;
+ *   &lt;span class="fieldValue nickname preferred"&gt;Bob&lt;/span&gt;
+ * &lt;/span&gt;
+ * </pre>
+ * 
+ * <p>Each view component has it's own rules that specify where in the HTML
+ * structure the attributes contained within &#64;Style will be written to. See
+ * the UI documentation or the final rendered HTML for more information.
+ * 
+ * <p> This annotation can be triggered for multiple events by providing one or
+ * more {@link Condition} annotations within {@code targetPath} and/or multiple
+ * {@link StyleConditional} annotations.
+ * 
+ * @author Tony Lopez
+ * @since 1.1
+ * @see com.antheminc.oss.nimbus.domain.defn.extension.StyleConditionals
+ * @see com.antheminc.oss.nimbus.domain.model.state.extension.StyleConditionalStateEventHandler
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+@Repeatable(StyleConditionals.class)
+@OnStateChange
+@OnStateLoad
+public @interface StyleConditional {
+
+	@Documented
+	@Retention(RUNTIME)
+	@Target(FIELD)
+	@Repeatable(Conditions.class)
+	public @interface Condition {
+
+		/**
+		 * <p>The {@link Style} object to assign to the param(s) identified by
+		 * {@code targetPath} when this condition's {@link #when()} is
+		 * {@code true}. <p><b>Applying more than one style
+		 * class</b><br>Multiple css classes can be applied by providing a space
+		 * delimited string for {@link Style#cssClass()}.
+		 */
+		Style then();
+
+		/**
+		 * <p>SpEL based condition to be evaluated relative to param's state on
+		 * which this annotation is declared.
+		 */
+		String when();
+	}
+
+	@Documented
+	@Retention(RUNTIME)
+	@Target(FIELD)
+	@RepeatContainer(Condition.class)
+	public @interface Conditions {
+
+		/**
+		 * <p>A single or set of conditions to evaluate against.
+		 */
+		Condition[] value();
+	}
+
+	/**
+	 * <p>An array of conditional metadata that is responsible for determining
+	 * whether or not the {@code target} field will be updated.
+	 * 
+	 * <p>Conditions are executed from top to bottom, in the order in which they
+	 * are defined. If it is necessary to define logic to override prior
+	 * conditions, consider setting the {@link #exclusive()} value to false.
+	 */
+	Condition[] condition();
+
+	/**
+	 * <p>Configures whether or not the first truthy condition should be
+	 * exclusive.
+	 * 
+	 * <p>If {@code true}, then only the first truthy condition will be
+	 * executed. If {@code false}, then all truthy conditions will be executed.
+	 * The default value is {@code true}.
+	 */
+	boolean exclusive() default true;
+
+	/**
+	 * <p>The order of execution this annotation should be executed in, with
+	 * respect to other conditional annotations that are also decorating this
+	 * param.
+	 */
+	int order() default Event.DEFAULT_ORDER_NUMBER;
+
+	/**
+	 * <p>Path of param to apply styles to when condition is satisfied. The path
+	 * is relative to param on which this annotation is declared.
+	 */
+	String targetPath();
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/StyleConditionals.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/StyleConditionals.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.defn.extension;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.antheminc.oss.nimbus.domain.RepeatContainer;
+
+/**
+ * <p>Repeat container for {@link StyleConditional}.
+ * 
+ * @see com.antheminc.oss.nimbus.domain.defn.extension.StyleConditional
+ * @author Tony Lopez
+ * @since 1.1
+ *
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+@RepeatContainer(StyleConditional.class)
+public @interface StyleConditionals {
+
+	/**
+	 * <p>The array of {@link StyleConditional} annotations to wrap.
+	 */
+	StyleConditional[] value();
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
@@ -27,6 +27,8 @@ import java.util.stream.Stream;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -548,6 +550,9 @@ public interface EntityState<T> {
 		LabelState getDefaultLabel();
 		LabelState getLabel(String localeLanguageTag);
 		
+		StyleState getStyle();
+		void setStyle(StyleState styleState);
+		
 		@Getter @Setter @ToString 
 		public static class LabelState {
 			private String locale; //default en-US
@@ -580,6 +585,36 @@ public interface EntityState<T> {
 			public int hashCode() {
 				String concat = this.locale + this.text;
 				return concat.hashCode();
+			}
+		}
+		
+		@Getter @Setter @ToString 
+		public static class StyleState {
+			
+			private String cssClass;
+			
+			@Override
+			public boolean equals(Object obj) {
+				if(obj == null) {
+					return false;
+				}
+				
+				if (!LabelState.class.isInstance(obj)) {
+					return false;
+				}
+				
+				StyleState rhs = StyleState.class.cast(obj);
+				
+				return new EqualsBuilder()
+						.append(this.cssClass, rhs.cssClass)
+						.isEquals();
+			}
+			
+			@Override
+			public int hashCode() {
+				return new HashCodeBuilder()
+						.append(this.cssClass)
+						.toHashCode();
 			}
 		}
 		

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/StateHolder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/StateHolder.java
@@ -473,5 +473,15 @@ public class StateHolder {
 			return this.ref.getLabel(localeLanguageTag);
 		}
 
+		@Override
+		public StyleState getStyle() {
+			return this.ref.getStyle();
+		}
+
+		@Override
+		public void setStyle(StyleState styleState) {
+			this.ref.setStyle(styleState);
+		}
+
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandler.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension;
+
+import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.defn.extension.Style;
+import com.antheminc.oss.nimbus.domain.defn.extension.StyleConditional;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.StyleState;
+import com.antheminc.oss.nimbus.support.JustLogit;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class StyleConditionalStateEventHandler extends EvalExprWithCrudDefaults<StyleConditional> {
+
+	public static final JustLogit LOG = new JustLogit();
+
+	public StyleConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
+		super(beanResolver);
+	}
+
+	protected void applyStyleToState(Param<?> onChangeParam, Param<?> targetParam,
+			Style style) {
+		StyleState styleState = new StyleState();
+		styleState.setCssClass(style.cssClass());
+		targetParam.setStyle(styleState);
+	}
+
+	@Override
+	protected void executeDefault(Param<?> onChangeParam, Param<?> targetParam) {
+		targetParam.setStyle(null);
+	}
+
+	@Override
+	protected void executeOnWhenConditionTrue(Object payload, Param<?> onChangeParam, Param<?> targetParam) {
+		// Convert the payload into the expected parameter type.
+		Style style = (Style) payload;
+		this.applyStyleToState(onChangeParam, targetParam, style);
+	}
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
@@ -123,13 +123,14 @@ public class DefaultParamState<T> extends AbstractEntityState<T> implements Para
 		}
 	};
 	
+	@JsonIgnore
+	private RemnantState<StyleState> styleState = this.new RemnantState<>(null);
+	
 	@Override
 	public boolean hasContextStateChanged() {
-		if(visibleState.hasChanged() || enabledState.hasChanged() || messageState.hasChanged()  
-				|| activeValidationGroupsState.hasChanged() || labelState.hasChanged())
-			return true;
-		
-		return false;
+		return visibleState.hasChanged() || enabledState.hasChanged() || messageState.hasChanged() || 
+				activeValidationGroupsState.hasChanged() || labelState.hasChanged() || 
+				styleState.hasChanged();
 	}
 	
 	
@@ -1015,5 +1016,15 @@ public class DefaultParamState<T> extends AbstractEntityState<T> implements Para
 					.append(", state=").append(getState())
 					.append(")")
 					.toString();
+	}
+
+	@Override
+	public StyleState getStyle() {
+		return this.styleState.getCurrState();
+	}
+
+	@Override
+	public void setStyle(StyleState styleState) {
+		this.styleState.setState(styleState);
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/support/DefaultJsonParamSerializer.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/support/DefaultJsonParamSerializer.java
@@ -52,6 +52,7 @@ public class DefaultJsonParamSerializer extends JsonSerializer<Param<?>> {
 	private static final String K_TYPE = "type";
 	private static final String K_VALUES = "values";
 	private static final String K_LABELS = "labels";
+	private static final String K_STYLE = "style";
 	private static final String K_ELEM_LABELS = "elemLabels";
 	
 	private static final String K_PAGE = "page";
@@ -110,6 +111,7 @@ public class DefaultJsonParamSerializer extends JsonSerializer<Param<?>> {
 			writer.writeObjectIfNotNull(K_MESSAGE, p::getMessages);
 			writer.writeObjectIfNotNull(K_VALUES, p::getValues);
 			writer.writeObjectIfNotNull(K_LABELS, p::getLabels);
+			writer.writeObjectIfNotNull(K_STYLE, p::getStyle);
 			
 			if(!p.getType().getName().equals("string"))
 				writer.writeObjectIfNotNull(K_TYPE, p::getType);

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParam.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParam.java
@@ -76,6 +76,7 @@ public class MockParam implements Param<Object> {
 	private boolean collectionElem;
 	private boolean nested;
 	private boolean leaf;
+	private StyleState style;
 
 	@Override
 	public String getConfigId() {

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/utils/ParamUtils.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/utils/ParamUtils.java
@@ -31,6 +31,39 @@ public class ParamUtils {
 
 	/**
 	 * <p> Given a framework response object, {@code response}, this method
+	 * deciphers and attempts to locate a value from each of the
+	 * {@link MultiOutput}'s {@link Output#getValue()} values that has is of
+	 * type {@code clazz}. If multiple params are found, only the first will be
+	 * returned.
+	 * 
+	 * @param response the response received as a result of the framework
+	 *            request
+	 * @param clazz the expected type to identify and return
+	 * @return the param identified within the response of the expected type
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T extractResponseByClass(Object response, Class<T> clazz) {
+		if (null == response) {
+			throw new RuntimeException("response must not be null");
+		}
+		if (null == clazz) {
+			throw new RuntimeException("clazz must not be null");
+		}
+
+		Holder<MultiOutput> resp = (Holder<MultiOutput>) response;
+		MultiOutput multiOutput = resp.getState();
+
+		for (Output<?> output : multiOutput.getOutputs()) {
+			if (output.getValue().getClass().isAssignableFrom(clazz)) {
+				return (T) output.getValue();
+			}
+		}
+
+		throw new RuntimeException("Unable to locate param in response having class'" + clazz.getSimpleName() + ".");
+	}
+
+	/**
+	 * <p> Given a framework response object, {@code response}, this method
 	 * deciphers and attempts to locate a param from each of the
 	 * {@link MultiOutput}'s {@link Output#getValue()} values that has a URI
 	 * path ending with {@code paramPathEndsWith}. If multiple params are found,
@@ -50,6 +83,10 @@ public class ParamUtils {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> Param<T> extractResponseByParamPath(Object response, String paramPathEndsWith) {
+		if (null == response) {
+			throw new RuntimeException("response must not be null");
+		}
+
 		Holder<MultiOutput> resp = (Holder<MultiOutput>) response;
 		MultiOutput multiOutput = resp.getState();
 

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageAqua.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageAqua.java
@@ -11,6 +11,8 @@ import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
 import com.antheminc.oss.nimbus.domain.defn.extension.LabelConditional;
 import com.antheminc.oss.nimbus.domain.defn.extension.LabelConditional.Condition;
 import com.antheminc.oss.nimbus.domain.defn.extension.MessageConditional;
+import com.antheminc.oss.nimbus.domain.defn.extension.Style;
+import com.antheminc.oss.nimbus.domain.defn.extension.StyleConditional;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 
 import lombok.Getter;
@@ -44,10 +46,15 @@ public class VPSampleViewPageAqua {
 		
 		@Model @Getter @Setter
 		public static class VSSampleForm{
+			
 			@Form
 			private VFSampleForm vfSampleForm;
 			
+			@Form
+			private VFStyleForm vfStyleForm;
+			
 		}
+		
 		@Model @Getter @Setter
 		@MapsTo.Type(SampleCoreEntity.class)
 		public static class VFSampleForm{
@@ -97,5 +104,36 @@ public class VPSampleViewPageAqua {
 			
 			private String p8_message;
 			
+		}
+		
+		@Model
+		@Getter @Setter
+		public static class VFStyleForm {
+			
+			private String p0;
+			
+			@StyleConditional(targetPath = "/../p0", condition = {
+				@StyleConditional.Condition(when = "state == 1", then = @Style(cssClass = "red"))
+			})
+			private int p1;
+			
+			@StyleConditional(targetPath = "/../p0", condition = {
+				@StyleConditional.Condition(when = "state == 1", then = @Style(cssClass = "red")),
+				@StyleConditional.Condition(when = "state == 2", then = @Style(cssClass = "blue")),
+				@StyleConditional.Condition(when = "state == 3", then = @Style(cssClass = "green"))
+			})
+			private int p2;
+			
+			@StyleConditional(targetPath = "/", exclusive = true, condition = {
+				@StyleConditional.Condition(when = "state > 5", then = @Style(cssClass = "red")),
+				@StyleConditional.Condition(when = "state > 10", then = @Style(cssClass = "green"))
+			})
+			private int p3Exclusive;
+			
+			@StyleConditional(targetPath = "/", exclusive = false, condition = {
+				@StyleConditional.Condition(when = "state > 5", then = @Style(cssClass = "red")),
+				@StyleConditional.Condition(when = "state > 10", then = @Style(cssClass = "green"))
+			})
+			private int p3NonExclusive;
 		}
 	}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultBehaviorExecutorStateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultBehaviorExecutorStateTest.java
@@ -31,6 +31,7 @@ import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.cmd.Behavior;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ParamUtils;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.view.VPSampleViewPageGreen.TileGreen;
 import com.antheminc.oss.nimbus.test.scenarios.s0.view.VRSampleViewRootEntity;
@@ -102,7 +103,7 @@ public class DefaultBehaviorExecutorStateTest extends AbstractFrameworkIngeratio
 		Object home_newResp = controller.handleGet(home_newReq, null);
 		assertNotNull(home_newResp);
 		
-		Object actual = ExtractResponseOutputUtils.extractOutput(home_newResp, 2);
+		Object actual = ParamUtils.extractResponseByClass(home_newResp, VRSampleViewRootEntity.class);
 		assertNotNull(actual);
 		assertTrue(VRSampleViewRootEntity.class.isInstance(actual));
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandlerTest.java
@@ -1,0 +1,129 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.model.state.AbstractStateEventHandlerTests;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class StyleConditionalStateEventHandlerTest extends AbstractStateEventHandlerTests {
+
+	@Test
+	public void testStyleConditionalSingle() {
+
+		Param<String> p_p0 = getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p0");
+
+		// Validate original style is set
+		Assert.assertNull(p_p0.getStyle());
+
+		// Trigger the and validate the style is set conditionally
+		getParam("/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p1").setState(1);
+		Assert.assertEquals("red", p_p0.getStyle().getCssClass());
+	}
+
+	@Test
+	public void testStyleConditionalMultiple() {
+
+		Param<Integer> p_p2 = getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p2");
+		
+		// Validate original label is set
+		Assert.assertNull(getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p0").getStyle());
+		
+		// Trigger and validate the style is set conditionally
+		p_p2.setState(1);
+		Assert.assertEquals("red", getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p0").getStyle().getCssClass());
+		
+		// Trigger and validate the style is set conditionally
+		p_p2.setState(2);
+		Assert.assertEquals("blue", getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p0").getStyle().getCssClass());
+		
+		// Trigger and validate the style is set conditionally
+		p_p2.setState(3);
+		Assert.assertEquals("green", getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p0").getStyle().getCssClass());
+	}
+
+	@Test
+	public void testStyleConditionalDontApply() {
+		Param<String> p_p0 = getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p0");
+
+		// Validate original style is set
+		Assert.assertNull(p_p0.getStyle());
+
+		// Trigger and validate the style is NOT set conditionally
+		getParam("/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p1").setState(999);
+		Assert.assertNull(p_p0.getState());
+	}
+
+	@Test
+	public void testStyleConditionalReset() {
+
+		Param<String> p_p0 = getParam(
+				"/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p0");
+
+		// Validate original style is set
+		Assert.assertNull(p_p0.getStyle());
+
+		// Trigger the and validate the style is set conditionally
+		getParam("/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p1").setState(1);
+		Assert.assertEquals("red", p_p0.getStyle().getCssClass());
+		
+		// Validate original style is set
+		getParam("/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p1").setState(0);
+		Assert.assertNull(p_p0.getStyle());
+	}
+	
+	@Test
+	public void testStyleConditional_exclusive() {
+		// Validate original styles are set
+		Param<Integer> p_exclusive = getParam("/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p3Exclusive");
+		Param<Integer> p_nonExclusive = getParam("/sample_view/page_aqua/vtAqua/vsSampleForm/vfStyleForm/p3NonExclusive");
+		Assert.assertNull(p_exclusive.getStyle());
+		Assert.assertNull(p_nonExclusive.getStyle());
+
+		// Trigger the exclusive style and check if it is set appropriately
+		p_exclusive.setState(20);
+		Assert.assertEquals("red", p_exclusive.getStyle().getCssClass());
+		
+		// Trigger the non-exclusive style and check if it is set appropriately
+		p_nonExclusive.setState(20);
+		Assert.assertEquals("green", p_nonExclusive.getStyle().getCssClass());
+	}
+
+	private <T> Param<T> getParam(String paramPath) {
+		return _q.getRoot().findParamByPath(paramPath);
+	}
+
+	@Override
+	protected Command createCommand() {
+		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
+		return cmd;
+	}
+}

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-builder.service.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-builder.service.ts
@@ -109,8 +109,8 @@ export class FormElementsService {
     var leafState;
     if (ParamUtils.isKnownDateType(param.config.type.name)) {
       leafState = param.leafState || null;
-    } else if(param.alias === 'Grid' && param.gridList && param.gridList.length > 0) {
-        leafState = param.gridList;
+    } else if(param.alias === 'Grid' && param.gridData.leafState && param.gridData.leafState.length > 0) {
+        leafState = param.gridData.leafState;
     } else {
       leafState = param.leafState || '';
     }

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/grid.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/grid.component.ts
@@ -137,8 +137,8 @@ export class InfiniteScrollGrid extends BaseElement implements ControlValueAcces
             });
         }
 
-        if (this.element.gridList != null && this.element.gridList.length > 0) {
-            this.value = this.element.gridList;
+        if (this.element.gridData.leafState != null && this.element.gridData.leafState.length > 0) {
+            this.value = this.element.gridData.leafState;
             this.totalRecords = this.value.length;
             this.updatePageDetailsState();
         }
@@ -178,7 +178,7 @@ export class InfiniteScrollGrid extends BaseElement implements ControlValueAcces
 
         this.pageSvc.gridValueUpdate$.subscribe(event => {
             if (event.path == this.element.path) {
-                this.value = event.gridList;
+                this.value = event.gridData.leafState;
                 //this.paramState = event.paramState;
                 //this.element.collectionParams = event.collectionParams;
                 this.totalRecords = this.value ? this.value.length : 0;

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
@@ -98,7 +98,7 @@
                 <ng-template ngFor let-col let-colIndex="index" [ngForOf]="params">
                     <td *ngIf="showColumn(col)" [ngClass]="getColumnStyle(col)">
                         <span title="{{getCellDisplayValue(rowData, col)}}" *ngIf="showValue(col)" [nmDisplayValue]='getCellDisplayValue(rowData, col)' [config]='col'>
-                            <span class="fieldValue">{{getCellDisplayValue(rowData, col)}}</span>
+                            <span class="fieldValue {{col.code}} {{getCellStyle(rowData.elemId, col.code)}}">{{getCellDisplayValue(rowData, col)}}</span>
                         </span>
                         <span *ngIf="col?.uiStyles?.attributes?.alias == viewComponent.link.toString()">
                             <nm-link

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
@@ -38,7 +38,7 @@ import { GridService } from '../../../services/grid.service';
 import { ServiceConstants } from './../../../services/service.constants';
 import { SortAs, GridColumnDataType } from './sortas.interface';
 import { ActionDropdown } from './../form/elements/action-dropdown.component';
-import { Param } from '../../../shared/param-state';
+import { Param, StyleState } from '../../../shared/param-state';
 import { HttpMethod } from './../../../shared/command.enum';
 import { TableComponentConstants } from './table.component.constants';
 import { ViewComponent, ComponentTypes } from '../../../shared/param-annotations.enum';
@@ -97,6 +97,7 @@ export class DataTable extends BaseElement implements ControlValueAccessor {
     defaultPattern: RegExp = /^[ A-Za-z0-9_@./#&+-,()!%_{};:?.<>-]*$/;
     numPattern: RegExp = /[\d\-\.]/;
     id: String = 'grid-control' + counter++;
+    gridRowConfig: any[];
 
     get value() {
         return this._value;
@@ -172,8 +173,8 @@ export class DataTable extends BaseElement implements ControlValueAccessor {
             this.columnsToShow ++;
         }
 
-        if (this.element.gridList != null && this.element.gridList.length > 0) {
-            this.value = this.element.gridList;
+        if (this.element.gridData.leafState != null && this.element.gridData.leafState.length > 0) {
+            this.value = this.element.gridData.leafState;
             this.totalRecords = this.value.length;
             this.updatePageDetailsState();
         }
@@ -216,7 +217,7 @@ export class DataTable extends BaseElement implements ControlValueAccessor {
 
         this.pageSvc.gridValueUpdate$.subscribe(event => {
             if (event.path == this.element.path) {
-                this.value = event.gridList;
+                this.value = event.gridData.leafState;
                 
                 // iterate over currently expanded rows and refresh the data
                 Object.keys(this.dt.expandedRowKeys).forEach(key => {
@@ -692,6 +693,11 @@ export class DataTable extends BaseElement implements ControlValueAccessor {
         } else {
             return this.defaultPattern;
         }
+    }
+
+    getCellStyle(rowIndex, code): string {
+        let style: StyleState = this.element.gridData.stateMap[rowIndex][code].style;
+        return style ? style.cssClass : '';
     }
 
     /**

--- a/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.ts
@@ -81,7 +81,7 @@ export class TreeGrid extends BaseElement implements ControlValueAccessor {
         this.pageSvc.processEvent(this.element.path, '$execute', new GenericDomain(), HttpMethod.GET.value, undefined);
         this.pageSvc.gridValueUpdate$.subscribe((treeList: Param) => {
             if(this.element.path === treeList.path){
-                this.treeData = this.getTreeStructure(treeList.gridList);
+                this.treeData = this.getTreeStructure(treeList.gridData.leafState);
             }
         });
 

--- a/nimbus-ui/nimbusui/src/app/services/page.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/page.service.ts
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 'use strict';
+
 import { LoaderService } from './loader.service';
 import { ConfigService } from './config.service';
 import { Action, HttpMethod, Behavior } from './../shared/command.enum';
-import { Injectable, EventEmitter, Inject } from '@angular/core';
+import { Injectable, EventEmitter } from '@angular/core';
 import { ServiceConstants } from './service.constants';
-import { ParamConfig, Validation } from '../shared/param-config';
 import { ModelEvent, Page, Result, ViewRoot } from '../shared/app-config.interface';
-import { Param, Model, Type, GridPage, TreeGridDeserializer } from '../shared/param-state';
+import { Param, Model, GridPage } from '../shared/param-state';
 import { CustomHttpClient } from './httpclient.service';
 
-import { Subject, Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import { GenericDomain } from '../model/generic-domain.model';
 import { RequestContainer } from '../shared/requestcontainer';
-import { ExecuteResponse, ExecuteException } from './../shared/app-config.interface';
+import { ExecuteException } from './../shared/app-config.interface';
 import { ParamUtils } from './../shared/param-utils';
 import { ParamAttribute } from './../shared/command.enum';
 import { ViewConfig } from './../shared/param-annotations.enum';
@@ -36,6 +36,8 @@ import { LoggerService } from './logger.service';
 import { SessionStoreService } from './session.store';
 import { Location } from '@angular/common';
 import { ViewComponent } from '../shared/param-annotations.enum';
+import { GridData } from './../shared/param-state';
+
 /**
  * \@author Dinakar.Meda
  * \@author Sandeep.Mantha
@@ -689,22 +691,45 @@ export class PageService {
          * Loop through the Param State and build the Grid
          *
          */
-        createGridData(gridElementParams: Param[], gridParam: Param) {
+        createGridData(gridElementParams: Param[], gridParam: Param): GridData {
                 let gridData = [];
                 let collectionParams = [];
+                // contains state data for the grid (other than leafState (e.g. style, etc.))
+                let gridStateMap = [];
+
                 if (gridElementParams) {
                         gridElementParams.forEach(param => {
                                 let p = new Param(this.configService).deserialize(param, gridParam.path);
                                 if (p != null) {
+                                        // build the gridList data
                                         if (p.leafState !== null && p.leafState.nestedGridParam) {
                                                 collectionParams = collectionParams.concat(p.leafState.nestedGridParam);
                                         }
+                                        // let leafState = p.leafState;
+                                        // delete leafState.nestedGridParam;
+                                        // gridData.push(leafState);
                                         gridData.push(p.leafState);
-                                }
+
+                                        // build the gridRowConfig data (other stateful data)
+                                        let rowStateData = {};
+                                        if (p.leafState) {
+                                                for (let cellParam of p.type.model.params) {
+                                                        let cellStateData = this.configService.getViewConfigById(cellParam.configId);
+                                                        rowStateData[cellStateData.code] = {
+                                                                style: cellParam.style
+                                                        };
+                                                }
+                                        }
+                                        gridStateMap.push(rowStateData);
+                                }       
                         });
                 }
                 gridParam['collectionParams'] = collectionParams;
-                return gridData;
+                
+                return {
+                        leafState: gridData,
+                        stateMap: gridStateMap
+                } as GridData;
         }
 
         /**
@@ -721,10 +746,10 @@ export class PageService {
                                         // Current Collection
                                         // Collection Element Check - update only the element
                                         if (eventModel.value.collectionElem) {
-                                                if (param.gridList == null) {
-                                                        param.gridList = this.createGridData(eventModel.value.type.model.params, param);
+                                                if (param.gridData.leafState == null) {
+                                                        param.gridData = this.createGridData(eventModel.value.type.model.params, param);
                                                 } else {
-                                                        param.gridList.push(this.createGridData(eventModel.value.type.model.params, param));
+                                                        param.gridData.leafState.push(this.createGridData(eventModel.value.type.model.params, param).leafState);
                                                 }
                                                 this.gridValueUpdate.next(param);
                                         }
@@ -734,7 +759,7 @@ export class PageService {
                                                         let page: GridPage = new GridPage().deserialize(eventModel.value.page);
                                                         param.page = page;
                                                 }
-                                                param.gridList = this.createGridData(eventModel.value.type.model.params, param);
+                                                param.gridData = this.createGridData(eventModel.value.type.model.params, param);
                                                 this.gridValueUpdate.next(param);
                                         }
                                         //handle visible, enabled, activatevalidationgroups - the state above will always run if visible is true or false
@@ -746,12 +771,12 @@ export class PageService {
                                 } else { // Nested Collection. Need to traverse to right location
                                         let nestedPath = eventModel.value.path.substr(param.path.length + 1);
                                         let elemIndex = nestedPath.substr(0, nestedPath.indexOf('/'));
-                                        if( param.gridList) {
-                                                for (var p = 0; p < param.gridList.length; p++) {
-                                                        if (param.gridList[p]['elemId'] == elemIndex) {
-                                                                let nestedElement = this.getNestedElementParam(param.gridList[p]['nestedElement'], nestedPath, eventModel.value.path);
+                                        if( param.gridData.leafState) {
+                                                for (var p = 0; p < param.gridData.leafState.length; p++) {
+                                                        if (param.gridData.leafState[p]['elemId'] == elemIndex) {
+                                                                let nestedElement = this.getNestedElementParam(param.gridData.leafState[p]['nestedElement'], nestedPath, eventModel.value.path);
                                                                 if (nestedElement) {
-                                                                        nestedElement['gridList'] = this.createGridData(eventModel.value.type.model.params, nestedElement);
+                                                                        nestedElement['gridData'] = this.createGridData(eventModel.value.type.model.params, nestedElement);
                                                                         this.gridValueUpdate.next(nestedElement);
                                                                 }
                                                                 // if nestedElement is not present, we do not need to handle this scenario.
@@ -820,14 +845,14 @@ export class PageService {
                         // find's and return the element based on the nestedelement.config.code and index
                         if (this.matchNode(element, tree[index])) {
                                 let matchFoundOnGrid = false;
-                                if (element.gridList && element.gridList.length >0){
+                                if (element.gridData.leafState && element.gridData.leafState.length >0){
                                         // if there is a gridlist, match the elemntId
                                         // and look into nested element of the gridlist.
-                                        for(let  i = 0; i < element.gridList.length; i++){
-                                                if (this.matchElementId(element.gridList[i], tree[index+1])){
+                                        for(let  i = 0; i < element.gridData.leafState.length; i++){
+                                                if (this.matchElementId(element.gridData.leafState[i], tree[index+1])){
                                                                 matchFoundOnGrid = true;
                                                                 index += 2; // skip the elementID in the path and the curentElements cnfig.code
-                                                                return  this.traverseNestedPath(element.gridList[i].nestedElement, index + 1, tree, eventPath);
+                                                                return  this.traverseNestedPath(element.gridData.leafState[i].nestedElement, index + 1, tree, eventPath);
                                                 }
                                         }
                                 }

--- a/nimbus-ui/nimbusui/src/app/shared/param-state.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-state.ts
@@ -1,4 +1,3 @@
-import { TreeGrid } from './../components/platform/tree-grid/tree-grid.component';
 /**
  * @license
  * Copyright 2016-2018 the original author or authors.
@@ -16,6 +15,16 @@ import { TreeGrid } from './../components/platform/tree-grid/tree-grid.component
  * limitations under the License.
  */
 'use strict';
+
+import { ConfigService } from './../services/config.service';
+import { ParamUtils } from './param-utils';
+import { Converter } from './object.conversion';
+import { Serializable } from './serializable';
+import { ParamConfig, LabelConfig } from './param-config';
+import { Message } from './message';
+import { ViewComponent } from './param-annotations.enum';
+import { TableComponentConstants } from '../components/platform/grid/table.component.constants';
+
 /**
  * \@author Sandeep.Mantha
  * \@whatItDoes 
@@ -23,18 +32,6 @@ import { TreeGrid } from './../components/platform/tree-grid/tree-grid.component
  * \@howToUse 
  * 
  */
-import { ConfigService } from './../services/config.service';
-import { SortAs } from "../components/platform/grid/sortas.interface";
-import { PageService } from '../services/page.service';
-import { GridService } from '../services/grid.service';
-import { ParamUtils } from './param-utils';
-import { Converter } from './object.conversion';
-import { Serializable } from './serializable';
-import { ParamConfig, LabelConfig } from './param-config';
-import { Message } from './message';
-import { ViewConfig, ViewComponent } from './param-annotations.enum';
-import { TableComponentConstants } from '../components/platform/grid/table.component.constants';
-
 export class Param implements Serializable<Param, string> {
     configId: string;
     type: Type;
@@ -43,20 +40,23 @@ export class Param implements Serializable<Param, string> {
     path: string;
     collection: boolean;
     collectionElem: boolean;
-    elemId: string;
     enabled: boolean = true;
-    gridList: any[];
     message : Message[];
     paramState: Param[];
     values : Values[];
     visible: boolean = true;
     activeValidationGroups: String[] = [];
-    collectionParams: Param[] = [];
     page: GridPage;
     _alias: string;
     _config: ParamConfig;
     labels: LabelConfig[];
     elemLabels: Map<string, LabelConfig[]>;
+    gridData: GridData;
+    style: StyleState;
+
+    // Move to Grid Data
+    elemId: string;
+    collectionParams: Param[] = [];
 
     constructor(private configSvc: ConfigService) {}
 
@@ -73,9 +73,9 @@ export class Param implements Serializable<Param, string> {
 
     private createRowData(param: Param) {
         let rowData: any = {};
-        let isTreeGrid = this.config != null && this.config.uiStyles && this.config.uiStyles.attributes.alias == ViewComponent.treeGrid.toString();
         rowData = param.leafState;
         if(param.type.model) {
+            let isTreeGrid = this.config != null && this.config.uiStyles && this.config.uiStyles.attributes.alias == ViewComponent.treeGrid.toString();
             rowData['nestedGridParam'] = [];
             for(let p of param.type.model.params) {
                 if(p != null) {
@@ -194,8 +194,10 @@ export class Param implements Serializable<Param, string> {
             if (inJson.page) {
                 this.page = new GridPage().deserialize(inJson.page);
             }
+            this.gridData = new GridData();
             if (inJson.type && inJson.type.model && inJson.type.model.params) {
-                this.gridList = [];
+                this.gridData.leafState = [];
+                this.gridData.stateMap = [];
                 //this.paramState = [];
                 if(this.path && typeof inJson.path == undefined)
                     inJson.path = this.path;
@@ -203,11 +205,28 @@ export class Param implements Serializable<Param, string> {
                     if (!ParamUtils.isEmpty(inJson.type.model.params[p])) {
                         //this.paramState.push(inJson.type.model.params[p].type.model.params); 
                         //this.gridList.push(this.createRowData(inJson.type.model.params[p])); 
-                        let lineItem = this.createRowData(new Param(this.configSvc).deserialize(inJson.type.model.params[p], this.path));
+                        let colElemParam = new Param(this.configSvc).deserialize(inJson.type.model.params[p], this.path)
+                        
+                        // TODO Refactor the following transformations for efficiency by 
+                        // combining this.createRowData and gridData.stateMap implementation
+                        // into single loop.
+                        
+                        // Update the gridData.leafState
+                        let lineItem = this.createRowData(colElemParam);
                         if(lineItem.nestedGridParam)
                           this.collectionParams = this.collectionParams.concat(lineItem.nestedGridParam); 
                         delete lineItem.nestedGridParam; 
-                        this.gridList.push(lineItem);  
+                        this.gridData.leafState.push(lineItem);
+
+                        // Update the gridData.stateMap
+                        let rowStateData = {};
+                        for(var cellParam of colElemParam.type.model.params) {
+                            let cellParamCode = this.configSvc.getViewConfigById(cellParam.configId).code;
+                            rowStateData[cellParamCode] = {
+                                style: cellParam.style
+                            };
+                        }
+                        this.gridData.stateMap.push(rowStateData);
                     }
                 }
             }
@@ -222,7 +241,9 @@ export class Param implements Serializable<Param, string> {
                 this.leafState = ParamUtils.applyLeafStateTransformations(inJson.leafState, this);
             }
         }
-
+        if ( inJson.style ) {
+            this.style = new StyleState().deserialize(inJson.style);
+        }
         if ( inJson.collectionElem && this.leafState) {
             this.leafState = this.createRowData(this);
         }
@@ -395,4 +416,23 @@ export class TreeGridDeserializer {
         }
     }
 
+}
+
+export class StyleState implements Serializable<StyleState, string> {
+
+    cssClass: string;
+
+    deserialize( inJson ) {
+        let obj = this;
+        obj = Converter.convert(inJson, obj);
+        return obj;
+    }
+}
+
+export class GridData {
+
+    elemId: string;
+    collectionParams: Param[] = [];
+    leafState: any[];
+    stateMap: any[];
 }


### PR DESCRIPTION
# Description

Adding `@StyleConditional` and UI Support for it. See the following example:

**Sample Config**
```java
// Assume state of nickname is: "Bob"
@GridColumn
@Path
private String nickname;

@GridColumn(hidden = true)
@Path
@StyleConditional(targetPath = "/../nickname", condition = {
    @StyleConditional.Condition(when = "state == true", then = @Style(cssClass = "preferred"))
})
private boolean shouldUseNickname;
```

**Rendered HTML**
If `shouldUseNickname` is `true` then:
```xml
<span title="Bob" class="ng-star-inserted">
    <span class="fieldValue nickname preferred">Bob</span>
</span>
```
If `shouldUseNickname` is `false` then:
```xml
<span title="Bob" class="ng-star-inserted">
    <span class="fieldValue nickname ">Bob</span>
</span>
```

## Overview of Changes
- Introduced `gridData` to the UI param state.
  - Refactored param state's `gridList` into `gridData`
  - Added `stateMap` to `gridData`, to hold all other stateful information other than `leafState`. This was needed for passing the `style` property to the grid component for each cell displayed in the table. We can expand on this by adding more to it, if necessary.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] StyleConditionalStateEventHandlerTest.java

# Additional Notes

- [ ] As of now, only `@GridColumn` is supported, but we can roll the change out to other view components as needed.