### PR TITLE
Grid filter multi-select bugfix 

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/header-checkbox.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/header-checkbox.component.ts
@@ -57,7 +57,7 @@ export class HeaderCheckBox {
     this.updateToggleRowsWithCheckbox();
     // with below subscription on filter, the select-all checkbox is updated to 'unchecked' since 
     // filter would change the rows that are being displayed from what was selected before
-    this.filterChangeSubscribe(); 
+    this.filterChangeSubscription(); 
 
   }
 
@@ -71,7 +71,7 @@ export class HeaderCheckBox {
     let firstEle = this.dt.first;
     this.dt.onPage.subscribe(val => {
       const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue:this.dt.value;
-      
+
       if (this.currentSelection.length > 0 && this.currentSelection[0] === filteredValues[val.first]) {
         this.dt.selection = this.currentSelection;
         this.headerChckbxState = true;
@@ -115,7 +115,7 @@ export class HeaderCheckBox {
     });
   }
 
-  filterChangeSubscribe() {
+  filterChangeSubscription() {
     this.dt.onFilter.subscribe(val => {
         this.headerChckbxState = false;
     });

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/header-checkbox.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/header-checkbox.component.ts
@@ -55,6 +55,10 @@ export class HeaderCheckBox {
     this.pageChangeSubscription();
     this.selectionChangeSubscription();
     this.updateToggleRowsWithCheckbox();
+    // with below subscription on filter, the select-all checkbox is updated to 'unchecked' since 
+    // filter would change the rows that are being displayed from what was selected before
+    this.filterChangeSubscribe(); 
+
   }
 
   ngDoCheck(): void {
@@ -66,7 +70,9 @@ export class HeaderCheckBox {
   pageChangeSubscription() {
     let firstEle = this.dt.first;
     this.dt.onPage.subscribe(val => {
-      if (this.currentSelection.length > 0 && this.currentSelection[0] === this.dt.value[val.first]) {
+      const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue:this.dt.value;
+      
+      if (this.currentSelection.length > 0 && this.currentSelection[0] === filteredValues[val.first]) {
         this.dt.selection = this.currentSelection;
         this.headerChckbxState = true;
         firstEle = val.first;
@@ -84,10 +90,12 @@ export class HeaderCheckBox {
     this.dt.selectionChange.subscribe(val => {
       const pageSize = this.element.config.uiStyles.attributes.pageSize;
       let allMatch = true;
-      for (let i = this.dt.first; i < this.dt.value.length && i < (this.dt.first + pageSize); i++) {
+      const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue: this.dt.value;
+      for (let i = this.dt.first; i < filteredValues.length && i < (this.dt.first + pageSize); i++) {
         let found = false;
+       
         for (let j = 0; j < val.length; j++) {
-          if (this.dt.value[i] === val[j]) {
+          if (filteredValues[i] === val[j]) {
             found = true;
           }
         }
@@ -104,6 +112,12 @@ export class HeaderCheckBox {
               this.updateDtSelection();
         }
       }
+    });
+  }
+
+  filterChangeSubscribe() {
+    this.dt.onFilter.subscribe(val => {
+        this.headerChckbxState = false;
     });
   }
 
@@ -136,8 +150,9 @@ export class HeaderCheckBox {
   updateDtSelection() {
     this.dt.selection = [];
     const pageSize = this.element.config.uiStyles.attributes.pageSize;
-    for (let i = this.dt.first; i < this.dt.value.length && i < (this.dt.first + pageSize); i++) {
-        this.dt.selection.push(this.dt.value[i]);
+    const filteredValues: any[] = this.dt.filteredValue != null ? this.dt.filteredValue:this.dt.value;
+    for (let i = this.dt.first; i < filteredValues.length && i < (this.dt.first + pageSize); i++) {
+        this.dt.selection.push(filteredValues[i]);
     }
     this.currentSelection = this.dt.selection;
   }

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
@@ -555,6 +555,8 @@ export class DataTable extends BaseTableElement implements ControlValueAccessor 
     filterCallBack(e: any) {
         this.totalRecords = e.filteredValue.length;
         this.updatePageDetailsState();
+        this.selectedRows.length = 0
+        this.dt.toggleRowsWithCheckbox(e, true);
     }
 
     export() {


### PR DESCRIPTION
# Description
Bugfix for grid filter on multi-select checkbox to select only filtered values instead of all values. Previously, when a grid data is filtered using table filter and the filtered records are selected using multi-select checkbox, all the records in the grid were being selected. 
Original PR details:
https://github.com/openanthem/nimbus-core/pull/303

# Overview of Changes
Uncheck all the checked rows onFilter event - this is to prevent keeping
old rows that may not be on current page checked based on current filter
criteria. Also will prevent them from being submitted on post event.
Cherry-pick commits:
f938f47f86b29e9fb1b91d99b646ebfe80ddaef5
2e93d2cd8f6e07ea1e4f804abe4099f57e31f5fc
4e6f5caa04e7522089f8f4f943c35ef31bbe91d7 from original PR 
https://github.com/openanthem/nimbus-core/pull/303

# Type of Change
 [ ] Bug fix
N/A

# Test Details


# Additional Notes

N/A
