### PR TITLE
Adding @Printable to support printing DOM content

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -1814,7 +1814,7 @@ public class ViewConfig {
 	
 	/**
 	 * <p>Renders a popup window with content defined by the nested fields
-	 * within the field that is decorated with <tt>&#64;Modal</tt>.
+	 * within the field that is decorated with &#64;{@code Modal}.
 	 * 
 	 * <p><b>Expected Field Structure</b>
 	 * 
@@ -1822,7 +1822,7 @@ public class ViewConfig {
 	 * following components: <ul> <li>{@link Tile}</li> </ul>
 	 * 
 	 * <p><b>Notes:</b> <ul> <li>Default contextual properties are set by
-	 * <tt>ModalStateEventHandler</tt> during the <tt>OnStateLoad</tt>
+	 * <tt>ModalStateEventHandler</tt> during the {@code OnStateLoad}
 	 * event.</li> </ul>
 	 * 
 	 * @since 1.0
@@ -2116,6 +2116,73 @@ public class ViewConfig {
 		
 	}
 
+	/**
+	 * <p>Enables a decorated {@link ViewStyle} component to be able to print
+	 * only the decorated component content by allowing the user to click a
+	 * print button.
+	 * 
+	 * <p>{@code Printable} currently supports the following components: <ul>
+	 * <li>{@link Modal}</li> </ul>
+	 * 
+	 * <p><b>Print Button Styling</b> <p>The default positioning and styling of
+	 * the rendered print button for a component is delegated to the individual
+	 * component itself.
+	 * 
+	 * <p><b>Sample Usage</b>
+	 * 
+	 * <pre>
+	 * &#64;Modal
+	 * &#64;Printable
+	 * private VMSampleModal vmSampleModal;
+	 * </pre>
+	 * 
+	 * @author Tony Lopez
+	 * @since 1.1
+	 *
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD })
+	@ViewParamBehavior
+	public @interface Printable {
+
+		/**
+		 * <p>Whether or not to close the opened browser window/tab containing
+		 * the printable content after the user completes actions within the
+		 * native browser print dialog.
+		 */
+		boolean closeAfterPrint() default true;
+		
+		/**
+		 * <p>The delay (in milliseconds) between when the browser opens a new
+		 * window/tab containing the printable content and when the browser
+		 * opens the native print dialog. <p>The {@code delay} will be applied
+		 * only when {@link #useDelay()} is {@code true}.
+		 */
+		int delay() default 300;
+
+		/**
+		 * <p>One or more relative URI's of stylesheets that should be applied
+		 * to the printable content. The URI's provided are relative to the
+		 * server context of the client application. For example,
+		 * {@code ["/styles/sheet1.css", "/styles/sheet2.css"]} would resolve
+		 * to: <ul> <li>http://localhost:8080/appcontext/styles/sheet1.css</li>
+		 * <li>http://localhost:8080/appcontext/styles/sheet2.css</li> </ul>
+		 * <p>*Note: The protocol, host, port, and context are client specific.
+		 * <p>If providing very large stylesheets, it may be necessary to modify
+		 * the {@link delay} property so that the stylesheets have time to load
+		 * prior to the print actions taking place.
+		 */
+		String[] stylesheets() default {};
+		
+		/**
+		 * <p>Whether or not to use the {@link delay} setting. <p>If
+		 * {@link #stylesheets()} is provided as a non-empty array,
+		 * {@code useDelay} will be set to {@code true} regardless of the value
+		 * set.
+		 */
+		boolean useDelay() default true;
+	}
+	
 	/**
 	 * <p><b>Expected Field Structure</b>
 	 * 

--- a/nimbus-ui/nimbusui/src/app/app.module.ts
+++ b/nimbus-ui/nimbusui/src/app/app.module.ts
@@ -106,6 +106,7 @@ import { BaseLabel } from './components/platform/base-label.component';
 import { Label } from './components/platform/content/label.component';
 import { InputLabel } from './components/platform/form/elements/input-label.component';
 import { BaseTableElement } from './components/platform/base-table-element.component';
+import { PrintButton } from './components/platform/print/print-button.component';
 // Services
 import { WebContentSvc } from './services/content-management.service';
 import { STOMPStatusComponent } from './services/stomp-status.component';
@@ -219,7 +220,7 @@ export function init_app(appinitservice: AppInitService) {
         KeysPipe, LinkPipe, DateTimeFormatPipe, SelectItemPipe, MultiSelectListBox, 
         CheckBox, FileUploadComponent, BreadcrumbComponent, TooltipComponent, Calendar, LoaderComponent, MessageComponent,
         HeaderCheckBox, SvgComponent, SvgDefinitions, ActionTray, SubDomainFlowCmp, Image, NmPanelMenu,NmPanelMenuSub, MenuRouterLinkActive, 
-        MenuRouteLink, BaseLabel, Label, InputLabel,InputSwitch,TreeGrid,InputLegend, FormErrorMessage, BaseTableElement
+        MenuRouteLink, BaseLabel, Label, InputLabel,InputSwitch,TreeGrid,InputLegend, FormErrorMessage, BaseTableElement, PrintButton
     ],
     entryComponents: [ FlowWrapper, PageContent, PageNotfoundComponent, LoginCmp, HomeLayoutCmp, SubDomainFlowCmp],
     providers: [ PageService, ConfigService, WebContentSvc, HttpClient,  HttpClientModule, AppInitService,

--- a/nimbus-ui/nimbusui/src/app/components/platform/base-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/base-element.component.ts
@@ -1,3 +1,4 @@
+import { ViewConfig } from './../../shared/param-annotations.enum';
 /**
  * @license
  * Copyright 2016-2018 the original author or authors.
@@ -19,7 +20,7 @@
 import { Component, Input } from '@angular/core';
 import { Param } from '../../shared/param-state';
 import { WebContentSvc } from '../../services/content-management.service';
-import { LabelConfig } from './../../shared/param-config';
+import { LabelConfig, UiNature } from './../../shared/param-config';
 import { ValidationUtils } from './validators/ValidationUtils';
 import { ParamUtils } from '../../shared/param-utils';
 import { ValidationConstraint } from './../../shared/validationconstraints.enum';
@@ -167,6 +168,33 @@ export class BaseElement {
      */
     public get type(): string {
         return this.element.config.uiStyles.attributes.type;
+    }
+
+    /**
+     * Get the @Printable UiNature if it exists on this instance
+     */
+    public get printable(): UiNature {
+        return this.getUiNature(ViewConfig.printable.toString());
+    }
+
+    /**
+     * Retrieve a UiNature by name from uiNatures. If not uiNatures is undefined or the uiNature 
+     * by name is not found, undefined is returned.
+     * @param name The name of the uiNature on this param to find
+     */
+    public getUiNature(name: string): UiNature {
+        return !this.uiNatures ? undefined : this.uiNatures.find(uiNature => uiNature.name === name);
+    }
+
+    /**
+     * Get the UiNature[] if it exists and is non-empty on this instance
+     */
+    public get uiNatures(): UiNature[] {
+        if (this.element.config && this.element.config.uiNatures && this.element.config.uiNatures.length > 0) {
+            return this.element.config.uiNatures;
+        } else {
+            return undefined;
+        }
     }
 
     /**

--- a/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/modal/modal.component.html
@@ -13,6 +13,9 @@
         <p-header>
             <nm-input-label [element]="element"></nm-input-label>
         </p-header>
+        <ng-template [ngIf]="printable">
+            <nm-print-button [config]="printable" [contentSelector]="'div.ui-dialog-content'"></nm-print-button>
+        </ng-template>
         <ng-template ngFor let-element [ngForOf]="nestedParams">
             <ng-template [ngIf]="element.alias == viewComponent.section.toString()">
                 <nm-section [element]="element"></nm-section>	

--- a/nimbus-ui/nimbusui/src/app/components/platform/print/print-button.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/print/print-button.component.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2016-2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+import { Component, Input } from '@angular/core';
+import { LoggerService } from '../../../services/logger.service';
+import { UiNature } from '../../../shared/param-config';
+import { ServiceConstants } from './../../../services/service.constants';
+
+/**
+ * \@author Tony Lopez
+ * \@whatItDoes 
+ *  Renders a button to allow for the printing of specific content.
+ * \@howToUse 
+ *  This component is driven by the server-side config of @Printable and the component
+ *  that implements <nm-print-button>.
+ * 
+ *  The following @Input fields are required:
+ *   - [config]:            The @Printable config that decorates the component invoking 
+ *                          this <nm-print-button> component.
+ *   - [contentSelector]:   A selector string that that identifies the closest parent 
+ *                          relative to this <nm-print-button> instance.
+ */
+@Component({
+    selector: 'nm-print-button',
+    template: `
+        <button pButton 
+            (click)="execute($event)"
+            type="button" 
+            icon="fa fa-print" 
+            class="ui-button-info ui-button-icon"></button>
+    `
+})
+export class PrintButton {
+
+    private readonly DEFAULT_DELAY = 300;
+
+    @Input('config') config: UiNature;
+
+    @Input('contentSelector') contentSelector: string;
+
+    closeAfterPrint: boolean = true;
+
+    delay: number = this.DEFAULT_DELAY;
+
+    stylesheets: string[];
+
+    useDelay: boolean = true;
+
+    constructor(private loggerService: LoggerService) {
+        
+    }
+
+    ngOnInit() {
+        this.closeAfterPrint = this.config.attributes.closeAfterPrint;
+        this.delay = this.config.attributes.delay;
+        this.stylesheets = this.config.attributes.stylesheets;
+        this.useDelay = this.config.attributes.useDelay;
+        if (this.stylesheets && this.stylesheets.length > 0) {
+            this.useDelay = true;
+            this.delay = this.delay > this.DEFAULT_DELAY ? this.delay : this.DEFAULT_DELAY;
+            this.loggerService.debug(`Stylesheets found. useDelay will be set to true with delay of ${this.delay}`);
+        }
+    }
+
+    execute($event: UIEvent): void {
+        this.loggerService.debug(`Print feature is looking for parent via selector: \"${this.contentSelector}\"`);
+        var printableElement = $event.srcElement.closest(this.contentSelector);
+        if (!printableElement) {
+            throw new Error(`Unable to identify parent DOM element using \"${this.contentSelector}\"`);
+        }
+        var printWindow = window.open('', '_blank');
+        if (this.stylesheets && this.stylesheets.length > 0) {
+            for(var stylesheet of this.stylesheets) {
+                var stylesheetURL = ServiceConstants.APP_BASE_URL + stylesheet;
+                var link = document.createElement('link');
+                link.setAttribute('rel', 'stylesheet');
+                link.setAttribute('type', 'text/css');
+                link.setAttribute('href', stylesheetURL);
+                printWindow.document.head.appendChild(link);
+                this.loggerService.debug(`Added print stylesheet for: \"${stylesheetURL}\"`);
+            }
+        }
+        printWindow.document.body.innerHTML = printableElement.innerHTML;
+        if (this.useDelay) {
+            window.setTimeout(() => this.doPrintActions(printWindow), this.delay);
+        } else {
+            this.doPrintActions(printWindow);
+        }
+    }
+
+    private doPrintActions(window: Window): void {
+        window.print();
+        if (this.closeAfterPrint) {
+            window.close();
+        }
+    }
+}

--- a/nimbus-ui/nimbusui/src/app/shared/param-annotations.enum.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-annotations.enum.ts
@@ -14,6 +14,7 @@ export class ViewConfig extends Enum<string> {
     public static readonly actiontray = new Enum('ViewConfig.ActionTray');
     public static readonly picklist = new Enum('ViewConfig.PickList');
     public static readonly selectedPicklist = new Enum('ViewConfig.PickListSelected');
+    public static readonly printable = new Enum('ViewConfig.Printable');
 
     static attributeList(): String[] {
       const keys = Object.keys(ViewConfig);

--- a/nimbus-ui/nimbusui/src/app/shared/param-config.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-config.ts
@@ -215,6 +215,10 @@ export class UiAttribute implements Serializable<UiAttribute,string> {
     scriptName: string;
     orientation: string;
     showMessages: boolean;
+    stylesheets: string[];
+    delay: number;
+    useDelay: boolean;
+    closeAfterPrint: boolean;
     
     deserialize( inJson ) {
         let obj = this;
@@ -222,6 +226,7 @@ export class UiAttribute implements Serializable<UiAttribute,string> {
         if(inJson['metaData'] || inJson['metaData'] === ""){
             obj['metaData'] = inJson['metaData'] !== "" ? inJson['metaData'].split(",") : [];
         }
+        this.stylesheets = inJson['stylesheets'];
         return obj;
     }
 }


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

- Added `@Printable` as a `@ViewParamBehavior` to support the printing of specific DOM content
- Added `@Printable` support to `@Modal`

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

- `@Printable`
  - Clients can specify `@Printable.stylesheets` to provide stylesheets related to print.
    - Currently, stylesheets must be served from the same host/port/context the client application is running on.

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Test case change
- [ ] Other
-->

- [ ] New feature
- [ ] This change requires a documentation update

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Tested in Petclinic

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

- This should give clients a fairly loose reign to incorporate print styles and the ability to enable printing where they see fit.
- The `@Printable` component is highly configurable and could be used in several other components in the future
- Added a few utility methods to `BaseElement` for retrieving `uiNatures`, and specifically the `printable` `uiNature`.
