### PR TITLE
Fixes applyValueStyles space replacement issue

### DIFF
--- a/nimbus-ui/nimbusui/src/app/directives/display-value.directive.ts
+++ b/nimbus-ui/nimbusui/src/app/directives/display-value.directive.ts
@@ -79,7 +79,7 @@ export class DisplayValueDirective {
      */
     getValue(val: any): any {
         var re = / /gi;
-        if (val instanceof String) {
+        if (typeof val === 'string') {
             return val.replace(re, "");
         } else {
             return val;


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixed an issue where using `applyValueStyles` in `@GridColumn` for the value of `On Hold` was nonfunctional

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

- Modified `display-value.directive.ts` to use `typeof` instead of `instaceof String`

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Functional testing in Pet Clinic application

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

There was an issue where using `applyValueStyles` in `@GridColumn` for the value of `On Hold` was delivering the following browser error:

```
{"stack":"Error: Failed to execute 'add' on 'DOMTokenList': The token provided ('On Hold') contains HTML space characters, which are not valid in tokens.
    at e.addClass (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:1087728)
    at e.addClass (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:2339959)
    at e.ngOnChanges (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:1982014)
    at http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:325709
    at http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:325807
    at ea (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:327130)
    at Ma (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:335155)
    at Object.updateDirectives (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:2115094)
    at Object.updateDirectives (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:331942)
    at Xr (http://localhost:8080/petclinic/main.83110ba23dbc1f916935.js:1:323711)","message":"Failed to execute 'add' on 'DOMTokenList': The token provided ('On Hold') contains HTML space characters, which are not valid in tokens.","name":"InvalidCharacterError","logData":"Uncaught Exception"}
```
