### PR TITLE
Enable caching for staticcodevalue dao search

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreConfiguration.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreConfiguration.java
@@ -18,6 +18,7 @@ package com.antheminc.oss.nimbus.app.extension.config;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -49,6 +50,7 @@ import com.antheminc.oss.nimbus.support.pojo.JavaBeanHandlerReflection;
  */
 @Configuration
 @ComponentScan(basePackageClasses = WebActionController.class)
+@EnableCaching
 public class DefaultCoreConfiguration {
 	
 	@Bean

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.BeanUtils;
+import org.springframework.cache.annotation.Cacheable;
 
 import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
@@ -45,6 +46,9 @@ import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 public class DefaultSearchFunctionHandlerLookup<T, R> extends DefaultSearchFunctionHandler<T, R> {
 
 	@Override
+	@Cacheable(value="staticcodevalues", 
+		key = "#executionContext.getCommandMessage().getCommand().getFirstParameterValue(\"where\")", 
+		condition= "T(org.apache.commons.lang3.StringUtils).equalsIgnoreCase(#executionContext.getCommandMessage().getCommand().getElementSafely(T(com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type).DomainAlias).getAlias(), \"staticCodeValue\")")
 	public R execute(ExecutionContext executionContext, Param<T> actionParameter) {
 		
 		ModelConfig<?> mConfig = getRootDomainConfig(executionContext);


### PR DESCRIPTION
Hi @jayantchaudhuri, per our discussion checking in the change to cache the static code value lookup calls see if it helps with performance. if perf shows improvement, we can discuss and optimize the caching settings/impl.