### PR TITLE
Missing dataEntryField attribute to MultiSelect component

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -2032,6 +2032,8 @@ public class ViewConfig {
 		String labelClass() default "anthem-label";
 
 		boolean postEventOnChange() default false;
+		
+		boolean dataEntryField() default true;
 
 	}
 


### PR DESCRIPTION
# Description
Adding the missing `dataEntryField` attribute to `@MultiSelect` viewconfig annotation, which is preventing the MultiSelect component from rendering in a form.

# Overview of Changes

# Type of Change
- [ ] Other

# Test Details

N/A

# Additional Notes

