### PR TITLE
Grid multi-select header checkbox to select all records in dataset based on`headerCheckboxToggleAllPages` attribute in @Grid

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -1195,6 +1195,15 @@ public class ViewConfig {
 		boolean showHeader() default true;
 
 		String url() default "";
+		
+		/**
+		 * @Since 1.1.11
+		 * Setting this to true will enable to select all the records in the dataset i.e across all pages 
+		 * within a table when selectAll checkbox in the header is checked. 
+		 * Default behavior is to select all the records only within the current  
+		 * page of the table when the table is paginated.
+		 */
+		boolean headerCheckboxToggleAllPages() default false;
 	}
 
 	/**

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/header-checkbox.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/header-checkbox.component.ts
@@ -22,7 +22,20 @@ import { Param } from '../../../../shared/param-state';
 
 /**
  * \@author Purna
+ * 
+ * \@author Swetha Vemuri
+ * 
  * \@whatItDoes 
+ * 
+ * Custom implementation for a select-all checkbox in a table header
+ * which overrides prime-ng's default implementation of selecting all the records in a paginated dataset when checked. 
+ * This component provides the capability to configure the behaviour of select-all checkbox in the table header
+ * based on the boolean value of grid attribute - `headerCheckboxToggleAllPages`.
+ * When the attribute is set to true the behavior is to select data in all pages in a dataset.
+ * When set to false (default) the behavior is to select only records within the current page (when table is paginated)
+ * and not to select all the records in a dataset.
+ * Primeng provides <p-tableHeaderCheckbox> with the default behavior
+ * of selecting all the records in a dataset when checked.
  * 
  * \@howToUse 
  * 
@@ -66,39 +79,61 @@ export class HeaderCheckBox {
         this.headerChckbxState = false;
     }
   }
-
+  /**
+   * Method to compute and set the state of select-all checkbox whenever a page is changed in a paginated table.
+   */
   pageChangeSubscription() {
     let firstEle = this.dt.first;
     this.dt.onPage.subscribe(val => {
-      const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue:this.dt.value;
-
-      if (this.currentSelection.length > 0 && this.currentSelection[0] === filteredValues[val.first]) {
-        this.dt.selection = this.currentSelection;
-        this.headerChckbxState = true;
-        firstEle = val.first;
-        return;
-      } 
-      if (firstEle !== val.first) {
-        this.dt.selection = [];
-        this.headerChckbxState = false;
-        firstEle = val.first;
+      const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue : this.dt.value;
+      if (!this.isHeaderCheckboxToggleAllPages()) {
+        /** If the current page is same as the header check box selected page, retain the selection */
+        if (this.currentSelection.length > 0 && this.currentSelection[0] === filteredValues[val.first]) {
+          this.dt.selection = this.currentSelection;
+          this.headerChckbxState = true;
+          firstEle = val.first;
+          return;
+        }
+        /** If the current page is different from the header check box selected page, uncheck the header checkbox,
+         * also do not retain any individual row selections */
+        if (firstEle !== val.first) {
+          this.dt.selection = [];
+          this.headerChckbxState = false;
+          firstEle = val.first;
+        }
+      } else {
+        if (this.currentSelection.length > 0 && this.currentSelection.length === filteredValues.length) {
+          this.dt.selection = this.currentSelection;
+          firstEle = val.first;
+          return;
+        }
       }
     });
   }
-
+  /**
+   * Enters the method whenever any selection changes on the table. It can be a single row or all rows in the page/table
+   * 
+   */
   selectionChangeSubscription() {
     this.dt.selectionChange.subscribe(val => {
       const pageSize = this.element.config.uiStyles.attributes.pageSize;
       let allMatch = true;
       const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue: this.dt.value;
+      /* The outer for loop checks for all rows within the current page*/
       for (let i = this.dt.first; i < filteredValues.length && i < (this.dt.first + pageSize); i++) {
         let found = false;
-       
+
+        /* Inner loop is for the value that subscribed for selection change.
+        It can be a single value or an array of values. 
+        This checks if the selection is made for all rows within the page or only a few */
         for (let j = 0; j < val.length; j++) {
           if (filteredValues[i] === val[j]) {
             found = true;
           }
         }
+        /** found = true if all values in page are selected. 
+         *  found = false when only some values have been selected in the current page.
+         */
         if (!found) {
           this.headerChckbxState = false;
           allMatch = false;
@@ -106,18 +141,26 @@ export class HeaderCheckBox {
           break;
         }
       }
+      /** If all the rows in the current page are selected, update table selection & 
+       *  set headerChckbxState to true if `headerCheckboxToggleAllPages` is false
+      */
       if (allMatch) {
-        this.headerChckbxState = true;
-        if (this.currentSelection.length === 0) {
-              this.updateDtSelection();
+        if (!this.isHeaderCheckboxToggleAllPages()) {
+          this.headerChckbxState = true;
+          if (this.currentSelection.length === 0) {
+            this.updateDtSelection();
+          }
         }
       }
     });
   }
 
+  /**
+   * Whenever any filter on the table is triggered, reset the selectAll checkbox on the header to unchecked state.
+   */
   filterChangeSubscription() {
     this.dt.onFilter.subscribe(val => {
-        this.headerChckbxState = false;
+      this.headerChckbxState = false;
     });
   }
 
@@ -136,6 +179,9 @@ export class HeaderCheckBox {
     };
   }
 
+  /** Invoke this method when selectAll checkbox id checked in header of the table.
+   * When the checkbox is selected, `check` parameter is false.
+   */
   selectingAll(event, check) {
     if (check) {
       this.dt.selection = [];
@@ -147,12 +193,23 @@ export class HeaderCheckBox {
     this.onClickSelectAll(event, !check);
   }
 
+  /**
+   * Update the DataTable selection (dt.selection) with the selected values.
+   * Before 1.2.0 - Update dt.selection with the current page values only.
+   * Since 1.2.0 - Based on the grid attribute `headerCheckboxToggleAllPages` - when set to true,
+   * update the dt.selection with data from all pages in the dataset.
+   */
   updateDtSelection() {
     this.dt.selection = [];
-    const pageSize = this.element.config.uiStyles.attributes.pageSize;
-    const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue:this.dt.value;
-    for (let i = this.dt.first; i < filteredValues.length && i < (this.dt.first + pageSize); i++) {
-        this.dt.selection.push(filteredValues[i]);
+    const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue : this.dt.value;
+
+    const startSelection = this.isHeaderCheckboxToggleAllPages() ? 0 : this.dt.first;
+    const maxRowsAllowed = this.getMaxRowsAllowed(filteredValues.length);
+    for (let i = startSelection ; i < filteredValues.length && i < maxRowsAllowed; i++) {
+      /** If `headerCheckboxToggleAllPages`  is true (startSelection = 0) - add all filtered records in all pages to selection*/
+      /** If `headerCheckboxToggleAllPages` is false (startSelection = this.dt.first) i.e first record of current page
+       * - add filtered records in just the current page to the selection */
+      this.dt.selection.push(filteredValues[i]);
     }
     this.currentSelection = this.dt.selection;
   }
@@ -161,5 +218,21 @@ export class HeaderCheckBox {
     if (this.dt.value && this.dt.value.length > 0) {
       this.dt.toggleRowsWithCheckbox(event, !check);
     }
+  }
+
+  /**
+   * Return the allowed size of data that can be selected based on the grid attribute `headerCheckboxToggleAllPages`
+   * @param filteredValuesLength
+   */
+  getMaxRowsAllowed(filteredValuesLength: number): number {
+    const pageSize = this.element.config.uiStyles.attributes.pageSize;
+    if (!this.element.config.uiStyles.attributes.headerCheckboxToggleAllPages) {
+      return this.dt.first + pageSize;
+    }
+      return filteredValuesLength;
+  }
+
+  isHeaderCheckboxToggleAllPages(): boolean {
+    return this.element.config.uiStyles.attributes.headerCheckboxToggleAllPages;
   }
 }

--- a/nimbus-ui/nimbusui/src/app/shared/param-config.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-config.ts
@@ -224,7 +224,7 @@ export class UiAttribute implements Serializable<UiAttribute,string> {
     autoPrint: boolean;
     dataEntryField: boolean;
     fixLayout: boolean;
-    
+    headerCheckboxToggleAllPages: boolean;
     deserialize( inJson ) {
         let obj = this;
         obj = Converter.convert(inJson,obj);


### PR DESCRIPTION
# Description
Providing support for multi-select header checkbox to select all records in the dataset (including all pages in a paginated datatable) and also retain the individual record selection across pages. 

# Overview of Changes
Adding a new attribute `headerCheckboxToggleAllPages` in `@Grid` annotation. By default this is set to false. The behavior for the attribute is as follows:

- When set to true - when a user checks the select-all checkbox in the header, all the rows in the dataset across all pages are selected. Also, individual selection of records will be retained as user moves from page to page.

- When set to false - when a user checks the select-all checkbox in the header, all the rows in the current page are selected. (current default implementation)

# Type of Change
- [ ] New feature
- [ ] Documentation Update
- [ ] This change requires a documentation update

N/A

# Test Details


# Additional Notes
