### PR TITLE
BugFix: Updating Page Labels when navigating between pages

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/base-label.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/base-label.component.ts
@@ -57,6 +57,13 @@ export class BaseLabel {
                 }
             }
         });
+        /* Update the labels when the domain is routed to a new page. In this case, there is no param event update,
+        hence an event is emitted explicitly in PageResolver */
+        this._wcs.routeLabelUpdate$.subscribe(event => {
+            if (event.labels && event.labels.length !== 0) {
+                this.loadLabelConfig(event);
+            }
+        });
     }
 
     /**	

--- a/nimbus-ui/nimbusui/src/app/components/platform/content/page-content.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/content/page-content.component.html
@@ -2,12 +2,8 @@
 <nm-message messageContext="{{element?.message.context}}" [messageArray]="element?.message.messageArray" [life]="element?.message.life"  *ngIf="element?.message"></nm-message>
 
 <ng-template [ngIf]="element?.visible" [nmPrint]="element" [isPage]="true">
-    <ng-template [ngIf]="element?.config?.labelConfigs?.length > 0">
-        <!-- <h1 class="page-title {{imgSrc}} ">
-            {{label}}
-        </h1> -->
-        <nm-label *ngIf="!isLabelEmpty" [element]="element" [labelClass]="imgSrc + ' page-title'" [size]="labelSize"></nm-label>
-    </ng-template>
+   
+    <nm-label *ngIf="!isLabelEmpty" [element]="element" [labelClass]="imgSrc + ' page-title'" [size]="labelSize"></nm-label>
 
     <nm-tile [element]="tile" *ngFor="let tile of tilesList" [ngClass]="tile.config.uiStyles.attributes.size" [position]="position+1" [nmPrint]="tile"></nm-tile>
 </ng-template>

--- a/nimbus-ui/nimbusui/src/app/components/platform/content/page-resolver.service.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/content/page-resolver.service.ts
@@ -48,11 +48,13 @@ export class PageResolver implements Resolve<Param> {
         //let flow = route.parent.data['domain'];
         let flow = route.parent.url[0]['path'];
         return this._pageSvc.getPageConfigById(pageId, flow).then(page => {
-            if (page) {
+           if (page) {
                 let labelConfig: LabelConfig = this._wcs.findLabelContent(page);
                 let labelText = page.config.code;
                 if (labelConfig.text && labelConfig.text.trim().length > 0) {
                     labelText = labelConfig.text;
+                    /** Emit an event explicitly when route is navigated, since it is not a param update */
+                    this._wcs.routeLabelUpdate.next(page);
                 }
                 // Push the home breadcrumb into memory under the domain name.
                 this._breadcrumbService.push(page.config.code, labelText, route['_routerState'].url);

--- a/nimbus-ui/nimbusui/src/app/services/content-management.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/content-management.service.ts
@@ -21,6 +21,7 @@ import { ServiceConstants } from './service.constants';
 import { LabelConfig } from './../shared/param-config';
 import { Param } from './../shared/param-state';
 import { Converter } from './../shared/object.conversion';
+import { Subject } from 'rxjs';
 
 /**
  * \@author Dinakar.Meda
@@ -32,6 +33,9 @@ import { Converter } from './../shared/object.conversion';
  */
 @Injectable()
 export class WebContentSvc {
+
+    routeLabelUpdate = new Subject<Param>();
+    routeLabelUpdate$ = this.routeLabelUpdate.asObservable();
 
 	constructor() {
 


### PR DESCRIPTION
# Description
Bugfix: Updating/Refreshing the Page label when navigating between different pages.

Earlier: When navigating through different pages, the label of the page does not update for the respective page and instead stays at the label for the first initiated page. The label updates only when the page is refreshed.

# Overview of Changes
Since the label changes were only subscribed to param event updates, any route changes (i.e page navigations using menu links) were not emitting any events and hence the labels were not being refreshed. 

Change made to emit a routeLabelUpdate event whenever a page is resolved (PageResolver) and subscribing to the corresponding event in base label component.

# Type of Change
- [ ] Bug fix

# Test Details
page-resolver.service.spec.ts
