### PR TITLE
Label Support for Persisted Codes from @Values

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 import com.antheminc.oss.nimbus.domain.Event;
 import com.antheminc.oss.nimbus.domain.defn.event.StateEvent.OnStateLoad;
 import com.antheminc.oss.nimbus.domain.defn.extension.ParamContext;
-
+import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -761,6 +761,9 @@ public class ViewConfig {
 	}
 
 	/**
+	 * <p>FieldValue is used to display the state of the decorated parameter as
+	 * text.
+	 * 
 	 * <p><b>Expected Field Structure</b>
 	 * 
 	 * <p>FieldValue will be rendered when annotating a field nested under one
@@ -768,6 +771,13 @@ public class ViewConfig {
 	 * <li>{@link CardDetailBody}</li> <li>{@link FieldValueGroup}</li> </ul>
 	 * 
 	 * <p>FieldValue should decorate a field having a simple type.
+	 * 
+	 * <p><b>Other Notes</b>
+	 * 
+	 * <p>When used with {@link Values}, the rendered component will attempt to
+	 * display a label from {@link Values.Source#getValues(String)}, whose code
+	 * is matching to the state of the param for the decorated field. If no
+	 * match is found, the default display value will be applied.
 	 * 
 	 * @since 1.0
 	 */
@@ -817,8 +827,9 @@ public class ViewConfig {
 		String cols() default "4";
 
 		/**
-		 * <p>CSS classes added here will be added to a container element surrounding this component.
-		 * <p>This can be used to apply additional styling, if necessary.
+		 * <p>CSS classes added here will be added to a container element
+		 * surrounding this component. <p>This can be used to apply additional
+		 * styling, if necessary.
 		 */
 		String cssClass() default "";
 
@@ -1240,6 +1251,9 @@ public class ViewConfig {
 	}
 
 	/**
+	 * <p>GridColumn is used to display the state of the decorated parameter as
+	 * text when used within a {@link Grid} component.
+	 * 
 	 * <p><b>Expected Field Structure</b>
 	 * 
 	 * <p>GridColumn will be rendered when annotating a field within a
@@ -1247,6 +1261,12 @@ public class ViewConfig {
 	 * GridColumn should decorate a simple type.
 	 * 
 	 * <p>GridColumn should decorate a field having a simple type.
+	 * 
+	 * <p><b>Other Notes</b>
+	 * <p>When used with {@link Values}, the rendered component will attempt to
+	 * display a label from {@link Values.Source#getValues(String)}, whose code
+	 * is matching to the state of the param for the decorated field. If no
+	 * match is found, the default display value will be applied.
 	 * 
 	 * @since 1.0
 	 * @see com.antheminc.oss.nimbus.domain.defn.Grid

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/utils/ConfigTestUtils.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/utils/ConfigTestUtils.java
@@ -1,0 +1,108 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.domain.support.utils;
+
+import java.lang.annotation.Annotation;
+
+import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values;
+import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.Source;
+import com.antheminc.oss.nimbus.domain.defn.extension.ValuesConditional;
+import com.antheminc.oss.nimbus.domain.defn.extension.ValuesConditional.Condition;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class ConfigTestUtils {
+
+	public static Values createValues(Class<? extends Source> value, String url) {
+		return new Values() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return Values.class;
+			}
+
+			@Override
+			public Class<? extends Source> value() {
+				return value;
+			}
+
+			@Override
+			public String url() {
+				return url;
+			}
+			
+		};
+	}
+	
+	public static ValuesConditional.Condition createValuesConditionalCondition(String when, Values then) {
+		return new Condition() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return Condition.class;
+			}
+
+			@Override
+			public Values then() {
+				return then;
+			}
+
+			@Override
+			public String when() {
+				return when;
+			}
+			
+		};
+	}
+	
+	public static ValuesConditional createValuesConditional(Condition[] condition, boolean exclusive, int order, boolean resetOnChange, String targetPath) {
+		return new ValuesConditional() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return ValuesConditional.class;
+			}
+
+			@Override
+			public Condition[] condition() {
+				return condition;
+			}
+
+			@Override
+			public boolean exclusive() {
+				return exclusive;
+			}
+
+			@Override
+			public int order() {
+				return order;
+			}
+
+			@Override
+			public boolean resetOnChange() {
+				return resetOnChange;
+			}
+
+			@Override
+			public String targetPath() {
+				return targetPath;
+			}
+			
+		};
+	}
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageValues.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageValues.java
@@ -1,0 +1,68 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s0.view;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.antheminc.oss.nimbus.domain.defn.Model;
+import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values;
+import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.Source;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.ComboBox;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Section;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Tile;
+import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Model
+@Getter @Setter
+public class VPSampleViewPageValues {
+
+	@Tile
+	private VT vt;
+	
+	@Model
+	@Getter @Setter
+	public static class VT {
+		
+		@Section
+		private VS vs;
+	}
+	
+	@Model
+	@Getter @Setter
+	public static class VS {
+		
+		@ComboBox
+		@Values(SampleValues1.class)
+		private String comboboxSingleValues;
+	}
+	
+	public static class SampleValues1 implements Source {
+		@Override
+		public List<ParamValue> getValues(String paramCode) {
+			List<ParamValue> values = new ArrayList<>();
+			values.add(new ParamValue("PVA1", "PVA1"));
+			return values;
+		}
+	}
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
@@ -55,6 +55,9 @@ public class VRSampleViewRootEntity {
 	@Page(route="sample_view_colors")
 	private VPSampleViewPageAqua page_aqua;
 	
+	@Page
+	private VPSampleViewPageValues page_values;
+	
 	@Path
 	private List<SampleCoreNestedEntity> attr_list_1_NestedEntity;
 	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandlerTest.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
+import com.antheminc.oss.nimbus.domain.model.state.AbstractStateEventHandlerTests;
+import com.antheminc.oss.nimbus.test.scenarios.s0.view.VPSampleViewPageValues.SampleValues1;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class DefaultParamValuesHandlerTest extends AbstractStateEventHandlerTests {
+
+	@Override
+	protected Command createCommand() {
+		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
+		return cmd;
+	}
+
+	@Test
+	public void testBuildValuesFromValueAttributeSingle() {
+		List<ParamValue> actual = _q.getView().findParamByPath("/page_values/vt/vs/comboboxSingleValues").getValues();
+		Assert.assertEquals(new SampleValues1().getValues(null), actual);
+	}
+	
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
@@ -15,7 +15,6 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,6 +40,7 @@ import com.antheminc.oss.nimbus.domain.model.state.StateHolder.ParamStateHolder;
 import com.antheminc.oss.nimbus.support.expr.ExpressionEvaluator;
 import com.antheminc.oss.nimbus.test.domain.mock.MockParam;
 import com.antheminc.oss.nimbus.test.domain.mock.MockParamConfig;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ConfigTestUtils;
 
 /**
  * 
@@ -99,8 +99,8 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t1_useDefault_handleResetOnChange() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
-		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final Values defaultValues = ConfigTestUtils.createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
@@ -123,7 +123,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t2_useDefault_handleDontResetOnChange_noDefaultValues() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
 		
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -144,8 +144,8 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t3_useDefault_handleDontResetOnChange_stateIsAlreadyNull() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
-		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final Values defaultValues = ConfigTestUtils.createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
@@ -169,8 +169,8 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t4_useDefault_handleDontResetOnChange_previousStateNotFoundInNewValues() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
-		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final Values defaultValues = ConfigTestUtils.createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
@@ -194,8 +194,8 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t5_useDefault_handleDontResetOnChange_preservePreviousState() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
-		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final Values defaultValues = ConfigTestUtils.createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
@@ -219,10 +219,10 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t6_exclusive_handleResetOnChange() {
-		final Condition condition1 = createCondition("condition1expr", createValues(SAMPLE_VALUES.class, null));
-		final Condition condition2 = createCondition("condition2expr", createValues(SAMPLE_VALUES.class, null));
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1, condition2 }, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
-		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
+		final Condition condition1 = ConfigTestUtils.createValuesConditionalCondition("condition1expr", ConfigTestUtils.createValues(SAMPLE_VALUES.class, null));
+		final Condition condition2 = ConfigTestUtils.createValuesConditionalCondition("condition2expr", ConfigTestUtils.createValues(SAMPLE_VALUES.class, null));
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{ condition1, condition2 }, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final Values defaultValues = ConfigTestUtils.createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
@@ -247,11 +247,11 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t7_nonExclusive_handleResetOnChange() {
-		final Condition condition1 = createCondition("condition1expr", createValues(SAMPLE_VALUES.class, null));
-		final Condition condition2 = createCondition("condition2expr", createValues(SAMPLE_VALUES.class, null));
-		final Condition condition3 = createCondition("condition3expr", createValues(SAMPLE_VALUES.class, null));
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1, condition2, condition3 }, false, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
-		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
+		final Condition condition1 = ConfigTestUtils.createValuesConditionalCondition("condition1expr", ConfigTestUtils.createValues(SAMPLE_VALUES.class, null));
+		final Condition condition2 = ConfigTestUtils.createValuesConditionalCondition("condition2expr", ConfigTestUtils.createValues(SAMPLE_VALUES.class, null));
+		final Condition condition3 = ConfigTestUtils.createValuesConditionalCondition("condition3expr", ConfigTestUtils.createValues(SAMPLE_VALUES.class, null));
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{ condition1, condition2, condition3 }, false, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final Values defaultValues = ConfigTestUtils.createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
@@ -278,9 +278,9 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t8_useDefault_targetParamDisabled() {
-		final Condition condition1 = createCondition("condition1expr", createValues(SAMPLE_VALUES.class, null));
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1 }, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
-		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
+		final Condition condition1 = ConfigTestUtils.createValuesConditionalCondition("condition1expr", ConfigTestUtils.createValues(SAMPLE_VALUES.class, null));
+		final ValuesConditional configuredAnnotation = ConfigTestUtils.createValuesConditional(new Condition[]{ condition1 }, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final Values defaultValues = ConfigTestUtils.createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
 		final MockParam targetParam = new MockParam();
@@ -304,83 +304,5 @@ public class ValuesConditionalStateEventHandlerTest {
 		Assert.assertEquals(expectedValues, targetParam.getValues());
 		// Validate state is preserved
 		Assert.assertEquals("bar", targetParam.getLeafState());
-	}
-	
-	private Condition createCondition(String when, Values then) {
-		return new Condition() {
-
-			@Override
-			public Class<? extends Annotation> annotationType() {
-				return Condition.class;
-			}
-
-			@Override
-			public Values then() {
-				return then;
-			}
-
-			@Override
-			public String when() {
-				return when;
-			}
-			
-		};
-	}
-	
-	private Values createValues(Class<? extends Source> value, String url) {
-		return new Values() {
-
-			@Override
-			public Class<? extends Annotation> annotationType() {
-				return Values.class;
-			}
-
-			@Override
-			public Class<? extends Source> value() {
-				return value;
-			}
-
-			@Override
-			public String url() {
-				return url;
-			}
-			
-		};
-	}
-	
-	private ValuesConditional createValuesConditional(Condition[] condition, boolean exclusive, int order, boolean resetOnChange, String targetPath) {
-		return new ValuesConditional() {
-
-			@Override
-			public Class<? extends Annotation> annotationType() {
-				return ValuesConditional.class;
-			}
-
-			@Override
-			public Condition[] condition() {
-				return condition;
-			}
-
-			@Override
-			public boolean exclusive() {
-				return exclusive;
-			}
-
-			@Override
-			public int order() {
-				return order;
-			}
-
-			@Override
-			public boolean resetOnChange() {
-				return resetOnChange;
-			}
-
-			@Override
-			public String targetPath() {
-				return targetPath;
-			}
-			
-		};
 	}
 }

--- a/nimbus-ui/nimbusui/src/app/app.module.ts
+++ b/nimbus-ui/nimbusui/src/app/app.module.ts
@@ -41,7 +41,7 @@ import { APP_BASE_HREF } from '@angular/common';
 import { MessagesModule } from 'primeng/messages';
 import { MessageModule } from 'primeng/message';
 import { DataTableModule, SharedModule, OverlayPanelModule, PickListModule, DragDropModule, CalendarModule, 
-    FileUpload, FileUploadModule, ListboxModule, DialogModule, CheckboxModule, DropdownModule, RadioButtonModule, 
+    FileUploadModule, ListboxModule, DialogModule, CheckboxModule, DropdownModule, RadioButtonModule, 
     ProgressBarModule, ProgressSpinnerModule, AccordionModule, GrowlModule, InputSwitchModule, TreeTableModule } from 'primeng/primeng';
 import { TableModule } from 'primeng/table';
 import { KeyFilterModule } from 'primeng/keyfilter';
@@ -145,8 +145,7 @@ import { LinkPipe } from './pipes/link.pipe';
 import { SelectItemPipe } from './pipes/select-item.pipe';
 import { LoaderComponent } from './components/platform/loader/loader.component';
 import { SubDomainFlowCmp } from './components/domain/subdomain-flow.component';
-import { PageResolver } from './components/platform/content/page-resolver.service';
-import {DateTimeFormatPipe} from './pipes/date.pipe';
+import { DateTimeFormatPipe } from './pipes/date.pipe';
 import { ValueStylesDirective } from './directives/value-styles.directive';
 import { NmPanelMenu, NmPanelMenuSub } from './components/platform/panelmenu.component';
 import { MenuRouteLink } from './directives/routes/route-link.component';
@@ -154,6 +153,7 @@ import { MenuRouterLinkActive } from './directives/routes/route-active.component
 import { InputSwitch } from './components/platform/form/elements/input-switch.component';
 import { InputLegend } from './components/platform/form/elements/input-legend.component';
 import { FormErrorMessage } from './components/platform/form-error-message.component';
+import { DisplayValue } from './directives/display-value';
 /**
  * \@author Dinakar.Meda
  * \@author Sandeep.Mantha
@@ -215,7 +215,7 @@ export function init_app(appinitservice: AppInitService) {
         DomainFlowCmp, HeaderGlobal, FooterGlobal,
         BreadcrumbComponent, NavLinkRouter,
         Modal, ActionDropdown, ActionLink,
-        GridMouseEventDirective, ValueStylesDirective, PrintDirective,
+        GridMouseEventDirective, ValueStylesDirective, PrintDirective, DisplayValue,
         HomeLayoutCmp, LoginCmp, LoginLayoutCmp, StyleGuideCmp, 
         KeysPipe, LinkPipe, DateTimeFormatPipe, SelectItemPipe, MultiSelectListBox, 
         CheckBox, FileUploadComponent, BreadcrumbComponent, TooltipComponent, Calendar, LoaderComponent, MessageComponent,

--- a/nimbus-ui/nimbusui/src/app/app.module.ts
+++ b/nimbus-ui/nimbusui/src/app/app.module.ts
@@ -147,7 +147,7 @@ import { LoaderComponent } from './components/platform/loader/loader.component';
 import { SubDomainFlowCmp } from './components/domain/subdomain-flow.component';
 import { PageResolver } from './components/platform/content/page-resolver.service';
 import {DateTimeFormatPipe} from './pipes/date.pipe';
-import { DisplayValueDirective } from './directives/display-value.directive';
+import { ValueStylesDirective } from './directives/value-styles.directive';
 import { NmPanelMenu, NmPanelMenuSub } from './components/platform/panelmenu.component';
 import { MenuRouteLink } from './directives/routes/route-link.component';
 import { MenuRouterLinkActive } from './directives/routes/route-active.component';
@@ -215,7 +215,7 @@ export function init_app(appinitservice: AppInitService) {
         DomainFlowCmp, HeaderGlobal, FooterGlobal,
         BreadcrumbComponent, NavLinkRouter,
         Modal, ActionDropdown, ActionLink,
-        GridMouseEventDirective, DisplayValueDirective, PrintDirective,
+        GridMouseEventDirective, ValueStylesDirective, PrintDirective,
         HomeLayoutCmp, LoginCmp, LoginLayoutCmp, StyleGuideCmp, 
         KeysPipe, LinkPipe, DateTimeFormatPipe, SelectItemPipe, MultiSelectListBox, 
         CheckBox, FileUploadComponent, BreadcrumbComponent, TooltipComponent, Calendar, LoaderComponent, MessageComponent,

--- a/nimbus-ui/nimbusui/src/app/components/domain/domain-flow.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/domain/domain-flow.component.spec.ts
@@ -63,7 +63,7 @@ import { TreeGrid } from '../platform/tree-grid/tree-grid.component';
 import { InputText } from '../platform/form/elements/textbox.component';
 import { InPlaceEditorComponent } from '../platform/form/elements/inplace-editor.component';
 import { TextArea } from '../platform/form/elements/textarea.component';
-import { DisplayValueDirective } from '../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../directives/value-styles.directive';
 import { FormGridFiller } from '../platform/form/form-grid-filler.component';
 import { Header } from '../platform/content/header.component';
 import { Signature } from '../platform/form/elements/signature.component';
@@ -275,7 +275,7 @@ describe('DomainFlowCmp', () => {
           InputText,
           InPlaceEditorComponent,
           TextArea,
-          DisplayValueDirective,
+          ValueStylesDirective,
           ActionLink,
           FormGridFiller,
           Header,
@@ -449,7 +449,7 @@ describe('DomainFlowCmp', () => {
             InputText,
             InPlaceEditorComponent,
             TextArea,
-            DisplayValueDirective,
+            ValueStylesDirective,
             ActionLink,
             FormGridFiller,
             Header,

--- a/nimbus-ui/nimbusui/src/app/components/platform/base-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/base-element.component.ts
@@ -213,10 +213,7 @@ export class BaseElement {
     }
 
     public get placeholder(): string {
-        if (this.element && this.element.config && this.element.config.uiStyles && this.element.config.uiStyles.attributes) {
-            return this.element.config.uiStyles.attributes.placeholder;
-        }
-        return undefined;
+        return ParamUtils.getPlaceholder(this.element);
     }
 
     updatePosition() {

--- a/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field-group.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field-group.component.spec.ts
@@ -14,7 +14,7 @@ import { DateTimeFormatPipe } from '../../../pipes/date.pipe';
 import { TooltipComponent } from '../tooltip/tooltip.component';
 import { SelectItemPipe } from '../../../pipes/select-item.pipe';
 import { CustomHttpClient } from '../../../services/httpclient.service';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { InputLabel } from '../../platform/form/elements/input-label.component';
 import { CardDetailsFieldGroupComponent } from './card-details-field-group.component';
 import { WebContentSvc } from '../../../services/content-management.service';
@@ -34,7 +34,7 @@ describe('CardDetailsFieldGroupComponent', () => {
         DateTimeFormatPipe,
         TooltipComponent,
         SelectItemPipe,
-        DisplayValueDirective,
+        ValueStylesDirective,
         InputLabel
       ],
       imports: [

--- a/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field.component.html
@@ -26,7 +26,7 @@
                 [element]="element" 
                 [required]="false">
             </nm-input-label>
-            <div class="textWrapBreakWord" [nmDisplayValue]='element.leafState' [config]='element.config'>
+            <div class="textWrapBreakWord" [nmValueStyles]='element.leafState' [config]='element.config'>
                 <span class="fieldValue">{{value ? value : placeholder}}&nbsp;</span>
             </div>    
         </div>

--- a/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field.component.html
@@ -11,7 +11,6 @@
                 [element]="element" 
                 [required]="false">
             </nm-input-label>
-            <!--<label class="" *ngIf="element.config.uiStyles.attributes.showName==true">{{label}}</label>-->
             <ng-template [ngIf]="value">
                 <div class="textWrapBreakWord">{{value | dateTimeFormat: element.config?.uiStyles?.attributes?.datePattern : element.config.type.name }}&nbsp;</div>
             </ng-template>
@@ -21,14 +20,17 @@
          </ng-template>
 
         <div class="form-group" *ngIf="!element.config.uiStyles.attributes.inplaceEdit && !isDate(element.config.type.name)">
-           <!-- <label class="" *ngIf="element.config.uiStyles.attributes.showName==true">{{label}}</label> -->
            <nm-input-label *ngIf="element.config.uiStyles.attributes.showName==true"
                 [element]="element" 
                 [required]="false">
             </nm-input-label>
-            <div class="textWrapBreakWord" [nmValueStyles]='element.leafState' [config]='element.config'>
-                <span class="fieldValue">{{value ? value : placeholder}}&nbsp;</span>
-            </div>    
+            <div class="textWrapBreakWord" [nmDisplayValue]='element' [nmValueStyles]="element.leafState" [config]="element.config">
+                <ng-template #body let-displayValue>
+                    <span class="fieldValue">
+                        {{displayValue}}&nbsp;
+                    </span>
+                </ng-template>
+            </div>
         </div>
     </ng-template>
 </div>

--- a/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-field.component.spec.ts
@@ -14,7 +14,7 @@ import { DateTimeFormatPipe } from '../../../pipes/date.pipe';
 import { TooltipComponent } from '../tooltip/tooltip.component';
 import { SelectItemPipe } from '../../../pipes/select-item.pipe';
 import { CustomHttpClient } from '../../../services/httpclient.service';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { InputLabel } from '../../platform/form/elements/input-label.component';
 
 let fixture, app;
@@ -31,7 +31,7 @@ describe('CardDetailsFieldComponent', () => {
         DateTimeFormatPipe,
         TooltipComponent,
         SelectItemPipe,
-        DisplayValueDirective,
+        ValueStylesDirective,
         InputLabel
       ],
       imports: [FormsModule, DropdownModule, HttpClientModule, HttpModule],

--- a/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-grid.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/card/card-details-grid.component.spec.ts
@@ -26,7 +26,7 @@ import { Label } from '../content/label.component';
 import { CardDetailsFieldGroupComponent } from './card-details-field-group.component';
 import { Paragraph } from '../content/paragraph.component';
 import { ButtonGroup } from '../../platform/form/elements/button-group.component';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { InputLabel } from '../../platform/form/elements/input-label.component';
 import { Button } from '../../platform/form/elements/button.component';
 import { Image } from '../../platform/image.component';
@@ -59,7 +59,7 @@ describe('CardDetailsGrid', () => {
         CardDetailsFieldGroupComponent,
         Paragraph,
         ButtonGroup,
-        DisplayValueDirective,
+        ValueStylesDirective,
         InputLabel,
         Button,
         Image,

--- a/nimbus-ui/nimbusui/src/app/components/platform/card/card-details.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/card/card-details.component.spec.ts
@@ -25,7 +25,7 @@ import { CardDetailsFieldGroupComponent } from './card-details-field-group.compo
 import { Paragraph } from '../content/paragraph.component';
 import { ButtonGroup } from '../../platform/form/elements/button-group.component';
 import { Label } from '../content/label.component';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { InputLabel } from '../../platform/form/elements/input-label.component';
 import { Button } from '../../platform/form/elements/button.component';
 import { Image } from '../../platform/image.component';
@@ -54,7 +54,7 @@ describe('CardDetailsComponent', () => {
         Paragraph,
         ButtonGroup,
         Label,
-        DisplayValueDirective,
+        ValueStylesDirective,
         InputLabel,
         Button,
         Image,

--- a/nimbus-ui/nimbusui/src/app/components/platform/content/accordion.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/content/accordion.component.spec.ts
@@ -63,7 +63,7 @@ import { Menu } from '../menu.component';
 import { Form } from '../form.component';
 import { Label } from './label.component';
 import { CardDetailsFieldGroupComponent } from '../card/card-details-field-group.component';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { InputLabel } from '../form/elements/input-label.component';
 import { TreeGrid } from '../tree-grid/tree-grid.component';
 import { FormGridFiller } from '../form/form-grid-filler.component';
@@ -131,7 +131,7 @@ describe('Accordion', () => {
           Form,
           Label,
           CardDetailsFieldGroupComponent,
-          DisplayValueDirective,
+          ValueStylesDirective,
           InputLabel,
           TreeGrid,
           FormGridFiller,

--- a/nimbus-ui/nimbusui/src/app/components/platform/content/field-value.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/content/field-value.component.ts
@@ -37,7 +37,11 @@ import { BaseElement } from '../base-element.component';
                 [element]="element" 
                 [required]="false">
         </nm-input-label>
-        <p style="margin-bottom:0rem;">{{element.leafState}}</p>
+        <p [nmDisplayValue]="element" style="margin-bottom:0rem;">
+            <ng-template #body let-displayValue>
+                {{displayValue}}
+            </ng-template>
+        </p>
     </div>
    `
 })

--- a/nimbus-ui/nimbusui/src/app/components/platform/content/page-content.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/content/page-content.component.spec.ts
@@ -73,7 +73,7 @@ import { InputSwitch } from '../form/elements/input-switch.component';
 import { TreeGrid } from '../tree-grid/tree-grid.component';
 import { InputLabel } from '../form/elements/input-label.component';
 import { CardDetailsFieldGroupComponent } from '../card/card-details-field-group.component';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { FormGridFiller } from '../form/form-grid-filler.component';
 import { InputLegend } from '../form/elements/input-legend.component';
 
@@ -194,7 +194,7 @@ describe('PageContent', () => {
         TreeGrid,
         InputLabel,
         CardDetailsFieldGroupComponent,
-        DisplayValueDirective,
+        ValueStylesDirective,
         FormGridFiller,
         InputLegend
        ],

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.spec.ts
@@ -57,7 +57,7 @@ import { Image } from './image.component';
 import { TreeGrid } from './tree-grid/tree-grid.component';
 import { InputSwitch } from './form/elements/input-switch.component';
 import { FormGridFiller } from './form/form-grid-filler.component';
-import { DisplayValueDirective } from '../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../directives/value-styles.directive';
 import { InputLabel } from './form/elements/input-label.component';
 import { Label } from './content/label.component';
 import { CardDetailsFieldGroupComponent } from './card/card-details-field-group.component';
@@ -122,7 +122,7 @@ describe('FormElement', () => {
         TreeGrid,
         InputSwitch,
         FormGridFiller,
-        DisplayValueDirective,
+        ValueStylesDirective,
         InputLabel,
         Label,
         CardDetailsFieldGroupComponent,

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-error-message.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-error-message.component.spec.ts
@@ -82,7 +82,7 @@ import { Image } from './image.component';
 import { TreeGrid } from './tree-grid/tree-grid.component';
 import { InputSwitch } from './form/elements/input-switch.component';
 import { FormGridFiller } from './form/form-grid-filler.component';
-import { DisplayValueDirective } from '../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../directives/value-styles.directive';
 import { InputLabel } from './form/elements/input-label.component';
 import { Label } from './content/label.component';
 import { CardDetailsFieldGroupComponent } from './card/card-details-field-group.component';
@@ -148,7 +148,7 @@ describe("form error message component", () => {
             TreeGrid,
             InputSwitch,
             FormGridFiller,
-            DisplayValueDirective,
+            ValueStylesDirective,
             InputLabel,
             FormErrorMessage,
             Label,

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-group.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-group.component.spec.ts
@@ -55,7 +55,7 @@ import { Image } from './image.component';
 import { TreeGrid } from './tree-grid/tree-grid.component';
 import { InputSwitch } from './form/elements/input-switch.component';
 import { FormGridFiller } from './form/form-grid-filler.component';
-import { DisplayValueDirective } from '../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../directives/value-styles.directive';
 import { InputLabel } from './form/elements/input-label.component';
 import { Label } from './content/label.component';
 import { CardDetailsFieldGroupComponent } from './card/card-details-field-group.component';
@@ -120,7 +120,7 @@ describe('FrmGroupCmp', () => {
         TreeGrid,
         InputSwitch,
         FormGridFiller,
-        DisplayValueDirective,
+        ValueStylesDirective,
         InputLabel,
         Label,
         CardDetailsFieldGroupComponent,

--- a/nimbus-ui/nimbusui/src/app/components/platform/form.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form.component.spec.ts
@@ -66,7 +66,7 @@ import { Image } from './image.component';
 import { TreeGrid } from './tree-grid/tree-grid.component';
 import { InputSwitch } from './form/elements/input-switch.component';
 import { FormGridFiller } from './form/form-grid-filler.component';
-import { DisplayValueDirective } from '../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../directives/value-styles.directive';
 import { InputLabel } from './form/elements/input-label.component';
 import { Label } from './content/label.component';
 import { CardDetailsFieldGroupComponent } from './card/card-details-field-group.component';
@@ -144,7 +144,7 @@ describe('Form', () => {
           TreeGrid,
           InputSwitch,
           FormGridFiller,
-          DisplayValueDirective,
+          ValueStylesDirective,
           InputLabel,
           Label,
           CardDetailsFieldGroupComponent,

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
@@ -97,7 +97,7 @@
 
                 <ng-template ngFor let-col let-colIndex="index" [ngForOf]="params">
                     <td *ngIf="showColumn(col)" [ngClass]="getColumnStyle(col)">
-                        <span title="{{getCellDisplayValue(rowData, col)}}" *ngIf="showValue(col)" [nmDisplayValue]='getCellDisplayValue(rowData, col)' [config]='col'>
+                        <span title="{{getCellDisplayValue(rowData, col)}}" *ngIf="showValue(col)" [nmValueStyles]='getCellDisplayValue(rowData, col)' [config]='col'>
                             <span class="fieldValue {{col.code}} {{getCellStyle(rowData.elemId, col.code)}}">{{getCellDisplayValue(rowData, col)}}</span>
                         </span>
                         <span *ngIf="col?.uiStyles?.attributes?.alias == viewComponent.link.toString()">

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.spec.ts
@@ -68,7 +68,7 @@ import { ViewComponent } from '../../../shared/param-annotations.enum';
 import { HeaderCheckBox } from '../form/elements/header-checkbox.component';
 import { SvgComponent } from '../svg/svg.component';
 import { Image } from '../image.component';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { InputSwitch } from '../../platform/form/elements/input-switch.component';
 import { TreeGrid } from '../../platform/tree-grid/tree-grid.component';
 import { Label } from '../../platform/content/label.component';
@@ -150,7 +150,7 @@ describe('DataTable', () => {
           HeaderCheckBox,
           SvgComponent,
           Image,
-          DisplayValueDirective,
+          ValueStylesDirective,
           InputSwitch,
           TreeGrid,
           Label,

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
@@ -275,6 +275,8 @@ export class DataTable extends BaseTableElement implements ControlValueAccessor 
         if (cellData) {
             if (super.isDate(col.type.name)) {
                 return this.dtFormat.transform(cellData, col.uiStyles.attributes.datePattern, col.type.name);
+            } else if (this.element.gridData.stateMap[rowData.elemId][col.code].displayValue) {
+                return this.element.gridData.stateMap[rowData.elemId][col.code].displayValue;
             } else {
                 return cellData;
             }

--- a/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.spec.ts
@@ -61,7 +61,7 @@ import { TreeGrid } from '../../platform/tree-grid/tree-grid.component';
 import { Label } from '../../platform/content/label.component';
 import { InputLabel } from '../../platform/form/elements/input-label.component';
 import { CardDetailsFieldGroupComponent } from '../../platform/card/card-details-field-group.component';
-import { DisplayValueDirective } from '../../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../../directives/value-styles.directive';
 import { FormGridFiller } from '../../platform/form/form-grid-filler.component';
 import { InputLegend } from '../../platform/form/elements/input-legend.component';
 
@@ -121,7 +121,7 @@ describe('Modal', () => {
         Label,
         InputLabel,
         CardDetailsFieldGroupComponent,
-        DisplayValueDirective,
+        ValueStylesDirective,
         FormGridFiller,
         InputLegend
        ],

--- a/nimbus-ui/nimbusui/src/app/components/platform/section.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/section.component.spec.ts
@@ -66,7 +66,7 @@ import { Label } from '../platform/content/label.component';
 import { TreeGrid } from '../platform/tree-grid/tree-grid.component';
 import { InputSwitch } from '../platform/form/elements/input-switch.component';
 import { CardDetailsFieldGroupComponent } from '../platform/card/card-details-field-group.component';
-import { DisplayValueDirective } from '../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../directives/value-styles.directive';
 import { FormGridFiller } from '../platform/form/form-grid-filler.component';
 import { InputLegend } from '../platform/form/elements/input-legend.component';
 
@@ -132,7 +132,7 @@ describe('Section', () => {
         TreeGrid,
         InputSwitch,
         CardDetailsFieldGroupComponent,
-        DisplayValueDirective,
+        ValueStylesDirective,
         FormGridFiller,
         InputLegend
        ],

--- a/nimbus-ui/nimbusui/src/app/components/platform/tile.component.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/tile.component.spec.ts
@@ -67,7 +67,7 @@ import { Label } from '../platform/content/label.component';
 import { TreeGrid } from '../platform/tree-grid/tree-grid.component';
 import { InputSwitch } from '../platform/form/elements/input-switch.component';
 import { CardDetailsFieldGroupComponent } from '../platform/card/card-details-field-group.component';
-import { DisplayValueDirective } from '../../directives/display-value.directive';
+import { ValueStylesDirective } from '../../directives/value-styles.directive';
 import { FormGridFiller } from '../platform/form/form-grid-filler.component';
 import { InputLegend } from '../platform/form/elements/input-legend.component';
 
@@ -136,7 +136,7 @@ describe('Tile', () => {
         TreeGrid,
         InputSwitch,
         CardDetailsFieldGroupComponent,
-        DisplayValueDirective,
+        ValueStylesDirective,
         FormGridFiller,
         InputLegend
        ],

--- a/nimbus-ui/nimbusui/src/app/directives/display-value.ts
+++ b/nimbus-ui/nimbusui/src/app/directives/display-value.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2016-2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { ParamUtils } from './../shared/param-utils';
+import { Param } from './../shared/param-state';
+import { Component, Input, TemplateRef, ContentChild } from '@angular/core';
+import { PageService } from './../services/page.service';
+
+/**
+ * \@author Tony Lopez
+ * \@whatItDoes 
+ *  Handles any common transformations when displaying the value received for a param on the server.
+ * 
+ * \@howToUse
+ *  Include [nmDisplayValue] as an attribute on an element and provide a 
+ *  template reference to #body to be able to utilize a template instance variable via "let-displayValue".
+ *  displayValue the can be used in accordance to the template reference.
+ * 
+ */
+@Component({ 
+    selector: '[nmDisplayValue]',
+    template: `
+        <ng-container *ngTemplateOutlet="bodyTemplate; context: { $implicit: displayValue }"></ng-container>
+    `
+})
+export class DisplayValue {
+
+    @Input("nmDisplayValue") element: Param;
+
+    @ContentChild('body') bodyTemplate: TemplateRef<any>;
+
+    displayValue: string;
+
+    constructor(private pageService: PageService) {
+        
+    }
+
+    ngOnInit() {
+        this.displayValue = this.determineDisplayValue(this.element);
+    }
+
+    ngAfterViewInit() {
+        this.pageService.eventUpdate.subscribe(event => {
+            if (event.path == this.element.path) {
+                this.displayValue = this.determineDisplayValue(event);
+            }
+        });
+    }
+    
+    private determineDisplayValue(param: Param): string {
+        let foundValuesLabel = ParamUtils.getValuesLabelMatchingLeafState(param)
+        if (foundValuesLabel) {
+            return foundValuesLabel;
+        }
+
+        let foundPlaceholder;
+        if (!param.leafState && (foundPlaceholder = ParamUtils.getPlaceholder(param))) {
+            return foundPlaceholder;
+        }
+
+        return param.leafState;
+    }
+}

--- a/nimbus-ui/nimbusui/src/app/directives/value-styles.directive.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/directives/value-styles.directive.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, async } from '@angular/core/testing';
 
-import { DisplayValueDirective } from './display-value.directive';
+import { ValueStylesDirective } from './value-styles.directive';
 import { ElementRef, Renderer2 } from '@angular/core';
 
 class MockElementRef {
@@ -22,7 +22,7 @@ describe('DisplayValueDirective', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
           declarations: [
-            DisplayValueDirective
+            ValueStylesDirective
            ],
            providers: [
                {provide: ElementRef, useClass: MockElementRef},
@@ -31,7 +31,7 @@ describe('DisplayValueDirective', () => {
         }).compileComponents();
         elementRef = TestBed.get(ElementRef);
         renderer = TestBed.get(Renderer2);
-        directive = new DisplayValueDirective(elementRef, renderer)
+        directive = new ValueStylesDirective(elementRef, renderer)
       }));
 
     it('should create an instance', () => {

--- a/nimbus-ui/nimbusui/src/app/directives/value-styles.directive.ts
+++ b/nimbus-ui/nimbusui/src/app/directives/value-styles.directive.ts
@@ -25,10 +25,10 @@ import { ParamConfig } from '../shared/param-config';
  * 
  */
 @Directive({
-  selector: '[nmDisplayValue]'
+  selector: '[nmValueStyles]'
 })
-export class DisplayValueDirective {
-    @Input('nmDisplayValue') displayValue: any;
+export class ValueStylesDirective {
+    @Input('nmValueStyles') displayValue: any;
     @Input('config') config: ParamConfig;
     static placeholder: string = 'placeholder';
 
@@ -47,7 +47,7 @@ export class DisplayValueDirective {
                                 || this.displayValue === '')) {
                 this.renderer.addClass(this.el.nativeElement, this.getValue(this.displayValue)); // Field Value
             } else {
-                this.renderer.addClass(this.el.nativeElement, DisplayValueDirective.placeholder); // placeholder Value
+                this.renderer.addClass(this.el.nativeElement, ValueStylesDirective.placeholder); // placeholder Value
             }
         }
     }
@@ -59,7 +59,7 @@ export class DisplayValueDirective {
         if (this.config && this.config.uiStyles.attributes.applyValueStyles) {
             // Remove the previous value styles
             if (changes.displayValue.previousValue === undefined) {
-                this.renderer.removeClass(this.el.nativeElement, DisplayValueDirective.placeholder);
+                this.renderer.removeClass(this.el.nativeElement, ValueStylesDirective.placeholder);
             } else {
                 this.renderer.removeClass(this.el.nativeElement, this.getValue(changes.displayValue.previousValue));
             }
@@ -67,7 +67,7 @@ export class DisplayValueDirective {
             if (changes.displayValue.currentValue === undefined || changes.displayValue.currentValue === '' ||
                 (changes.displayValue.currentValue instanceof String && changes.displayValue.currentValue.trim() === '') ||
                 changes.displayValue.currentValue === null) {
-                this.renderer.addClass(this.el.nativeElement, DisplayValueDirective.placeholder);
+                this.renderer.addClass(this.el.nativeElement, ValueStylesDirective.placeholder);
             } else {
                 this.renderer.addClass(this.el.nativeElement, this.getValue(changes.displayValue.currentValue));
             }

--- a/nimbus-ui/nimbusui/src/app/shared/param-state.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-state.ts
@@ -223,6 +223,7 @@ export class Param implements Serializable<Param, string> {
                         for(var cellParam of colElemParam.type.model.params) {
                             let cellParamCode = this.configSvc.getViewConfigById(cellParam.configId).code;
                             rowStateData[cellParamCode] = {
+                                displayValue: ParamUtils.getValuesLabelMatchingLeafState(cellParam),
                                 style: cellParam.style
                             };
                         }

--- a/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
@@ -332,4 +332,21 @@ export class ParamUtils {
         }
         return `/${domain}/${page}`;
     }
+
+    static getPlaceholder(param: Param): string {
+        if (param && param.config && param.config.uiStyles && param.config.uiStyles.attributes) {
+            return param.config.uiStyles.attributes.placeholder;
+        }
+        return undefined;
+    }
+
+    static getValuesLabelMatchingLeafState(param: Param) {
+        if (param && param.values && param.values.length > 0) {
+            let paramValue = param.values.find(pv => pv.code === param.leafState);
+            if (paramValue) {
+                return paramValue.label;
+            }
+        }
+        return undefined;
+    }
 }


### PR DESCRIPTION
# Description

Adds support for retrieving the `label` associated with a `ParamValue`'s `code` that has been previously persisted.

Fixes [Discourse Issue #352](http://discourse.oss.antheminc.com/t/display-value-from-values-instead-of-persisted-code-with-gridcolumn-and-fieldvalue/352)

## Overview of Changes

- Added support for `@GridColumn` and `@FieldValue` to display the `label` instead of a `code` from a given `@Values` annotation, when the `code` has been persisted
  - Renamed existing `[nmDisplayValue]` directive logic to `[nmValueStyles]`.
  - Repurposed `[nmDisplayValue]` to be a component
    - `nmDisplayValue` now applies both `@Values` logic and existing `placeholder` logic, otherwise the `leafState` is used
  - Modified `@FieldValue` to use `[nmDisplayValue]`
  - Modified `@GridColumn` to use `[nmDisplayValue]`
- Created `ConfigTestUtils` for Config Annotation test support

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] `DefaultParamValuesHandlerTest`
- [ ] `DefaultParamValuesHandlerUnitTest`

# Additional Notes

Consider the following code:

```java
public static class Foods {
	
	public static class Dog implements Source {
		@Override
		public List<ParamValue> getValues(String paramPath) {
			List<ParamValue> values = new ArrayList<>();
			values.add(new ParamValue("DOG_FOOD_1", "Dog Food 1"));
			return values;
		}
	}
	
	public static class Cat implements Source {
		@Override
		public List<ParamValue> getValues(String paramPath) {
			List<ParamValue> values = new ArrayList<>();
			values.add(new ParamValue("CAT_FOOD_1", "Cat Food 1"));
			return values;
		}
	}
}
```

```java
@Label("Food Name")
@GridColumn(placeholder = "--")
// Foods.All.class contains both sets of values from Dog.class and Cat.class
@Values(Foods.All.class)
@Path
private PetFood petFood;
```

Assume the state of a param for `petFood` is `Food.Cat.CAT_FOOD_1`. Then the value persisted for the core of `petFood` is `CAT_FOOD_1`. The UI will then use the provided `@Values`to determine and display the label `Cat Food 1`, instead of `CAT_FOOD_1`.

See [Discourse Issue #352](http://discourse.oss.antheminc.com/t/display-value-from-values-instead-of-persisted-code-with-gridcolumn-and-fieldvalue/352) for more background on this issue.
