### PR TITLE
NIMBUS-10:: RichText Component (readonly support)

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -2425,6 +2425,12 @@ public class ViewConfig {
 		boolean postEventOnChange() default false;
 
 		/**
+		 * <p>Marks if this rich text box should be used in readonly mode. Using this mode will
+		 * simply display a readonly text field with the rich text formatting preserved.
+		 */
+		boolean readOnly() default false;
+		
+		/**
 		 * <p>The features to include when rendering the toolbar.<p>Features
 		 * will be rendered in the order they are configured.
 		 */

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/rich-text.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/rich-text.component.ts
@@ -57,13 +57,14 @@ export const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR: any = {
             (focusout)="emitValueChangedEvent(this, value)"
             [placeholder]="element?.config?.uiStyles?.attributes?.placeholder"
             [disabled]="!element?.enabled"
-            [readonly]="!element?.enabled"
+            [readonly]="!element?.enabled || element?.config?.uiStyles?.attributes?.readOnly"
+            [attr.readonly]="element?.config?.uiStyles?.attributes?.readOnly ? true : null"
             [style]="element?.config?.uiStyles?.attributes?.inlineStyle"
             [styleClass]="element?.config?.uiStyles?.attributes?.cssClass"
             [formats]="element?.config?.uiStyles?.attributes?.formats"
             >
             
-            <p-header>
+            <p-header [hidden]="element?.config?.uiStyles?.attributes?.readOnly">
                 <ng-template ngFor let-toolbarFeature [ngForOf]="element?.config?.uiStyles?.attributes?.toolbarFeatures">
 
                     <ng-template [ngIf]="toolbarFeature === 'HEADER'">
@@ -186,6 +187,10 @@ export class RichText extends BaseControl<String> {
     }
 
     ngOnInit() {
+
+        if (this.element.config.uiStyles.attributes.readOnly) {
+            return;
+        }
 
         let fontConfig = this.buildConfigFromNature(ViewConfig.fonts.toString());
         if (fontConfig) {


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* Includes support for `@RichText` for `readonly` mode

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Added `readonly` as an attribute
  * `@RichText` now supports the following scenarios:
    * Editable and Enabled
    * Editable and Disabled (displays the toolbar but is non-functional, e.g. user can not input)
    * Readonly and Enabled (effectively just a readonly field, but is not marked as form disabled)
    * Readonly and Disabled

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

N/A

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
