### PR TITLE
Reset Message state in JSONSerialization

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/support/DefaultJsonParamSerializer.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/support/DefaultJsonParamSerializer.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.function.Supplier;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Grid;
@@ -108,7 +109,13 @@ public class DefaultJsonParamSerializer extends JsonSerializer<Param<?>> {
 			if(ArrayUtils.isNotEmpty(activeValidationGroups))
 				gen.writeObjectField(K_ACTIVE_VALS, p.getActiveValidationGroups());
 			
-			writer.writeObjectIfNotNull(K_MESSAGE, p::getMessages);
+			if(CollectionUtils.isNotEmpty(p.getMessages())) {
+				writer.writeObjectIfNotNull(K_MESSAGE, p::getMessages);
+				// Resetting the message in param, so that once the message is read through the http response, it is removed from param state.
+				/* TODO Scenarios where further conditional processing is done based on the message text needs to be addressed,
+				 since the message state has been reset. There will be a sync issue until a state is reloaded and message is set.*/
+				p.setMessages(null);
+			}
 			writer.writeObjectIfNotNull(K_VALUES, p::getValues);
 			writer.writeObjectIfNotNull(K_LABELS, p::getLabels);
 			writer.writeObjectIfNotNull(K_STYLE, p::getStyle);

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageAqua.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageAqua.java
@@ -11,6 +11,7 @@ import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
 import com.antheminc.oss.nimbus.domain.defn.extension.LabelConditional;
 import com.antheminc.oss.nimbus.domain.defn.extension.LabelConditional.Condition;
 import com.antheminc.oss.nimbus.domain.defn.extension.MessageConditional;
+import com.antheminc.oss.nimbus.domain.defn.extension.Rule;
 import com.antheminc.oss.nimbus.domain.defn.extension.Style;
 import com.antheminc.oss.nimbus.domain.defn.extension.StyleConditional;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
@@ -103,6 +104,9 @@ public class VPSampleViewPageAqua {
 			private String p7_messagetest;
 			
 			private String p8_message;
+			
+			@Rule("p9_message_onload")
+			private String p9_message;
 			
 		}
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
@@ -1,0 +1,114 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.apache.commons.lang.StringUtils;
+import org.hamcrest.core.IsNull;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.Message;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.scenarios.s0.view.VRSampleViewRootEntity;
+
+/**
+ * @author Swetha Vemuri
+ * This test case demonstrates the message reset in DefaultJsonParamSerializer
+ */
+@AutoConfigureMockMvc
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MessageEventHandlerTest extends AbstractFrameworkIngerationPersistableTests {
+	
+	@Autowired
+	private MockMvc mvc;
+	
+	private MockHttpServletRequest createRequest(String domainPath, Action a) {
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(domainPath)
+				.addAction(a).getMock();
+		
+		return req;
+	}
+	
+	@Test
+	public void t00_messageState_json_get() throws Exception{
+		domainRoot_refId = createOrGetDomainRoot_RefId();
+		assertNotNull(domainRoot_refId);
+		
+		String uri; 
+		MockHttpServletRequest req;
+		uri = VIEW_PARAM_ROOT + ":"+domainRoot_refId+"/page_aqua/vtAqua/vsSampleForm/vfSampleForm/testWarningTextBox";
+		req = createRequest(uri, Action._update);
+		
+		final Object update_resp = controller.handlePost(req, "101");
+		Object ob = ExtractResponseOutputUtils.extractOutput(update_resp);
+		assertNotNull(ob);
+		uri = VIEW_PARAM_ROOT+":"+domainRoot_refId;
+		// _get call the first time runs the message conditional on param and sets the message on testWarningTextBox to true
+		Object root_getResp = controller.handleGet(createRequest(uri, Action._get), null);
+		assertNotNull(root_getResp);
+		Param<VRSampleViewRootEntity> view = ExtractResponseOutputUtils.extractOutput(root_getResp, 0);
+		Param<?> testWarningTextBox_p = view.findParamByPath("/page_aqua/vtAqua/vsSampleForm/vfSampleForm/testWarningTextBox");
+		assertNotNull(testWarningTextBox_p.getMessages());
+		assertEquals(1, testWarningTextBox_p.getMessages().size());
+		Message msg = testWarningTextBox_p.getMessages().stream()
+			.filter(m -> StringUtils.equalsIgnoreCase("This is a Test Warning Message", m.getText())).findFirst().get();		
+		assertEquals("This is a Test Warning Message",msg.getText());
+		
+		// to simulate the _get call with JsonSerializer
+		mvc.perform(get(createRequest(uri, Action._get).getRequestURI())
+				.contentType(APPLICATION_JSON_UTF8))
+               	.andExpect(status().isOk())
+               	.andExpect(jsonPath("$.result.0.result.outputs[0].value.type.model.params[4].type.model.params[0].type.model.params[0].type.model.params[0].type.model.params[0].message[0].text", IsNull.notNullValue()))
+               	.andReturn()
+               	.getResponse()
+               	.getContentAsString()
+               ;
+		
+		// After JSONSerialization, the message state is set to null
+		assertNull(view.findParamByPath("/page_aqua/vtAqua/vsSampleForm/vfSampleForm/testWarningTextBox").getMessages());
+	}
+	
+	@Test
+	public void t02_messageState_json_onload() throws Exception{
+		MockHttpServletRequest home_newReq = createRequest(VIEW_PARAM_ROOT, Action._new);
+		mvc.perform(get(home_newReq.getRequestURI())
+				.contentType(APPLICATION_JSON_UTF8))
+               	.andExpect(status().isOk())
+               	.andExpect(jsonPath("$.result.0.result.outputs[0].value.type.model.params[4].type.model.params[0].type.model.params[0].type.model.params[0].type.model.params[9].message[0].text", IsNull.notNullValue()))
+               	.andReturn()
+               	.getResponse()
+               	.getContentAsString()
+               ;
+		
+	}
+}

--- a/nimbus-test/src/test/resources/p9_message_onload.drl
+++ b/nimbus-test/src/test/resources/p9_message_onload.drl
@@ -1,0 +1,24 @@
+//created on: Jan 10, 2019
+package com.antheminc.oss.nimbus.test
+
+import com.antheminc.oss.nimbus.domain.model.state.internal.DefaultModelState;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.internal.DefaultParamState;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.Message;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.Message.Context;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.Message.Type;
+
+import java.util.HashSet;
+import java.util.Set;
+
+rule "Set Message on p9_message on new"
+
+    when
+        $param: DefaultParamState()
+    then
+    	String text = "Test Message on load";
+        Message msg = new Message(text, text, Type.INFO, Context.TOAST,null);
+        Set<Message> msgs = new HashSet<Message>();
+        msgs.add(msg);
+        $param.setMessages(msgs);
+end


### PR DESCRIPTION
# Description
Reset messages on param once the json response has been created, such that message state is not retained in the param by the server side. This ensures that when a message is set on a param, the message does not get displayed on UI every time a user navigates to the page where the param has the message.
# Overview of Changes
Setting messages on param to null in DefaultJsonParamSerializer.

# Type of Change
- [ ] New feature
- [ ] This change requires a documentation update

# Test Details
MessageEventHandlerTest.java

# Additional Notes
TODO : Scenarios where further conditional processing is done based on the message text needs to be addressed, since the message state has been reset. There will be a sync issue until a state is reloaded and message is set.
