### PR TITLE
NIM-17467: Fixing collection instantiation issue

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/MappedDefaultListParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/MappedDefaultListParamState.java
@@ -115,7 +115,7 @@ public class MappedDefaultListParamState<T, M> extends DefaultListParamState<T> 
 			@Override
 			protected void onEventResetModel(Notification<List<M>> event) {
 				// ensure model is instantiated
-				super.onEventUpdateState(event);
+//				super.onEventUpdateState(event);
 				
 				// synch-up between mapped & mapsTo
 				ListModel<?> mapsToListModel = event.getEventParam().findIfCollection().getType().getModel();	

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s13/core/S13Core.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s13/core/S13Core.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s13.core;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Domain(value="s13_core", includeListeners = { ListenerType.persistence })
+@Repo(Database.rep_mongodb)
+@Getter @Setter
+public class S13Core extends IdLong {
+
+	private static final long serialVersionUID = 1L;
+
+	private String attr_String;	
+	private int attr_int;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s13/view/S13SampleLineItem.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s13/view/S13SampleLineItem.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s13.view;
+
+import com.antheminc.oss.nimbus.domain.defn.MapsTo;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo.Path;
+import com.antheminc.oss.nimbus.test.scenarios.s13.core.S13Core;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@MapsTo.Type(S13Core.class)
+@Getter @Setter @ToString
+@AllArgsConstructor @NoArgsConstructor
+public class S13SampleLineItem {
+	
+	@Path
+	private String attr_String;
+	
+	@Path
+	private int attr_int;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s13/view/S13View.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s13/view/S13View.java
@@ -1,0 +1,98 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s13.view;
+
+import java.util.List;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo;
+import com.antheminc.oss.nimbus.domain.defn.Model;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Grid;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Page;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Section;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Tile;
+import com.antheminc.oss.nimbus.domain.defn.extension.ActivateConditional;
+import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
+import com.antheminc.oss.nimbus.test.scenarios.s13.core.S13Core;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Domain(value="s13_view", includeListeners = { ListenerType.websocket })
+@MapsTo.Type(S13Core.class)
+@Repo(Database.rep_none)
+@Getter @Setter
+public class S13View {
+
+	@Page
+	private VPMain page;
+	
+	@Model
+	@Getter @Setter
+	public static class VPMain {
+	
+		@Tile 
+		private VTTile tile;	
+	}
+	
+	@MapsTo.Type(S13Core.class)
+	@Getter @Setter
+	public static class VTTile {
+
+		@Section
+		private SampleFilterSection filterSection;
+		
+		@Section
+		private SampleSection1 section1;
+		
+		@Section
+		private SampleSection2 section2;
+    }
+	
+	@Model
+	@Getter @Setter
+	public static class SampleFilterSection {
+		
+		@ActivateConditional(when = "state == '1'", targetPath = "/../../section1")
+		@ActivateConditional(when = "state == '2'", targetPath = "/../../section2")
+		private String filter;
+	}
+	
+	@Model
+	@Getter @Setter
+	public static class SampleSection1 {
+		
+		@MapsTo.Path(linked = false)
+		@Config(url = "<!#this!>.m/_process?fn=_set&url=/p/s13_core/_search?fn=query&where=s13_core.attr_int.eq(42)")
+		private List<S13SampleLineItem> grid;
+	}
+	
+	@Model
+	@Getter @Setter
+	public static class SampleSection2 {
+		
+		@MapsTo.Path(linked = false)
+		private List<S13SampleLineItem> grid;
+	}
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s13/CollectionsStateRetrievalTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s13/CollectionsStateRetrievalTest.java
@@ -1,0 +1,208 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s13;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ParamUtils;
+import com.antheminc.oss.nimbus.test.scenarios.s13.view.S13SampleLineItem;
+import com.antheminc.oss.nimbus.test.scenarios.s13.view.S13View;
+import com.antheminc.oss.nimbus.test.scenarios.s13.view.S13View.VTTile;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class CollectionsStateRetrievalTest extends AbstractFrameworkIngerationPersistableTests {
+	
+	public static final String CORE_DOMAIN_ALIAS = "s13_core";
+	public static final String VIEW_DOMAIN_ALIAS = "s13_view";
+	public static final String CORE_PARAM_ROOT = PLATFORM_ROOT + "/" + CORE_DOMAIN_ALIAS;
+	public static final String VIEW_PARAM_ROOT = PLATFORM_ROOT + "/" + VIEW_DOMAIN_ALIAS;
+	
+	private Long refId;
+	private Param<S13View> rootParam;
+	
+	@SuppressWarnings("unchecked")
+	@Before
+	public void before() {
+		super.before();
+		
+		MockHttpServletRequest home_newReq = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
+		Holder<MultiOutput> home_newResp = (Holder<MultiOutput>) controller.handleGet(home_newReq, null);
+		Assert.assertNotNull(home_newResp);
+		
+		this.refId = ExtractResponseOutputUtils.extractDomainRootRefId(home_newResp);
+		this.rootParam = (Param<S13View>) home_newResp.getState().getSingleResult();
+	}
+	
+	/**
+	 * <p>This test case addresses a scenario where invoking a _get call on a param that looks like the following:
+	 * <pre>
+	 * &#64;MapsTo.Path(linked = false)
+	 * &#64;Config(url = "<!#this!>.m/_process?fn=_set&url=/p/s13_core/_search?fn=query&where=s13_core.attr_int.eq(42)")
+	 * private List<S13SampleLineItem> grid;
+	 * </pre>
+	 * and given the result of the framework call {@code /p/s13_core/_search?fn=query&where=s13_core.attr_int.eq(42)} is returning something like:
+	 * <pre>
+	 * [{
+	 *   "attr_String": "I'm the first!",
+	 *   "attr_int": 42,
+	 * }, {
+	 *   "attr_String": "I'm the second!",
+	 *   "attr_int": 42,
+	 * }]
+	 * </pre>
+	 * then the returned leafState of the collection is returning a list of elements with the last element as empty, or something
+	 * like the following:
+	 * <pre>
+	 * [{
+	 *   "attr_String": "I'm the second!",
+	 *   "attr_int": 42,
+	 * }, {
+	 * 
+	 * }]
+	 * </pre>
+	 * This test case expects that the leaf state is similar to the result of the query call, or: 
+	 * <pre>
+	 * [{
+	 *   "attr_String": "I'm the first!",
+	 *   "attr_int": 42,
+	 * }, {
+	 *   "attr_String": "I'm the second!",
+	 *   "attr_int": 42,
+	 * }]
+	 * </pre>
+	 * @see com.antheminc.oss.nimbus.test.scenarios.s13.view.S13View
+	 */
+	@Test
+	@SuppressWarnings({ "unused" })
+	public void t01() throws JsonProcessingException {
+		
+		// Build params to inspect
+		Param<VTTile> tileParam = this.rootParam.findParamByPath("/page/tile");
+		Param<List<S13SampleLineItem>> gridParam = tileParam.findParamByPath("/section1/grid");
+		
+		// Create some sample entities to add via a _new call
+		S13SampleLineItem sampleCore1 = new S13SampleLineItem("I'm the first!", 42);
+		S13SampleLineItem sampleCore2 = new S13SampleLineItem("I'm the second!", 42);
+
+		// Add sampleCore1 via _new call
+		Holder<MultiOutput> newResponse1 = this.addViaNewAction(CORE_PARAM_ROOT, sampleCore1);
+		
+		// Show section1/grid by applying activate conditional logic on field: (see S13View.SampleFilterSection#filter)
+		this.selectFilter(1);
+		
+		// Simulate the UI _get call on: section1/grid
+		Holder<MultiOutput> getSection1GridResponse1 = this.getSectionGrid(1);
+		
+		// Validate the entries in the grid are as expected
+		Assert.assertEquals(1, ((List<?>) tileParam.findParamByPath("/section1/grid").getLeafState()).size());
+		Assert.assertEquals(sampleCore1.getAttr_String(), gridParam.getLeafState().get(0).getAttr_String());
+		Assert.assertEquals(sampleCore1.getAttr_int(), gridParam.getLeafState().get(0).getAttr_int());
+		
+		// Show section2/grid by applying activate conditional logic on field: (see S13View.SampleFilterSection#filter)
+		this.selectFilter(2);
+		
+		// Simulate the UI _get call on: section2/grid
+		Holder<MultiOutput> getSectionGrid2Response1 = this.getSectionGrid(2);
+		
+		// Validate the entries in the grid are as expected
+		Assert.assertEquals(0, ((List<?>) tileParam.findParamByPath("/section2/grid").getLeafState()).size());
+		
+		// Add sampleCore2 via _new call
+		Holder<MultiOutput> newResponse2 = this.addViaNewAction(CORE_PARAM_ROOT, sampleCore2);
+		
+		// Show section1/grid by applying activate conditional logic on field: (see S13View.SampleFilterSection#filter)
+		this.selectFilter(1);
+		
+		// Simulate the UI _get call on: section1/grid
+		Holder<MultiOutput> getSection1GridResponse2 = this.getSectionGrid(1);
+		
+		// TODO Remove the following block of commented lines once the test case is passing.
+		// NOTE: Enabling the following line of code will make the test pass. (making a 2nd _get call)
+//		Holder<MultiOutput> getSection1GridResponse3 = this.getSectionGrid(1);
+		
+		// Validate the entries in the grid are as expected
+		Assert.assertEquals(2, gridParam.getLeafState().size());
+		Assert.assertEquals(sampleCore1.getAttr_String(), gridParam.getLeafState().get(0).getAttr_String());
+		Assert.assertEquals(sampleCore1.getAttr_int(), gridParam.getLeafState().get(0).getAttr_int());
+		Assert.assertEquals(sampleCore2.getAttr_String(), gridParam.getLeafState().get(1).getAttr_String());
+		Assert.assertEquals(sampleCore2.getAttr_int(), gridParam.getLeafState().get(1).getAttr_int());
+	}
+	
+	@SuppressWarnings("unchecked")
+	private Holder<MultiOutput> selectFilter(int filterNum) throws JsonProcessingException {
+		
+		ModelEvent<String> event = new ModelEvent<>();
+		event.setId("/" + VIEW_DOMAIN_ALIAS + ":" + this.refId + "/page/tile/filterSection/filter");
+		event.setType(Action._update.name());
+		event.setPayload(this.om.writeValueAsString(filterNum));
+		Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handleEventNotify(MockHttpRequestBuilder.withUri(PLATFORM_ROOT).addNested("/event/notify").getMock(), event);
+		
+		final String sectionName = "/section" + filterNum;
+		Param<?> tileParam = ParamUtils.extractResponseByParamPath(response, sectionName).findParamByPath("/..");
+		
+		// Validate the appropriate section and grid are active.
+		Assert.assertTrue(tileParam.findParamByPath(sectionName).isActive());
+		Assert.assertTrue(tileParam.findParamByPath(sectionName + "/grid").isActive());
+		
+		// Validate that the other sections are not active.
+		for (int i = 1; i<= 2; i++) {
+			if (i != filterNum) {
+				Assert.assertFalse(tileParam.findParamByPath("/section" + i).isActive());
+				Assert.assertFalse(tileParam.findParamByPath("/section" + i + "/grid").isActive());
+			}
+		}
+		
+		return response;
+	}
+	
+	@SuppressWarnings("unchecked")
+	private Holder<MultiOutput> addViaNewAction(String path, Object toCreate) throws JsonProcessingException {
+		MockHttpServletRequest newReq = MockHttpRequestBuilder.withUri(path)
+				.addAction(Action._new)
+				.getMock();
+		return (Holder<MultiOutput>) controller.handlePost(newReq, this.om.writeValueAsString(toCreate));
+	}
+	
+	@SuppressWarnings("unchecked")
+	private Holder<MultiOutput> getSectionGrid(int filterNum) throws JsonProcessingException {
+		MockHttpServletRequest getSectionGridRequest = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT)
+				.addRefId(this.refId)
+				.addNested("/page/tile/section" + filterNum + "/grid")
+				.addAction(Action._get)
+				.getMock();
+		return (Holder<MultiOutput>) controller.handlePost(getSectionGridRequest, null);
+	}
+}


### PR DESCRIPTION
# Description

Fixed an isolated issue where a core param's (collection) instantiation was not correctly updating the associated view param's leaf state.

See more details in **Additional Notes** below.

## Overview of Changes
- Added test case for bug.
- Added fix.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] CollectionsStateRetrievalTest#t01()
- [ ] Validated this fix against the scenario described in the cm-product application.

# Additional Notes
This addresses NIM-17467, a bug where invoking a `_get` call on a param that looks like the following:

```java
 @MapsTo.Path(linked = false)
 @Config(url = ".m/_process?fn=_set&url=/p/s13_core/_search?fn=query&where=s13_core.attr_int.eq(42)")
 private List grid;
 ```

and given the result of the framework call `/p/s13_core/_search?fn=query&where=s13_core.attr_int.eq(42)` is returning something like:
```json
 [{
   "attr_String": "I'm the first!",
   "attr_int": 42,
 }, {
   "attr_String": "I'm the second!",
   "attr_int": 42,
 }]
 ```

then the returned leafState of the collection was returning a list of elements with the last element as empty:
```json
 [{
   "attr_String": "I'm the second!",
   "attr_int": 42,
 }, {
 
 }]
 ```

After this fix, the following expected result is delivered:
```json
 [{
   "attr_String": "I'm the first!",
   "attr_int": 42,
 }, {
   "attr_String": "I'm the second!",
   "attr_int": 42,
 }]
```