### PR TITLE
Table/Grid Updates

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -1034,6 +1034,12 @@ public class ViewConfig {
 
 		String cssClass() default "";
 
+		/**
+		 * <p>As of release 1.1.7, {@code dataKey} is no longer needed to
+		 * support grid row expansion. This attribute will be removed in the
+		 * future releases.
+		 */
+		@Deprecated
 		String dataKey() default "id";
 
 		boolean expandableRows() default false;

--- a/nimbus-ui/nimbusui/src/app/app.module.ts
+++ b/nimbus-ui/nimbusui/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { ToastModule } from 'primeng/toast';
 import { LayoutService } from './services/layout.service';
 import { ContentContainer } from './components/platform/content/content-container.component';
 import { BaseElement } from './components/platform/base-element.component';
+import { BaseTableElement } from './components/platform/base-table-element.component';
 import { AppComponent }  from './app.component';
 import { Tile }  from './components/platform/tile.component';
 import { Section } from './components/platform/section.component';
@@ -207,7 +208,7 @@ export function init_app(appinitservice: AppInitService) {
     ],
     declarations: [ AppComponent, STOMPStatusComponent, FlowWrapper, PageContent, PageNotfoundComponent, StaticText,
         Tile, Section, Header, Form, FormElement, InputText, ComboBox, RadioButton, Signature, DateControl, CheckBoxGroup,
-        InPlaceEditorComponent, Paragraph, Value, BaseElement, FormGridFiller, 
+        InPlaceEditorComponent, Paragraph, Value, BaseElement, BaseTableElement, FormGridFiller, 
         MultiselectCard, Link, Menu, CardDetailsComponent, CardDetailsFieldGroupComponent, CardDetailsFieldComponent, CardDetailsGrid, FieldValue,
         Accordion, AccordionTab, FrmGroupCmp, Button, ButtonGroup, FilterButton, OrderablePickList,
         STOMPStatusComponent, InfiniteScrollGrid, DataTable, SubHeaderCmp, TextArea, LandingPage,

--- a/nimbus-ui/nimbusui/src/app/components/platform/base-table-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/base-table-element.component.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2016-2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { ActionDropdown } from './form/elements/action-dropdown.component';
+import { fromEvent as observableFromEvent, Subscription } from 'rxjs';
+import { first, filter } from 'rxjs/operators';
+import { Component, ViewChildren, QueryList, ChangeDetectorRef } from '@angular/core';
+import { WebContentSvc } from './../../services/content-management.service';
+import { BaseElement } from './base-element.component';
+
+/**
+ * \@author Tony Lopez
+ * \@whatItDoes A base element for components that use an underling table structure
+ */
+@Component({
+    selector: 'nm-base-table-element',
+    providers: [ WebContentSvc ],
+    template: ``
+})
+export class BaseTableElement extends BaseElement {
+
+    @ViewChildren('dropDown') dropDowns: QueryList<any>;
+    mouseEventSubscription: Subscription;
+
+    constructor(
+        protected _wcs: WebContentSvc, 
+        protected cd: ChangeDetectorRef) {
+            super(_wcs);
+    }
+
+    toggleOpen(e: any) {
+
+        let selectedDropDownIsOpen = e.isOpen;
+        let selectedDropDownState = e.state;
+
+        if (this.dropDowns)
+            this.dropDowns.toArray().forEach((item) => {
+                if (!item.selectedItem) {
+                    item.isOpen = false;
+                    item.state = 'closedPanel';
+                }
+            });
+
+        e.isOpen = !selectedDropDownIsOpen;
+
+        if (selectedDropDownState == 'openPanel') {
+            e.state = 'closedPanel';
+            if (!this.mouseEventSubscription.closed)
+                this.mouseEventSubscription.unsubscribe();
+        }
+        else {
+            e.state = 'openPanel';
+            if (this.dropDowns && (this.mouseEventSubscription == undefined || this.mouseEventSubscription.closed))
+                this.mouseEventSubscription =
+                    observableFromEvent(document, 'click').pipe(filter((event: any) =>
+                        !this.isClickedOnDropDown(this.dropDowns.toArray(), event.target)),first()).subscribe(() => {
+                            this.dropDowns.toArray().forEach((item) => {
+                                item.isOpen = false;
+                                item.state = 'closedPanel';
+                            });
+                            this.cd.detectChanges();
+                        });
+        }
+        e.selectedItem = false;
+        this.cd.detectChanges();
+    }
+
+    isClickedOnDropDown(dropDownArray: Array<ActionDropdown>, target: any) {
+
+        for (var i = 0; i < dropDownArray.length; i++) {
+            if (dropDownArray[i].elementRef.nativeElement.contains(target))
+                return true;
+        }
+        return false;
+
+    }
+
+}

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-builder.service.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-builder.service.ts
@@ -1,4 +1,3 @@
-import { ParamUtils } from './../../shared/param-utils';
 /**
  * @license
  * Copyright 2016-2018 the original author or authors.
@@ -20,9 +19,10 @@ import { Injectable } from '@angular/core';
 import { FormGroup, FormBuilder, Validators, ValidatorFn, FormControl } from '@angular/forms';
 
 import { CustomValidators } from './validators/custom.validators';
-import { Param } from '../../shared/param-state';
+import { Param, CollectionParam } from '../../shared/param-state';
 import { ValidationUtils } from './validators/ValidationUtils';
 import { ViewComponent } from '../../shared/param-annotations.enum';
+import { ParamUtils } from './../../shared/param-utils';
 
 /**
  * \@author Dinakar.Meda
@@ -109,8 +109,8 @@ export class FormElementsService {
     var leafState;
     if (ParamUtils.isKnownDateType(param.config.type.name)) {
       leafState = param.leafState || null;
-    } else if(param.alias === 'Grid' && param.gridData.leafState && param.gridData.leafState.length > 0) {
-        leafState = param.gridData.leafState;
+    } else if(param instanceof CollectionParam && param.alias === 'Grid' && param.gridData.leafState && param.gridData.leafState.length > 0) {
+      leafState = param.gridData.leafState;
     } else {
       leafState = param.leafState || '';
     }

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/input-label.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/input-label.component.ts
@@ -30,14 +30,13 @@ import { BaseLabel } from '../../base-label.component';
 @Component({
   selector: 'nm-input-label',
   template: `
-    <label
+    <label *ngIf="label"
         [className]="getCssClass()"
         [attr.for]="for">
         
         {{label}} 
-        
-        <nm-tooltip *ngIf="helpText" [helpText]='helpText'></nm-tooltip>
     </label>
+    <nm-tooltip *ngIf="helpText" [helpText]='helpText'></nm-tooltip>
    `
 })
 export class InputLabel extends BaseLabel {

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/grid.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/grid.component.html
@@ -98,7 +98,7 @@
 		</ng-template>
 
 		<ng-template let-row pTemplate="rowexpansion">
-			<nm-section [element]="row.nestedElement"></nm-section>	
+			<nm-section [element]="row.$nestedElement"></nm-section>	
 		</ng-template> 
 		
 		<p-footer>

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
@@ -4,6 +4,7 @@
             <caption>{{label}}</caption>
             <nm-tooltip *ngIf="helpText" [helpText]='helpText'></nm-tooltip>
         </p-header>
+        
         <div class="recordsDisplayed">Showing {{rowStart}}-{{rowEnd}} of {{totalRecords}}
             <button *ngIf="element.config?.uiStyles?.attributes?.clearAllFilters" class="btn-plain ml-2" (click)="clearAll()">
                 <i class="fa fa-fw fa-times hidden-md-down" aria-hidden="true"></i>Clear Grid Filters</button>
@@ -16,7 +17,7 @@
     </div>
 
     <p-table #dt [value]="value" [columns]="params" 
-        [dataKey]="element.config?.uiStyles?.attributes?.dataKey"
+        [dataKey]="'$elemId'"
         [(selection)]="selectedRows"
         [rows]="element.config?.uiStyles?.attributes?.pageSize"
         [totalRecords]=totalRecords
@@ -98,25 +99,25 @@
                 <ng-template ngFor let-col let-colIndex="index" [ngForOf]="params">
                     <td *ngIf="showColumn(col)" [ngClass]="getColumnStyle(col)">
                         <span title="{{getCellDisplayValue(rowData, col)}}" *ngIf="showValue(col)" [nmDisplayValue]='getCellDisplayValue(rowData, col)' [config]='col'>
-                            <span class="fieldValue {{col.code}} {{getCellStyle(rowData.elemId, col.code)}}">{{getCellDisplayValue(rowData, col)}}</span>
+                            <span class="fieldValue {{col.code}} {{getCellStyle(rowData.$elemId, col.code)}}">{{getCellDisplayValue(rowData, col)}}</span>
                         </span>
                         <span *ngIf="col?.uiStyles?.attributes?.alias == viewComponent.link.toString()">
                             <nm-link
-                                [element] = "getViewParam(col, rowData['elemId'])">
+                                [element] = "getViewParam(col, rowData['$elemId'])">
                             </nm-link>
                         </span>
                         <span *ngIf="col?.uiStyles?.attributes?.alias == viewComponent.gridcolumn.toString() && col?.uiStyles?.attributes?.showAsLink === true">
                             <nm-link
-                                [element] = "getViewParam(col, rowData['elemId'])">
+                                [element] = "getViewParam(col, rowData['$elemId'])">
                             </nm-link>
                         </span>
                         <span *ngIf="col?.uiStyles?.attributes?.alias == viewComponent.button.toString()">
                             <nm-button
-                                [element] = "getViewParam(col, rowData['elemId'])">
+                                [element] = "getViewParam(col, rowData['$elemId'])">
                             </nm-button>
                         </span>
                         <span *ngIf="col?.uiStyles?.attributes?.alias == viewComponent.linkMenu.toString()">
-                            <nm-action-dropdown #dropDown [element]="getViewParam(col, rowData['elemId'])" 
+                            <nm-action-dropdown #dropDown [element]="getViewParam(col, rowData['$elemId'])" 
                                 [params]="col?.type?.model?.paramConfigs" 
                                 [rowData]="rowData" 
                                 [elementPath]="getRowPath(col, rowData)" 
@@ -131,7 +132,7 @@
         <ng-template pTemplate="rowexpansion" let-rowData>
             <tr class="ui-expanded-row-content">
                 <td [attr.colspan]="columnsToShow" >
-                    <nm-section *ngIf="rowData.nestedElement" [position]="position+1" [element]="rowData.nestedElement"></nm-section>
+                    <nm-section *ngIf="rowData.$nestedElement" [position]="position+1" [element]="rowData.$nestedElement"></nm-section>
                 </td>
             </tr>
         </ng-template>

--- a/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.html
@@ -1,16 +1,17 @@
 <ng-template [ngIf]="type == componentTypes.dialog.toString()">
-    <p-dialog [(visible)]="display" 
-    [closable]="closable"
-    [closeOnEscape]="false" 
-    [modal]="true" 
-    [width]="width" 
-    (visibleChange)="closeDialog($event)"
-    appendTo="body" 
-    [responsive]="true" 
-    [blockScroll]="true">
-        <p-header *ngIf="label">
-            {{label}}
-            <nm-tooltip *ngIf="helpText" [helpText]='helpText'></nm-tooltip>
+    <p-dialog 
+        [(visible)]="display" 
+        [closable]="closable"
+        [closeOnEscape]="false" 
+        [modal]="true" 
+        [width]="width" 
+        (visibleChange)="closeDialog($event)"
+        appendTo="body" 
+        [responsive]="true" 
+        [blockScroll]="true">
+        
+        <p-header>
+            <nm-input-label [element]="element"></nm-input-label>
         </p-header>
         <ng-template ngFor let-element [ngForOf]="nestedParams">
             <ng-template [ngIf]="element.alias == viewComponent.section.toString()">

--- a/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.ts
@@ -16,12 +16,10 @@
  */
 'use strict';
 
-import { Component, ElementRef, Input, OnInit, OnDestroy } from '@angular/core';
-import { Param, Model } from '../../../shared/param-state';
-import { DialogModule } from 'primeng/primeng';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { WebContentSvc } from './../../../services/content-management.service';
 import { PageService } from '../../../services/page.service';
-import { Action, HttpMethod, Behavior} from './../../../shared/command.enum';
+import { HttpMethod, Behavior} from './../../../shared/command.enum';
 import { GenericDomain } from '../../../model/generic-domain.model';
 import { BaseElement } from '../base-element.component';
 import { ViewComponent, ComponentTypes } from '../../../shared/param-annotations.enum';
@@ -48,16 +46,17 @@ import { ViewComponent, ComponentTypes } from '../../../shared/param-annotations
     ]
 })
 export class Modal extends BaseElement implements OnInit, OnDestroy {
-    // width of modal window
-    public _width: string;
-    // closable to indicate whether modal window can be closed
-    public _closable: boolean;
+
     display: boolean = false;
-    private _resizable: boolean;
-    private elementCss: string;
     viewComponent = ViewComponent;
     componentTypes = ComponentTypes;
     
+    readonly modalSize: { [id: string]: IModalSize } = {
+        SMALL: { width: '500' },
+        MEDIUM: { width: '700' },
+        LARGE: { width: '900' }
+    };
+
     constructor(private wcsvc: WebContentSvc, private pageSvc: PageService) {
         super(wcsvc);
     }
@@ -85,17 +84,11 @@ export class Modal extends BaseElement implements OnInit, OnDestroy {
      */
     public get width(): string {
         let myWidth = this.element.config.uiStyles.attributes.width;
-
-        if(myWidth === 'small') {
-            return '500';
-        }else if(myWidth === 'medium') {
-            return '700';
-        }else if(myWidth === 'large') {
-            return '900';
-        }else {
-            return myWidth;
+        if (!myWidth) {
+            return undefined;
         }
-        
+        let modalSize = this.modalSize[myWidth.toUpperCase()];
+        return modalSize ? modalSize.width : myWidth;
     }
 
     /**
@@ -113,3 +106,7 @@ export class Modal extends BaseElement implements OnInit, OnDestroy {
         return this.element.config.uiStyles.attributes.resizable;
     }
 }
+
+export interface IModalSize {
+    width: string;
+};

--- a/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.html
@@ -36,8 +36,16 @@
                     <td *ngIf="isRenderableComponent(col)" [ngClass]="gridUtils.getColumnStyle(col)">
 
                         <nm-button *ngIf="viewComponent.button.toString() === col.uiStyles.attributes.alias"
-                            [element]="getViewParam(col, rowNode)">
+                            [element] = "getViewParam(col, rowNode)">
                         </nm-button>
+
+                        <nm-action-dropdown #dropDown *ngIf="viewComponent.linkMenu.toString() === col.uiStyles.attributes.alias"
+                            [element]="getViewParam(col, rowNode)"
+                            [params]="col?.type?.model?.paramConfigs" 
+                            [rowData]="rowData" 
+                            [elementPath]="getRowPath(col, rowNode)" 
+                            (dropDownClick)="toggleOpen($event)">
+                        </nm-action-dropdown>
                     </td>
                 </ng-template>
             </ng-template>

--- a/nimbus-ui/nimbusui/src/app/shared/grid-utils.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/grid-utils.ts
@@ -16,7 +16,7 @@
  */
 'use strict';
 
-import {Injectable} from "@angular/core";
+import { Injectable } from "@angular/core";
 import { ParamConfig } from './param-config';
 import { DateTimeFormatPipe } from '../pipes/date.pipe';
 import { ViewComponent} from './param-annotations.enum';
@@ -72,4 +72,5 @@ import { ParamUtils } from './param-utils';
     isDate(dataType: string): boolean {
         return ParamUtils.isKnownDateType(dataType);
     }
+
  }

--- a/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
@@ -16,12 +16,9 @@
  */
 'use strict';
 
-import { ConfigService } from './../services/config.service';
-import { SortAs } from '../components/platform/grid/sortas.interface';
-import { PageService } from '../services/page.service';
-import { GridService } from '../services/grid.service';
 import { ServiceConstants } from '../services/service.constants';
 import { Param } from './param-state';
+
 /**
  * \@author Tony.Lopez
  * \@whatItDoes 
@@ -136,6 +133,7 @@ export class ParamUtils {
      * 
      * <pre>
      * {
+     *      "elemId": "0",
      *      "id": "1",
      *      "startDate": "2018-03-29T00:00:00.000Z",
      *      "additionalInformation": {
@@ -146,6 +144,7 @@ export class ParamUtils {
      * becomes:
      * 
      * {
+     *      "$elemId": "0",
      *      "id": "1",
      *      "startDate": Thu Mar 29 2018 00:00:00 GMT-0400 (EST) {},
      *      "additionalInformation": {
@@ -164,7 +163,7 @@ export class ParamUtils {
 
         // Check for collectionElement and add elementId to leafstate 
         if (relativeParam && relativeParam.collectionElem) { 
-            transformed['elemId'] = relativeParam.elemId; 
+            transformed['$elemId'] = relativeParam['elemId']; 
         }
 
         // iterate over each of the properties of the object.
@@ -174,9 +173,8 @@ export class ParamUtils {
             let x_param = ParamUtils.findParamByPath(relativeParam, x);
 
             // Check for collectionElement and add elementId to leafstate 
-            if (x_param && x_param.collectionElem) { 
-                if(transformed[x] instanceof Object)
-                    transformed[x]['elemId'] = x_param.elemId; 
+            if (x_param && x_param.collectionElem && transformed[x] instanceof Object) { 
+                transformed[x]['$elemId'] = x_param['elemId'];
             }
 
             if (x_param ) {


### PR DESCRIPTION
# Description

Under the hood refactor for table/treegrid/grid support and minor bugfixes.

## Overview of Changes
- Efficiency updates for `@Grid` and `@TreeGrid` Angular components
  - Created `BaseTableElement` to contain common code used between table related components
  - Created `CollectionParam` and `CollectionElementParam` with extrapolated logic from `Param`
   - Moved grid related data to its own encapsulated object (`GridData`)
    - Modified `leafState` data within `CollectionParam` is now prefixed with `$`
      - `elemId` has been changed to `$elemId`
      - `nestedGridParam` has been changed to `$nestedGridParam`
- The `dataKey` attribute of `@Grid` has been deprecated
  - The PrimeNG components now use the `$elemId` value instead of a default`id` or a configured `dataKey` to expand `@GridRowBody` content within a collection element
- `@TreeGrid` and `@TreeGridChild` now support the `@LinkMenu` component
- Fixed an issue where `@LabelConditional` was not working for `@Modal` components.

## Type of change

- [ ] Refactor
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Functional Testing using Petclinic

# Additional Notes

N/A
