### PR TITLE
lombok v1.16.20 requires a new property to generate @ConstructorProperties

### DIFF
--- a/nimbus-core/lombok.config
+++ b/nimbus-core/lombok.config
@@ -1,0 +1,2 @@
+lombok.anyConstructor.addConstructorProperties=true
+config.stopBubbling = true


### PR DESCRIPTION
# Description
After spring boot upgrade, there was an JSON parse error when using GenericExecute. Based on lombok's release notes -  v1.16.20 requires a new property to generate @ConstructorProperties

https://github.com/rzwitserloot/lombok/issues/1563
https://projectlombok.org/changelog (v1.16.20 (January 9th, 2018))

JSON parse error: Cannot construct instance of `com.antheminc.oss.nimbus.domain.cmd.exec.ExecuteOutput$BehaviorExecute` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator); nested exception is com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.antheminc.oss.nimbus.domain.cmd.exec.ExecuteOutput$BehaviorExecute` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator) at [Source: java.io.PushbackInputStream@8da77ed; line: 1, column: 17] (through reference chain: com.antheminc.oss.nimbus.domain.cmd.exec.ExecuteOutput$GenericExecute["result"]->java.util.LinkedHashMap["0"])

# Overview of Changes
Added lombok.config file with properties:
lombok.anyConstructor.addConstructorProperties=true
config.stopBubbling = true
# Type of Change

- [ ] Bug fix
- [ ] Other

# Test Details


N/A

N/A
