### PR TITLE
Support for @ValuesConditional and non-string types

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandler.java
@@ -98,8 +98,9 @@ public class ValuesConditionalStateEventHandler extends EvalExprWithCrudDefaults
 			// if there are no values set (default config values) OR
 			// if previously selected targetParam state is not in the list of
 			// new values. then reset to null.
-			if (null == targetParam.getValues() || null != targetParam.getState() && !targetParam.getValues().stream()
-					.map(ParamValue::getCode).collect(Collectors.toList()).contains(targetParam.getState())) {
+			String stateAsString = targetParam.getState() != null ? targetParam.getState().toString() : null;
+			if (null == targetParam.getValues() || (null != targetParam.getState() && !targetParam.getValues().stream()
+					.map(ParamValue::getCode).collect(Collectors.toList()).contains(stateAsString))) {
 
 				targetParam.setState(null);
 			}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreValuesEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreValuesEntity.java
@@ -83,6 +83,14 @@ public class SampleCoreValuesEntity {
 		
 		@Radio
 		private String statusReason2;
+		
+		@ValuesConditional(targetPath = "/../contactStatus", resetOnChange = false, condition = {
+			@ValuesConditional.Condition(when = "state == 'changeit'", then = @Values(StatusPast.class))
+		})
+		private String contactType;
+		
+		@Values(StatusAll.class)
+		private Status contactStatus;
 	}
 	
 	public static class SR_DEFAULT implements Source {
@@ -107,6 +115,32 @@ public class SampleCoreValuesEntity {
 		public List<ParamValue> getValues(String paramCode) {
 			final List<ParamValue> values = new ArrayList<>();
 			values.add(new ParamValue("B1", "B1"));
+			return values;
+		}
+	}
+	@Getter
+	public static enum Status {
+		CURRENT("Current"),
+		PAST("Past");
+		private String name;
+		private Status(String name){
+			this.name = name;
+		}
+	}
+	public static class StatusAll implements Source {
+		@Override
+		public List<ParamValue> getValues(String paramCode) {
+			final List<ParamValue> values = new ArrayList<>();
+			values.add(new ParamValue("PAST", "Past"));
+			values.add(new ParamValue("CURRENT", "Current"));
+			return values;
+		}
+	}
+	public static class StatusPast implements Source {
+		@Override
+		public List<ParamValue> getValues(String paramCode) {
+			final List<ParamValue> values = new ArrayList<>();
+			values.add(new ParamValue("PAST", "Past"));
 			return values;
 		}
 	}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
@@ -32,6 +32,7 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
 import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreValuesEntity.Status;
 
 /**
  * 
@@ -254,5 +255,23 @@ public class ValuesConditionalStateEventHandlerIntegTest extends AbstractStateEv
 		
 		Assert.assertNull(statusForm.findParamByPath("/statusReason2").getValues());
 		Assert.assertNull(statusForm.findParamByPath("/statusReason2").getState());
+	}
+	
+	@Test
+	public void t11_nonStringState() {
+		final Param<?> statusForm = _q.getRoot().findParamByPath(STATUS_FORM);
+		assertNotNull(statusForm);
+		
+		Assert.assertNotNull(statusForm.findParamByPath("/contactStatus").getValues());
+		Assert.assertNull(statusForm.findParamByPath("/contactStatus").getState());
+		
+		statusForm.findParamByPath("/contactStatus").setState(Status.PAST);
+		
+		statusForm.findParamByPath("/contactType").setState("changeit");
+		Assert.assertEquals(1, statusForm.findParamByPath("/contactStatus").getValues().size());
+		Assert.assertEquals("PAST", statusForm.findParamByPath("/contactStatus").getValues().get(0).getCode());
+		Assert.assertEquals("Past", statusForm.findParamByPath("/contactStatus").getValues().get(0).getLabel());
+		
+		Assert.assertEquals(Status.PAST, statusForm.findParamByPath("/contactStatus").getState());
 	}
 }


### PR DESCRIPTION
# Description

Fixed an issue where non-string types were not working in `@ValuesConditional`

## Overview of Changes
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- ValuesConditionalStateEventHandlerIntegTest#t11_nonStringState()

# Additional Notes

N/A
