### PR TITLE
NIMBUS-64:: Rich Text Values Dropdown

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -2385,7 +2385,14 @@ public class ViewConfig {
 	public @interface RichText {
 
 		public enum ToolbarFeature {
-			ALIGN, BACKGROUND, BLOCKQUOTE, BOLD, CLEAN, CODE, CODE_BLOCK, COLOR, DIRECTION, FONT, HEADER, IMAGE, INDENT, ITALIC, LINK, LIST, SCRIPT, SIZE, STRIKE, UNDERLINE, VIDEO;
+			ALIGN, BACKGROUND, BLOCKQUOTE, BOLD, CLEAN, CODE, CODE_BLOCK, COLOR, DIRECTION, FONT, HEADER, IMAGE, INDENT,
+			/**
+			 * <p>Adds a combobox to the toolbar. Selected values from the
+			 * combobox will be inserted into the editor's last known cursor
+			 * position (at the start if untouched).</p><p>Values can be
+			 * supplied by decorating the field with {@link Values}.</p>
+			 */
+			VALUES_COMBOBOX, ITALIC, LINK, LIST, SCRIPT, SIZE, STRIKE, UNDERLINE, VIDEO;
 		}
 
 		String alias() default "RichText";

--- a/nimbus-ui/nimbusui/src/app/mockdata/rich-text.component.mockdata.spec.ts
+++ b/nimbus-ui/nimbusui/src/app/mockdata/rich-text.component.mockdata.spec.ts
@@ -27,7 +27,8 @@ export const MockRichText = {
                     "LINK",
                     "IMAGE",
                     "VIDEO",
-                    "CLEAN"
+                    "CLEAN",
+                    "VALUES_COMBOBOX"
                 ],
                 "formats": "",
                 "cssClass": "nm-sample-style-class",
@@ -53,6 +54,15 @@ export const MockRichText = {
         "locale": "en-US",
         "text": "Sample @RichText Component (w/ postEventOnChange = true)"
       }
+    ],
+    "values" : [
+        {
+            "label": "Value 1",
+            "code": "#{VALUE_1}"
+        }, {
+            "label": "Value 2",
+            "code": "#{VALUE_2}"
+        }
     ],
     "enabled": true,
     "visible": true,


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* `@RichText`
  * Added support for `ToolbarFeature.VALUES_COMBOBOX`

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Adds a combobox to the toolbar. Selected values from the combobox will be inserted:
  * into the editor's last known cursor position (at the start if untouched)
  * into the editor's previous highlighted text
* Values can be supplied by decorating the field with `@Values`.

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--

- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* Functional testing in Pet Clinic
* See `rich-text.component.spec.ts`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
