### PR TITLE
Deprecating @Grid dataKey Attribute

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -1156,6 +1156,12 @@ public class ViewConfig {
 		 */
 		String cssClass() default "";
 
+		/**
+		 * <p>As of release 1.1.9, {@code dataKey} is no longer needed to
+		 * support grid row expansion. This attribute will be removed in the
+		 * future releases.
+		 */
+		@Deprecated
 		String dataKey() default "id";
 
 		boolean expandableRows() default false;

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.html
@@ -16,7 +16,7 @@
     </div>
 
     <p-table #dt [value]="value" [columns]="params" 
-        [dataKey]="element.config?.uiStyles?.attributes?.dataKey"
+        [dataKey]="'elemId'"
         [(selection)]="selectedRows"
         [rows]="element.config?.uiStyles?.attributes?.pageSize"
         [totalRecords]=totalRecords

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
@@ -222,7 +222,7 @@ export class DataTable extends BaseElement implements ControlValueAccessor {
                 // iterate over currently expanded rows and refresh the data
                 Object.keys(this.dt.expandedRowKeys).forEach(key => {
                     this.value.find((lineItem, index) => {
-                        if (lineItem[this.element.config.uiStyles.attributes.dataKey] == key) {
+                        if (lineItem[this.element.elemId] == key) {
                             this._putNestedElement(event.collectionParams, index, lineItem);
                             return true;
                         }

--- a/nimbus-ui/nimbusui/src/app/shared/param-config.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-config.ts
@@ -164,7 +164,6 @@ export class UiAttribute implements Serializable<UiAttribute,string> {
     postEventOnChange: boolean;
     draggable: boolean;
     rowSelection: boolean;
-    dataKey: string;
     showHeader: boolean;
     pagination: boolean;
     pageSize: number = 25; //server side has a default but defaulting here so that coverter can cast to number


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

- Deprecated `dataKey` attribute of `@Grid`
  - The `dataKey` attribute may be removed in the future. Marked it as deprecated for now.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

- The `@Grid` template now uses the server-generated `elemId` value instead of the default `id` or a configured `dataKey` to expand `@GridRowBody` content within a collection element

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Functional Testing in Petclinic

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

- Existing implementations that generated an `datakey` for nested collections can remove these implementations.
