### PR TITLE
_update fix for collections

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdate.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdate.java
@@ -128,10 +128,10 @@ public class DefaultActionExecutorUpdate extends AbstractCommandExecutor<Boolean
 		Param<Object> p = findParamByCommandOrThrowEx(eCtx);
 		String json = eCtx.getCommandMessage().getRawPayload();
 
-		if (p.isLeaf()) {
-			handleLeaf(p, json);
-		} else if (p.isCollection()) {
+		if (p.isCollection()) {
 			handleCollection(p.findIfCollection(), json);
+		} else if (p.isLeaf()) {
+			handleLeaf(p, json);
 		} else {
 			// remaining scenarios apply to nested params or collection elements
 			handleParam(p, json);

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreEntity.java
@@ -194,4 +194,6 @@ public class SampleCoreEntity extends IdLong {
 	private SampleValidateEntity2 attr_validate_nested_2;
 
 	private String testEntry;
+	
+	private List<String> attr_list_2_simple;
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
@@ -57,4 +57,7 @@ public class VRSampleViewRootEntity {
 	
 	@Path
 	private List<SampleCoreNestedEntity> attr_list_1_NestedEntity;
+	
+	@Path
+	private List<String> attr_list_2_simple;
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdateTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -39,6 +40,7 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.ListParam;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ParamUtils;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreLevel1_Entity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity;
@@ -486,6 +488,31 @@ public class DefaultActionExecutorUpdateTest extends AbstractFrameworkIngeration
 		List<SampleCoreNestedEntity> actual = viewParam.getState();
 		
 		assertEquals(3, actual.size());
+	}
+	
+	@Test
+	public void t12_update_collection_simple() {
+		Long refId = createOrGetDomainRoot_RefId();
+		
+		// Build the request objects
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(refId)
+			.addNested("/attr_list_2_simple").addAction(Action._update).getMock();
+		
+		List<String> expected = Arrays.asList("field 1", "field 2");
+		
+		// Invoke _update on the list with "field 1"
+		Object response1 = controller.handlePut(request, null, converter.toJson(expected.get(0)));
+		
+		// Validate list should have "field 1" only
+		Param<List<String>> viewParam = ParamUtils.extractResponseByParamPath(response1, "/attr_list_2_simple");
+		assertEquals(Arrays.asList(expected.get(0)), viewParam.getState());
+		
+		// Invoke _update on the list with "field 2"
+		Object response2 = controller.handlePut(request, null, converter.toJson(expected.get(1)));
+		
+		// Validate list should have ["field 1", "field 2"]
+		viewParam = ParamUtils.extractResponseByParamPath(response2, "/attr_list_2_simple");
+		assertEquals(expected, viewParam.getState());
 	}
 }
 


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed an issue where `_update` was setting the state instead of adding for a collection containing a non-nested type.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

Parsing collections now takes priority over leaf state parsing (this was the previous behavior back [before it was broken](https://github.com/lopezton-anthem/nimbus-core/commit/1036874c8ed4217a83f193f2dbe38046a0551843#diff-ac63c7ab314e5f56d2f3ee26bb92a817))

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

See `DefaultActionExecutorUpdateTest#t12_update_collection_simple()`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

It looks like this was introduced back in `1.1.0.M1-SNAPSHOT`.
