### PR TITLE
1.1.x

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreBuilderConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreBuilderConfig.java
@@ -74,6 +74,8 @@ public class DefaultCoreBuilderConfig {
 	
 	private List<String> basePackages;
 	
+	private List<String> basePackagesToExclude;
+	
 	@Value("${platform.config.secure.regex}")
 	private String secureRegex;
 	
@@ -90,7 +92,7 @@ public class DefaultCoreBuilderConfig {
 	
 	@Bean
 	public DomainConfigBuilder domainConfigBuilder(EntityConfigBuilder configBuilder){
-		return new DomainConfigBuilder(configBuilder, basePackages);
+		return new DomainConfigBuilder(configBuilder, basePackages, basePackagesToExclude);
 	}
 	
 	@Bean

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/exclude/core/SampleExcludeEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/exclude/core/SampleExcludeEntity.java
@@ -1,0 +1,14 @@
+package com.antheminc.oss.nimbus.test.exclude.core;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+
+import lombok.Data;
+
+@Domain(value = "sampleExcludeEntity", includeListeners = { ListenerType.websocket })
+@Repo(value = Repo.Database.rep_none, cache = Repo.Cache.rep_device)
+@Data
+public class SampleExcludeEntity {
+
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/config/builder/ExcludePackageScanTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/config/builder/ExcludePackageScanTest.java
@@ -1,0 +1,25 @@
+package com.antheminc.oss.nimbus.domain.config.builder;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+
+public class ExcludePackageScanTest extends AbstractFrameworkIntegrationTests  {
+	
+	@Rule
+	public ExpectedException thrown= ExpectedException.none();
+	
+	@Test
+	public void testShouldNotScanTheConfiguredBasePackage(){		
+        MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/sampleExcludeEntity").addAction(Action._new).getMock();									
+		thrown.expect(InvalidConfigException.class);
+		thrown.expectMessage("Domain model config not found for root-alias: sampleExcludeEntity");
+		controller.handlePost(request, null);
+	}	
+}

--- a/nimbus-test/src/test/resources/application-test.yml
+++ b/nimbus-test/src/test/resources/application-test.yml
@@ -48,6 +48,9 @@ domain:
       - com.antheminc.oss.nimbus.**.view
       - com.antheminc.oss.nimbus.domain.bpm
       - com.antheminc.oss.nimbus.domain.rules
+    basePackagesToExclude:
+      - com.antheminc.oss.nimbus.test.exclude.core.*
+      
     typeClassMappings:
       java.time.LocalDate : 
         date


### PR DESCRIPTION
# Description
Ability to exclude basepackage scanning through configuration.

# Overview of Changes
We can now tell the framework to exclude scanning of few packages using the "basePackagesToExclude" property in the yml file.

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

N/A

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

N/A

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
