### PR TITLE
NIMBUS-2:: Additional test cases - DomainPathResolver to resolve cross domain paths 

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilder.java
@@ -18,6 +18,7 @@ package com.antheminc.oss.nimbus.domain.cmd;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -56,6 +57,26 @@ public class CommandBuilder {
 		CommandBuilder cb = new CommandBuilder(new Command(absoluteUri));
 		cb.handleUriAndParamsIfAny(absoluteUri);
 		return cb;
+	}
+	
+	public static CommandBuilder withCommand(Command cmd) {
+		CommandBuilder cb = new CommandBuilder(cmd);
+		cb.handleUriAndParamsIfAny(cmd.getAbsoluteUri());
+		return cb;
+	}
+	
+	/**
+	 * Builds a CommandBuilder by appending a given platform path to a uri untill a given end CommandElementType 
+	 * @param rootCmd
+	 * @param endWhenType
+	 * @param appendPath
+	 * @return
+	 */
+	public static CommandBuilder withPlatformRelativePath(Command rootCmd, Type endWhenType, String appendPath) {
+		String hostUri = rootCmd.buildUri(endWhenType);
+		StringBuilder absoluteUri = new StringBuilder(hostUri);
+		absoluteUri.append(appendPath);
+		return withUri(absoluteUri.toString());	
 	}
 	
 	public static CommandBuilder withDomainRelativePath(Command rootCmd, String domainRelPath) {
@@ -233,4 +254,13 @@ public class CommandBuilder {
 		return this;
 	}
 	
+	public CommandBuilder setAction(Action action) {
+		cmd.setAction(action);
+		return withCommand(cmd);
+	}
+	
+	public CommandBuilder setBehaviors(List<Behavior> behaviors) {
+		cmd.setBehaviors(behaviors);
+		return withCommand(cmd);
+	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
@@ -27,8 +27,15 @@ import org.springframework.core.env.PropertyResolver;
 
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.Behavior;
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
+import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessageConverter;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandPathVariableResolver;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ParamPathExpressionParser;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
@@ -59,12 +66,14 @@ public class DefaultCommandPathVariableResolver implements CommandPathVariableRe
 	private final PropertyResolver propertyResolver;
 	private final SessionProvider sessionProvider;
 	private final Environment environment;
+	private final CommandExecutorGateway executorGateway;
 	
 	public DefaultCommandPathVariableResolver(BeanResolverStrategy beanResolver, PropertyResolver propertyResolver) {
 		this.converter = beanResolver.get(CommandMessageConverter.class);
 		this.propertyResolver = propertyResolver;
 		this.sessionProvider = beanResolver.get(SessionProvider.class);
 		this.environment = beanResolver.get(Environment.class);
+		this.executorGateway = beanResolver.find(CommandExecutorGateway.class);
 	}
 	
 	
@@ -126,6 +135,9 @@ public class DefaultCommandPathVariableResolver implements CommandPathVariableRe
 		if(StringUtils.startsWithIgnoreCase(pathToResolve, Constants.MARKER_ELEM_ID.code)) 
 			return mapColElem(param, pathToResolve);
 		
+		if(StringUtils.startsWithIgnoreCase(pathToResolve, Constants.SEGMENT_PLATFORM_MARKER.code))
+			return String.valueOf(mapCrossDomain(param, pathToResolve));
+		
 		return mapQuad(param, pathToResolve);
 	}
 	
@@ -149,12 +161,17 @@ public class DefaultCommandPathVariableResolver implements CommandPathVariableRe
 	protected String mapQuad(Param<?> param, String pathToResolve) {
 		if(StringUtils.startsWith(pathToResolve, "json(")) {
 			String paramPath = StringUtils.substringBetween(pathToResolve, "json(", ")");
-			Param<?> p = param.findParamByPath(paramPath) != null? param.findParamByPath(paramPath): param.getParentModel().findParamByPath(paramPath);
-			if(p == null) {
-				logit.error(() -> new StringBuffer().append(" Param (using paramPath) ").append(paramPath).append(" not found from param reference: ").append(param).toString());
-				return NULL_STRING;
+			Object state;
+			if (StringUtils.startsWithIgnoreCase(paramPath, Constants.SEGMENT_PLATFORM_MARKER.code)) {
+				state = mapCrossDomain(param, paramPath);
+			} else {
+				Param<?> p = param.findParamByPath(paramPath) != null? param.findParamByPath(paramPath): param.getParentModel().findParamByPath(paramPath);
+				if(p == null) {
+					logit.error(() -> new StringBuffer().append(" Param (using paramPath) ").append(paramPath).append(" not found from param reference: ").append(param).toString());
+					return NULL_STRING;
+				}				
+				state = p.getLeafState();
 			}
-			Object state = p.getLeafState();
 			String json = getConverter().toJson(state);
 			return String.valueOf(json);
 		} else {
@@ -178,5 +195,38 @@ public class DefaultCommandPathVariableResolver implements CommandPathVariableRe
 		
 		// throw ex ..or.. blank??
 		return "";
+	}
+	
+	/**
+	 * 
+	 * @param commandParam
+	 * @param pathToResolve
+	 * @return
+	 * @since 1.1.11
+	 */
+	protected Object mapCrossDomain(Param<?> commandParam, String pathToResolve) {
+		String hostUri = commandParam.getRootExecution().getRootCommand().buildUri(Type.AppAlias);
+		StringBuilder uri = new StringBuilder(hostUri);
+		uri.append(pathToResolve);
+		/* action */
+		uri.append(Constants.SEPARATOR_URI.code).append(Action._get.name()); // /_get
+		
+		/* behavior */
+		uri.append(Constants.REQUEST_PARAMETER_MARKER.code).append(Constants.MARKER_URI_BEHAVIOR.code)
+			.append(Constants.PARAM_ASSIGNMENT_MARKER.code); // ?b=
+		uri.append(Behavior.$state.name()); // '$state'
+				
+		Command cmd = CommandBuilder.withUri(uri.toString()).getCommand();
+		CommandMessage cmdMsg = new CommandMessage(cmd, null);		
+		MultiOutput output = executorGateway.execute(cmdMsg);
+		Object response = output.getSingleResult();
+		
+		if (response == null) {
+			logit.error(() -> new StringBuffer().append(" Param (using paramPath) [").append(pathToResolve).append("] not found from param: ").append(commandParam).toString());
+			return null;
+		}
+		
+		logit.debug(() -> new StringBuffer().append(" Param (using paramPath) [").append(pathToResolve).append("] has been resolved to ").append(response).toString());
+		return response;
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
@@ -15,6 +15,8 @@
  */
 package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -208,15 +210,10 @@ public class DefaultCommandPathVariableResolver implements CommandPathVariableRe
 		String hostUri = commandParam.getRootExecution().getRootCommand().buildUri(Type.AppAlias);
 		StringBuilder uri = new StringBuilder(hostUri);
 		uri.append(pathToResolve);
-		/* action */
-		uri.append(Constants.SEPARATOR_URI.code).append(Action._get.name()); // /_get
 		
-		/* behavior */
-		uri.append(Constants.REQUEST_PARAMETER_MARKER.code).append(Constants.MARKER_URI_BEHAVIOR.code)
-			.append(Constants.PARAM_ASSIGNMENT_MARKER.code); // ?b=
-		uri.append(Behavior.$state.name()); // '$state'
-				
 		Command cmd = CommandBuilder.withUri(uri.toString()).getCommand();
+		cmd.setAction(Action._get);
+		cmd.setBehaviors(new LinkedList<>(Arrays.asList(Behavior.$state)));
 		CommandMessage cmdMsg = new CommandMessage(cmd, null);		
 		MultiOutput output = executorGateway.execute(cmdMsg);
 		Object response = output.getSingleResult();

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandPathVariableResolver.java
@@ -207,13 +207,11 @@ public class DefaultCommandPathVariableResolver implements CommandPathVariableRe
 	 * @since 1.1.11
 	 */
 	protected Object mapCrossDomain(Param<?> commandParam, String pathToResolve) {
-		String hostUri = commandParam.getRootExecution().getRootCommand().buildUri(Type.AppAlias);
-		StringBuilder uri = new StringBuilder(hostUri);
-		uri.append(pathToResolve);
-		
-		Command cmd = CommandBuilder.withUri(uri.toString()).getCommand();
-		cmd.setAction(Action._get);
-		cmd.setBehaviors(new LinkedList<>(Arrays.asList(Behavior.$state)));
+		Command rootCmd = commandParam.getRootExecution().getRootCommand();
+		CommandBuilder cmdBuilder = CommandBuilder.withPlatformRelativePath(rootCmd, Type.AppAlias, pathToResolve);
+		cmdBuilder.setAction(Action._get);
+		cmdBuilder.setBehaviors(new LinkedList<>(Arrays.asList(Behavior.$state)));
+		Command cmd = cmdBuilder.getCommand();
 		CommandMessage cmdMsg = new CommandMessage(cmd, null);		
 		MultiOutput output = executorGateway.execute(cmdMsg);
 		Object response = output.getSingleResult();

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleCrossDomain.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleCrossDomain.java
@@ -1,0 +1,60 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.crossdomainresolver.view;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Model;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Cache;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * @author Swetha Vemuri
+ *
+ */
+@Domain(value="sample_crossdomain_pathresolver") 
+@Repo(value=Database.rep_none, cache=Cache.rep_device)
+@Getter @Setter @ToString
+public class VRSampleCrossDomain {
+	
+	private String language;
+	
+	private SampleNested nested;
+	
+	private List<String> simple_coll;
+	
+	private List<SampleNested> nested_coll;
+	
+	private Long count;
+	
+	private LocalDate date_attr;
+		
+	@Getter @Setter @Model 
+	@AllArgsConstructor @ToString @NoArgsConstructor
+	public static class SampleNested {
+		private String attr_1;
+		private String attr_2;
+	}
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleMultiDomain.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleMultiDomain.java
@@ -27,6 +27,7 @@ import com.antheminc.oss.nimbus.domain.defn.extension.ConfigConditional;
 import com.antheminc.oss.nimbus.domain.defn.extension.ConfigConditionals;
 import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
 import com.antheminc.oss.nimbus.test.scenarios.crossdomainresolver.view.VRSampleCrossDomain.SampleNested;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -95,4 +96,17 @@ public class VRSampleMultiDomain {
 	private String attr8_date_action;
 	
 	private LocalDate attr8;
+	
+	@Config(url="/attr9_string/_replace?rawPayload=\"<!/p/sample_core:<!/../attr9_id!>/attr_String!>\"")
+	private String attr9_crossdomain_refId_action;
+	
+	@Config(url="/attr9/_replace?rawPayload=<!json(/p/sample_core:<!/../attr9_id!>)!>")
+	private String attr9_crossdomain_with_refId_nested_action;
+	
+	private SampleCoreEntity attr9;
+	
+	private String attr9_string;
+	
+	private Long attr9_id;
+	
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleMultiDomain.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleMultiDomain.java
@@ -1,0 +1,87 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.crossdomainresolver.view;
+
+import java.util.List;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Cache;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.defn.extension.ConfigConditional;
+import com.antheminc.oss.nimbus.domain.defn.extension.ConfigConditionals;
+import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
+import com.antheminc.oss.nimbus.test.scenarios.crossdomainresolver.view.VRSampleCrossDomain.SampleNested;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * @author Swetha Vemuri
+ *
+ */
+@Domain(value="sample_multi_domain") 
+@Repo(value=Database.rep_none, cache=Cache.rep_device)
+@Getter @Setter @ToString
+public class VRSampleMultiDomain {
+	
+	@Label("This label is shown in {<!/p/sample_crossdomain_pathresolver/language!>}")
+	private String attr1;
+	
+	@ConfigConditionals({
+		@ConfigConditional(when="findStateByPath('/../attr1') == 'English'", config = { 
+				@Config(url = "/attr3/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/language!> Breakfast\"")}),
+		@ConfigConditional(when="findStateByPath('/../attr1') == 'French'", config = { 
+				@Config(url = "/attr3/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/language!> Pastries\"")}),
+	})
+	private String attr2_conditional_action;
+	
+	@Config(url = "/attr3/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/language!> Breakfast\"")
+	private String attr2_action;
+	
+	private String attr3;
+	
+	@Config(url="/nested_attr4/_replace?rawPayload=<!json(/p/sample_crossdomain_pathresolver/nested)!>")
+	private String nested_attr4_action_complex;
+	
+	@Config(url="/attr3/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/nested/attr_1!>\"")
+	private String nested_attr4_action;
+	
+	@Config(url="/nested_attr4_test/_replace?rawPayload=<!json(/../nested_attr4)!>")
+	private String test;
+	
+	private SampleNested nested_attr4;
+	
+	private SampleNested nested_attr4_test;
+	
+	@Config(url="/coll_attr5/_replace?rawPayload=<!json(/p/sample_crossdomain_pathresolver/simple_coll)!>")
+	private String coll_attr5_action_complex;
+	
+	@Config(url="/attr3/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/simple_coll/1!>\"")
+	private String coll_attr5_action;
+	
+	private List<String> coll_attr5;
+	
+	@Config(url="/nested_coll_attr6/_replace?rawPayload=<!json(/p/sample_crossdomain_pathresolver/nested_coll)!>")
+	private String nested_coll_attr6_action_complex;
+	
+	@Config(url="/attr3/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/nested_coll/1/attr_2!>\"")
+	private String nested_coll_attr6_action;
+	
+	private List<SampleNested> nested_coll_attr6;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleMultiDomain.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/view/VRSampleMultiDomain.java
@@ -15,6 +15,7 @@
  */
 package com.antheminc.oss.nimbus.test.scenarios.crossdomainresolver.view;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import com.antheminc.oss.nimbus.domain.defn.Domain;
@@ -84,4 +85,14 @@ public class VRSampleMultiDomain {
 	private String nested_coll_attr6_action;
 	
 	private List<SampleNested> nested_coll_attr6;
+	
+	@Config(url="/attr7/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/count!>\"")
+	private String attr7_long_action;
+	
+	private Long attr7;
+	
+	@Config(url="/attr8/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/date_attr!>\"")
+	private String attr8_date_action;
+	
+	private LocalDate attr8;
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -278,13 +279,42 @@ public class CrossDomainPathResolverTest extends AbstractStateEventHandlerTests 
 		assertEquals("yellow", multi_root_param.findParamByPath("/attr3").getState());
 	}
 	
+	@SuppressWarnings("unchecked")
 	@Test
 	public void t10_resolve_attr_long() {
-		//TODO
+		Param<Long> count_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/count");
+		count_param.setState(new Long("99"));
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/attr7_long_action", Action._get), null);	
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+		assertEquals(new Long("99"), multi_root_param.findParamByPath("/attr7").getState());
 	}
 	
+	@SuppressWarnings("unchecked")
 	@Test
 	public void t11_resolve_attr_date() {
-		//TODO
+		Param<LocalDate> date_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/date_attr");
+		LocalDate now = LocalDate.now();
+		date_param.setState(now);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/attr8_date_action", Action._get), null);	
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+		assertEquals(now, multi_root_param.findParamByPath("/attr8").getState());
 	}
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
@@ -1,0 +1,290 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.crossdomainresolver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.model.state.AbstractStateEventHandlerTests;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.session.TestSessionProvider;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.scenarios.crossdomainresolver.view.VRSampleCrossDomain.SampleNested;
+
+/**
+ * @author Swetha Vemuri
+ *
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class CrossDomainPathResolverTest extends AbstractStateEventHandlerTests {
+	
+	private final static String ENG_LANG = "English";
+	private final static String FRENCH_LANG = "French";
+	private final static String SAMPLE_VIEW_ROOT = "sample_crossdomain_pathresolver";
+	protected static final String SAMPLE_VIEW_PARAM_ROOT = PLATFORM_ROOT + "/" + SAMPLE_VIEW_ROOT;
+	private final static String SAMPLE_VIEW_MULTI_ROOT = "sample_multi_domain";
+	protected static final String SAMPLE_VIEW_MULTI_PARAM_ROOT = PLATFORM_ROOT + "/" + SAMPLE_VIEW_MULTI_ROOT;
+	
+	@Autowired
+	TestSessionProvider sessionProvider;
+	
+	@Override
+	protected Command createCommand() {
+		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_crossdomain_pathresolver/_new").getCommand();
+		return cmd;
+	}
+	
+	private MockHttpServletRequest createRequest(String domainPath, Action a) {
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(domainPath)
+				.addAction(a).getMock();
+		
+		return req;
+	}
+
+	@Test
+	public void t00_init() {
+		assertNotNull(_q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language"));
+		
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t01_resolve_label_name() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(ENG_LANG);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_new_resp).getState());
+		Param<?> param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(param.findParamByPath("/attr1").getLabel("en-US"));
+		assertEquals("This label is shown in {English}", param.findParamByPath("/attr1").getLabel("en-US").getText());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t02_resolve_parampath_rawPayload() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(ENG_LANG);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		Holder<MultiOutput> multi_action_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/attr2_action", Action._get), null);
+		assertNotNull(multi_action_get_resp);
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> attr2_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(attr2_param);
+		assertNotNull(attr2_param.findParamByPath("/attr3"));
+		assertNotNull(attr2_param.findParamByPath("/attr3").getLeafState());		
+		assertEquals("English Breakfast", attr2_param.findParamByPath("/attr3").getState());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t03_resolve_parampath_conditional() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(FRENCH_LANG);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		final MultiOutput output = MultiOutput.class.cast(Holder.class.cast(multi_new_resp).getState());
+		Param<?> param = (Param<?>) output.getSingleResult();
+		param.findParamByPath("/attr1").setState("French");
+		param.findParamByPath("/attr2_conditional_action").setState("test");
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> attr2_action_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(attr2_action_param);
+		assertEquals("French Pastries", attr2_action_param.findParamByPath("/attr3").getState());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t04_resolve_parampath_nested_attr_complex() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(FRENCH_LANG);
+		SampleNested sample_nested = new SampleNested("blue", "green");
+		_q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/nested").setState(sample_nested);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/nested_attr4_action_complex", Action._get), null);
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+		assertTrue(StringUtils.equalsIgnoreCase(sample_nested.getAttr_1(), (String)multi_root_param.findParamByPath("/nested_attr4/attr_1").getState()));
+		assertTrue(StringUtils.equalsIgnoreCase(sample_nested.getAttr_2(), (String)multi_root_param.findParamByPath("/nested_attr4/attr_2").getState()));
+		assertEquals("blue",(String)multi_root_param.findParamByPath("/nested_attr4/attr_1").getState());
+		assertEquals("green",(String)multi_root_param.findParamByPath("/nested_attr4/attr_2").getState());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t05_resolve_nested_attr_valid() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(FRENCH_LANG);
+		SampleNested sample_nested = new SampleNested("blue", "green");
+		_q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/nested").setState(sample_nested);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/nested_attr4_action", Action._get), null);
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+		assertEquals("blue", multi_root_param.findParamByPath("/attr3").getState());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t06_resolve_coll_attr_complex() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(FRENCH_LANG);
+		List<String> str_lst = new ArrayList<String>(Arrays.asList("latin","greek","spanish"));
+		_q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/simple_coll").findIfCollection().addAll(str_lst);
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/coll_attr5_action_complex", Action._get), null);
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t07_resolve_coll_attr_valid() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(FRENCH_LANG);
+		List<String> str_lst = new ArrayList<String>(Arrays.asList("latin","greek","spanish"));
+		_q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/simple_coll").findIfCollection().addAll(str_lst);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/coll_attr5_action", Action._get), null);
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+		assertEquals("greek", multi_root_param.findParamByPath("/attr3").getState());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t08_resolve_nested_coll_attr_invalid() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(FRENCH_LANG);
+		SampleNested sample_nested1 = new SampleNested("blue", "green");
+		SampleNested sample_nested2 = new SampleNested("red", "yellow");
+		SampleNested sample_nested3 = new SampleNested("grey", "black");
+		List<SampleNested> sample_nested_coll = new ArrayList<>();
+		sample_nested_coll.add(sample_nested1);
+		sample_nested_coll.add(sample_nested2);
+		sample_nested_coll.add(sample_nested3);
+		_q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/nested_coll").findIfCollection().addAll(sample_nested_coll);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/nested_coll_attr6_action_complex", Action._get), null);	
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+		assertTrue(StringUtils.equalsIgnoreCase(sample_nested_coll.get(0).getAttr_1(), (String)multi_root_param.findParamByPath("/nested_coll_attr6/0/attr_1").getState()));
+		assertTrue(StringUtils.equalsIgnoreCase(sample_nested_coll.get(1).getAttr_1(), (String)multi_root_param.findParamByPath("/nested_coll_attr6/1/attr_1").getState()));
+		assertTrue(StringUtils.equalsIgnoreCase(sample_nested_coll.get(2).getAttr_1(), (String)multi_root_param.findParamByPath("/nested_coll_attr6/2/attr_1").getState()));
+		
+		assertEquals("green",	(String)multi_root_param.findParamByPath("/nested_coll_attr6/0/attr_2").getState());
+		assertEquals("yellow",	(String)multi_root_param.findParamByPath("/nested_coll_attr6/1/attr_2").getState());
+		assertEquals("black",	(String)multi_root_param.findParamByPath("/nested_coll_attr6/2/attr_2").getState());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t09_resolve_nested_coll_attr_valid() {
+		Param<String> lang_param = _q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/language");
+		lang_param.setState(FRENCH_LANG);
+		SampleNested sample_nested1 = new SampleNested("blue", "green");
+		SampleNested sample_nested2 = new SampleNested("red", "yellow");
+		SampleNested sample_nested3 = new SampleNested("grey", "black");
+		List<SampleNested> sample_nested_coll = new ArrayList<>();
+		sample_nested_coll.add(sample_nested1);
+		sample_nested_coll.add(sample_nested2);
+		sample_nested_coll.add(sample_nested3);
+		_q.getRoot().findParamByPath("/sample_crossdomain_pathresolver/nested_coll").findIfCollection().addAll(sample_nested_coll);
+		
+		Holder<MultiOutput> multi_new_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._new), null);
+		assertNotNull(multi_new_resp);
+		
+		controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT+"/nested_coll_attr6_action", Action._get), null);	
+		
+		Holder<MultiOutput> multi_get_resp = (Holder<MultiOutput>) controller.handleGet(createRequest(SAMPLE_VIEW_MULTI_PARAM_ROOT, Action._get), null);
+		assertNotNull(multi_get_resp);
+		final MultiOutput singleOut = MultiOutput.class.cast(Holder.class.cast(multi_get_resp).getState());
+		Param<?> multi_root_param = (Param<?>) singleOut.getSingleResult();
+		assertNotNull(multi_root_param);
+		assertEquals("yellow", multi_root_param.findParamByPath("/attr3").getState());
+	}
+	
+	@Test
+	public void t10_resolve_attr_long() {
+		//TODO
+	}
+	
+	@Test
+	public void t11_resolve_attr_date() {
+		//TODO
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,10 @@
 		<dependency>
 			<groupId>org.owasp.esapi</groupId>
     		<artifactId>esapi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
 		</dependency>		
 	</dependencies>
 


### PR DESCRIPTION
# Description
Capability for DomainPathResolver to resolve cross domain paths.

Creating PR for 1.1.x branch with additional test cases (cross domain with refID).
Original PR to 1.1.11: https://github.com/openanthem/nimbus-core/pull/338

# Overview of Changes
NIMBUS-2 : Added a check in DefaultCommandPathVariableResolver to resolve cross domain paths.
Ex: `@Config(url="/attr3/_replace?rawPayload=\"<!/p/sample_crossdomain_pathresolver/nested/attr_1!>\"")`
`@Config(url="/attr9/_replace?rawPayload=<!json(/p/sample_core:<!/../attr9_id!>)!>")`
# Type of Change
- Testcase update

# Test Details
CrossDomainPathResolverTest.java

