### PR TITLE
refresh scope changes for defaultcorebuilder

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreBuilderConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreBuilderConfig.java
@@ -22,14 +22,17 @@ import java.util.Map;
 
 import javax.validation.Constraint;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.core.env.PropertyResolver;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.context.DefaultBeanResolverStrategy;
@@ -67,18 +70,18 @@ import lombok.Setter;
 @EnableConfigurationProperties
 @ConfigurationProperties(prefix="domain.model")
 @Getter @Setter
+@RefreshScope
 @EnableAspectJAutoProxy(proxyTargetClass=true)
 public class DefaultCoreBuilderConfig {
 	
 	private Map<String, String> typeClassMappings;
-	
+
 	private List<String> basePackages;
 	
 	private List<String> basePackagesToExclude;
 	
 	@Value("${platform.config.secure.regex}")
 	private String secureRegex;
-	
 	
 	@Bean	
 	public BeanResolverStrategy defaultBeanResolver(ApplicationContext appCtx) {
@@ -90,7 +93,8 @@ public class DefaultCoreBuilderConfig {
 		return new ChangeLogCommandEventHandler(beanResolver);
 	}
 	
-	@Bean
+	@Bean(name="default.DomainConfigBuilder")
+	@RefreshScope
 	public DomainConfigBuilder domainConfigBuilder(EntityConfigBuilder configBuilder){
 		return new DomainConfigBuilder(configBuilder, basePackages, basePackagesToExclude);
 	}
@@ -167,9 +171,4 @@ public class DefaultCoreBuilderConfig {
 		return new SecurityUtils(secureRegex);
 	}
 	
-	@Bean
-	public DefaultLoggingInterceptor defaultLoggingHandler() {
-		return new DefaultLoggingInterceptor();
-	}
-
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreConfiguration.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreConfiguration.java
@@ -48,6 +48,7 @@ import com.antheminc.oss.nimbus.domain.rules.DefaultRulesEngineFactoryProducer;
 import com.antheminc.oss.nimbus.domain.rules.drools.DecisionTableConfigBuilder;
 import com.antheminc.oss.nimbus.domain.rules.drools.DrlConfigBuilder;
 import com.antheminc.oss.nimbus.domain.rules.drools.DroolsRulesEngineFactory;
+import com.antheminc.oss.nimbus.support.DefaultLoggingInterceptor;
 import com.antheminc.oss.nimbus.support.pojo.JavaBeanHandler;
 import com.antheminc.oss.nimbus.support.pojo.JavaBeanHandlerReflection;
 
@@ -158,7 +159,11 @@ public class DefaultCoreConfiguration {
 			public Optional<TemporalAccessor> getNow() {
 				return Optional.of(ZonedDateTime.now());
 			}
-		};
-	}
+	    };
+    }
 	
+	@Bean
+	public DefaultLoggingInterceptor defaultLoggingHandler() {
+		return new DefaultLoggingInterceptor();
+	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreConfiguration.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultCoreConfiguration.java
@@ -163,7 +163,7 @@ public class DefaultCoreConfiguration {
     }
 	
 	@Bean
-	public DefaultLoggingInterceptor defaultLoggingHandler() {
-		return new DefaultLoggingInterceptor();
-	}
+ 	public DefaultLoggingInterceptor defaultLoggingHandler() {
+ 		return new DefaultLoggingInterceptor();
+ 	}
 }


### PR DESCRIPTION
# Description
Added refresh scope to refresh the Defaultcorebuilder bean when the base packages change.

# Overview of Changes
Refresh scope is added to Defaultconfigbuilder bean and the defaultcorebuilderconfig class. The class needs the refresh scope as the properties are not getting refreshed on deleting.

N/A

# Type of Change
New feature-

# Test Details
Used Petclinic app to demonstrate this change

N/A

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
