### PR TITLE
NIMBUS-96:: Updates the regex for aggregate query match

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByQuery.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByQuery.java
@@ -57,7 +57,7 @@ public class MongoSearchByQuery extends MongoDBSearch {
 
 	private static final ScriptEngine groovyEngine = new ScriptEngineManager().getEngineByName("groovy");
 	
-	private static final String AGGREGATION_QUERY_REGEX = ".*aggregate\\s*:.*";
+	private static final String AGGREGATION_QUERY_REGEX = ".*\"?aggregate\"?\\s*:.*";
 	private static final Pattern AGGREGATION_QUERY_REGEX_PATTERN = Pattern.compile(AGGREGATION_QUERY_REGEX, Pattern.CASE_INSENSITIVE | Pattern.DOTALL | Pattern.MULTILINE);
 
 	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
@@ -264,7 +264,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		createQueues();
 		
 		String query = "{" + 
-				"    \"aggregate\" : \"clientusergroup\"," + 
+				"    aggregate : \"clientusergroup\"," + 
 				"    \"pipeline\" : [ " + 
 				"        {" + 
 				"			$match: {" + 

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/chart/SampleChartDataSetTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/chart/SampleChartDataSetTest.java
@@ -46,7 +46,7 @@ public class SampleChartDataSetTest  extends AbstractFrameworkIntegrationTests {
 		// if the aggregation query is used to get the data group, the param type must be List<DataGroup> just like @Grid param
 		
 		String request = "/samplechart/_search?fn=query&where={\n" + 
-				"    aggregate: \"samplechart\",\n" + 
+				"    aggregate : \"samplechart\",\n" + 
 				"    pipeline: [\n" + 
 				"	    {\n" + 
 				"			$match: {\n" + 


### PR DESCRIPTION
# Description
The regex was not checking for if the aggregate word had been escaped. e.g \"aggregate\". This change fixes it.

# Type of Change
- [ ] Bug fix
- [ ] Test case change
