### PR TITLE
Bugfix/zdt

### DIFF
--- a/nimbus-core/pom.xml
+++ b/nimbus-core/pom.xml
@@ -14,6 +14,13 @@
 		<sonar.coverage.exclusions>src/main/java/com/antheminc/oss/nimbus/entity/**/*.java</sonar.coverage.exclusions>
 	</properties>
 
+	<dependencies>
+		<dependency>
+	        <groupId>com.fasterxml.jackson.datatype</groupId>
+	        <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+	</dependencies>
+	
     <build>
 	     <plugins>
 			<plugin>

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/WebConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/WebConfig.java
@@ -38,6 +38,7 @@ import com.antheminc.oss.nimbus.support.json.CustomLocalDateTimeSerializer;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * Configures classloader to load resources from custom locations
@@ -74,6 +75,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 				jacksonObjectMapperBuilder.serializationInclusion(Include.NON_NULL);
 				jacksonObjectMapperBuilder.featuresToEnable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 				jacksonObjectMapperBuilder.featuresToDisable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+				jacksonObjectMapperBuilder.featuresToDisable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
 
 				jacksonObjectMapperBuilder.deserializerByType(LocalDate.class, new CustomLocalDateDeserializer());
 				jacksonObjectMapperBuilder.serializerByType(LocalDate.class, new CustomLocalDateSerializer());
@@ -82,6 +84,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 						new CustomLocalDateTimeDeserializer());
 				jacksonObjectMapperBuilder.serializerByType(Date.class, new CustomDateSerializer());
 				jacksonObjectMapperBuilder.deserializerByType(Date.class, new CustomDateDeserializer());
+				jacksonObjectMapperBuilder.modules(new JavaTimeModule());
 			}
 
 		};

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/calendar.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/calendar.component.ts
@@ -21,6 +21,7 @@ import { WebContentSvc } from '../../../../services/content-management.service';
 import { BaseControl } from './base-control.component';
 import { ControlSubscribers } from './../../../../services/control-subscribers.service';
 import { ValidationConstraint } from '../../../../shared/validationconstraints.enum';
+import { ParamUtils } from './../../../../shared/param-utils';
 
 /**
  * \@author Sandeep Mantha
@@ -51,8 +52,8 @@ export const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR: any = {
 
         </nm-input-label>
         <p-calendar [(ngModel)]="value"  
-            (onSelect)="emitValueChangedEvent(this,$event)"
-            (change)="emitValueChangedEvent(this,$event)"
+            (onSelect)="handleValueChange($event)"
+            (change)="handleValueChange($event)"
             [showIcon]="true"
             [timeOnly]="element.config?.uiStyles?.attributes?.timeOnly"
             [showTime]="element.config?.uiStyles?.attributes?.showTime" 
@@ -94,4 +95,10 @@ export class Calendar extends BaseControl<Date> {
         }
     }
 
+    handleValueChange($event: any) {
+        if (this.element && this.element.config && ParamUtils.shouldUseBrowserTimeZone(this.element.config.type.name)) {
+            ParamUtils.setDateJsonHandler(this.value);
+        }
+        this.emitValueChangedEvent(this, $event)
+    }
 }

--- a/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
@@ -20,6 +20,7 @@ import { ServiceConstants } from '../services/service.constants';
 import { Param } from './param-state';
 import { LabelConfig } from './param-config';
 import { UiNature } from './param-config';
+import * as moment from 'moment';
 
 /**
  * \@author Tony.Lopez
@@ -35,7 +36,7 @@ export class ParamUtils {
         DATE:               { name: 'Date', defaultFormat: 'MM/dd/yyyy hh:mm a' },
         LOCAL_DATE:         { name: 'LocalDate', defaultFormat: 'MM/dd/yyyy' },
         LOCAL_DATE_TIME:    { name: 'LocalDateTime', defaultFormat: 'MM/dd/yyyy hh:mm a' },
-        ZONED_DATE_TIME:    { name: 'ZonedDateTime', defaultFormat: 'MM/dd/yyyy hh:mm a' },
+        ZONED_DATE_TIME:    { name: 'ZonedDateTime', defaultFormat: 'MM/dd/yyyy hh:mm a', useBrowserTimezone: true },
     };
 
     public static DEFAULT_DATE_FORMAT: string = 'MM/dd/yyyy hh:mm a';
@@ -109,7 +110,19 @@ export class ParamUtils {
                 break;
             }
         }
+        if (ParamUtils.shouldUseBrowserTimeZone(typeClassMapping)) {
+            ParamUtils.setDateJsonHandler(convertedDate);
+        }
         return convertedDate;
+    }
+
+    public static shouldUseBrowserTimeZone(typeClassMapping: string) {
+        let dateTypeMetadata = ParamUtils.getDateTypeConfig(typeClassMapping);
+        return dateTypeMetadata ? dateTypeMetadata.useBrowserTimezone : undefined;
+    }
+
+    public static setDateJsonHandler(date: Date): void {
+        date.toJSON = function() { return moment(this).format(); }
     }
 
     /**

--- a/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
@@ -92,21 +92,24 @@ export class ParamUtils {
         }
 
         var serverDateTime = new Date(value);
+        let convertedDate;
         switch(typeClassMapping) {
             case ParamUtils.DATE_TYPE_METADATA.LOCAL_DATE.name: {
-                return new Date(serverDateTime.getUTCFullYear(), serverDateTime.getUTCMonth(), serverDateTime.getUTCDate());
+                convertedDate = new Date(serverDateTime.getUTCFullYear(), serverDateTime.getUTCMonth(), serverDateTime.getUTCDate());
+                break;
             }
-
             case ParamUtils.DATE_TYPE_METADATA.LOCAL_DATE_TIME.name: {
-                return new Date(serverDateTime.getUTCFullYear(), serverDateTime.getUTCMonth(), serverDateTime.getUTCDate(), 
+                convertedDate = new Date(serverDateTime.getUTCFullYear(), serverDateTime.getUTCMonth(), serverDateTime.getUTCDate(), 
                     serverDateTime.getHours(), serverDateTime.getMinutes(), serverDateTime.getSeconds());
+                break;
             }
-
             default: {
-                return new Date(serverDateTime.getFullYear(), serverDateTime.getMonth(), serverDateTime.getDate(), 
+                convertedDate = new Date(serverDateTime.getFullYear(), serverDateTime.getMonth(), serverDateTime.getDate(), 
                     serverDateTime.getHours(), serverDateTime.getMinutes(), serverDateTime.getSeconds());
+                break;
             }
         }
+        return convertedDate;
     }
 
     /**
@@ -117,13 +120,18 @@ export class ParamUtils {
      * @param typeClassMapping the class type of the server date object
      */
     public static getDateFormatForType(typeClassMapping: string): string {
+        let dateTypeMetadata = ParamUtils.getDateTypeConfig(typeClassMapping);
+        return dateTypeMetadata ? dateTypeMetadata.defaultFormat : null;
+    }
+
+    private static getDateTypeConfig(typeClassMapping: string): any {
         for(let x in ParamUtils.DATE_TYPE_METADATA) {
             let dateTypeMetadata = ParamUtils.DATE_TYPE_METADATA[x];
             if (dateTypeMetadata.name === typeClassMapping) {
-                return dateTypeMetadata.defaultFormat;
+                return dateTypeMetadata;
             }
         }
-        return null;
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

 - Fixed an issue where `@Calendar` as `ZonedDateTime` did not store the browser time zone.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

## Serverside changes
- Added `JavaTimeModule` to Framework object mapper
  - Disabled Jackson deserialization check for timezone so that timezones sent from the UI are set when received on the server
  - `ZonedDateTime` objects will now be stored correctly in the db like the following:

```json
{
    "_date" : ISODate("2018-11-16T23:23:00.000Z"),
    "_zone" : "-06:00"
}
```
## UI changes
- Overrode the date objects native `toJSON()` in params where a `ZonedDateTime` is used
  - `ZonedDateTime` will now be sent from the UI as: `2018-11-16T17:23:00-06:00`
  - `Date`, `LocalDate`, and `LocalDateTime` will continue to be sent as: `2018-11-16T23:23:00.000Z`

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Functional testing in Petclinic

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

- This issue was related to a client application issue where the browser time zone was always being retrained as `UTC` in the db whenever a user made a change on the UI to a `ZoneDateTime` object. Consequently, when trying to send the data from server to a third party system, the necessary zone information was lost.
