### PR TITLE
Adding isEmpty() for Param

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
@@ -473,6 +473,8 @@ public interface EntityState<T> {
 //			return false;
 //		}
 		
+		boolean isEmpty();
+		
 		boolean isNested();
 //		default boolean isNested() {
 //			return getType().isNested();

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/StateHolder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/StateHolder.java
@@ -483,5 +483,10 @@ public class StateHolder {
 			this.ref.setStyle(styleState);
 		}
 
+		@Override
+		public boolean isEmpty() {
+			return this.ref.isEmpty();
+		}
+
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultListParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultListParamState.java
@@ -456,4 +456,9 @@ public class DefaultListParamState<T> extends AbstractListPaginatedParam<T> impl
 		}
 		this.elemLabels = elemLabels;
 	}
+
+	@Override
+	public boolean isEmpty() {
+		return this.findIfNested().getParams() == null || this.findIfNested().getParams().size() <= 0; 
+	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
@@ -29,9 +29,9 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.springframework.util.ClassUtils;
 
 import com.antheminc.oss.nimbus.FrameworkRuntimeException;
@@ -1026,5 +1026,17 @@ public class DefaultParamState<T> extends AbstractEntityState<T> implements Para
 	@Override
 	public void setStyle(StyleState styleState) {
 		this.styleState.setState(styleState);
+	}
+
+	@Override
+	public boolean isEmpty() {
+		T leafState = this.getLeafState();
+		if (leafState == null) {
+			return true;
+		}
+		if (String.class == this.getType().getConfig().getReferredClass()) {
+			return ((String) leafState).isEmpty();
+		}
+		return false;
 	}
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParam.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParam.java
@@ -77,6 +77,7 @@ public class MockParam implements Param<Object> {
 	private boolean nested;
 	private boolean leaf;
 	private StyleState style;
+	private boolean empty;
 
 	@Override
 	public String getConfigId() {

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/SampleParamStateHolders.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/SampleParamStateHolders.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s0.view;
+
+import java.util.List;
+
+import com.antheminc.oss.nimbus.domain.defn.Model;
+import com.antheminc.oss.nimbus.domain.defn.extension.ActivateConditional;
+
+import lombok.Data;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Model
+@Data
+public class SampleParamStateHolders {
+
+	private String p1;
+	private String p2;
+	private String p3;
+	
+	@ActivateConditional(when="!isEmpty()", targetPath = "/../p1")
+	private List<String> simpleCollection1;
+	
+	@ActivateConditional(when="!isEmpty()", targetPath = "/../p2")
+	private String string1;
+	
+	@ActivateConditional(when="!isEmpty()", targetPath = "/../p3")
+	private Object object1;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
@@ -60,4 +60,6 @@ public class VRSampleViewRootEntity {
 	
 	@Path
 	private List<String> attr_list_2_simple;
+	
+	private SampleParamStateHolders paramStateHolders;
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/ParamStateHolderTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/ParamStateHolderTests.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ParamUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class ParamStateHolderTests extends AbstractFrameworkIngerationPersistableTests {
+
+	private Long refId;
+	
+	@Before
+	public void init() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT)
+				.addAction(Action._new).getMock();
+		Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handlePost(request, null);
+		this.refId = response.getState().getRootDomainId();
+	}
+	
+	@Test
+	public void testCollectionIsEmpty() throws JsonProcessingException {
+		String payload = this.om.writeValueAsString(Arrays.asList("change"));
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(this.refId)
+				.addNested("/paramStateHolders/simpleCollection1")
+				.addAction(Action._update)
+				.getMock();
+		Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handlePost(request, payload);
+		Param<String> targetParam = ParamUtils.extractResponseByParamPath(response, "/p1");
+		Assert.assertTrue(targetParam.isActive());
+	}
+	
+	@Test
+	public void testStringIsEmpty() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(this.refId)
+				.addNested("/paramStateHolders/string1")
+				.addAction(Action._process)
+				.addParam("fn", "_set").addParam("value", "change")
+				.getMock();
+		Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handlePost(request, null);
+		Param<String> targetParam = ParamUtils.extractResponseByParamPath(response, "/p2");
+		Assert.assertTrue(targetParam.isActive());
+	}
+	
+	@Test
+	public void testObjectIsEmpty() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(this.refId)
+				.addNested("/paramStateHolders/object1")
+				.addAction(Action._process)
+				.addParam("fn", "_set").addParam("value", "change")
+				.getMock();
+		Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handlePost(request, null);
+		Param<String> targetParam = ParamUtils.extractResponseByParamPath(response, "/p3");
+		Assert.assertTrue(targetParam.isActive());
+	}
+}


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

- Added `isEmpty()` for `Param` implemenetations

# Overview of Changes

 - Behavior for invoking `isEmpty` on the following parameter types is as follows:
   - **Collection**: returns `true` if the collection's nested params is `null` or its size is <= 0
   - **String**: returns `true` if the string is `null` or the length of the string is `0`
   - **Anything else**: returns `true` if the state is `null`

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

See `com.antheminc.oss.nimbus.domain.model.state.ParamStateHolderTests`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
