### PR TITLE
Nimbus-115:: Change Aggregate Query Implementation

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
@@ -99,6 +99,7 @@ public enum Constants {
 	SEARCH_REQ_PROJECT_MAPPING_MARKER("projection.mapsTo"),
 	
 	SEARCH_REQ_AGGREGATE_MARKER("aggregate"),
+	SEARCH_REQ_AGGREGATE_PIPELINE("pipeline"),
 	SEARCH_REQ_AGGREGATE_COUNT("count"),
 	
 	SEARCH_REQ_FETCH_MARKER("fetch"),

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByQuery.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByQuery.java
@@ -24,6 +24,7 @@ import javax.script.Bindings;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
@@ -185,11 +186,12 @@ public class MongoSearchByQuery extends MongoDBSearch {
 	private  <T> Object searchByAggregation(Class<?> referredClass, String alias, SearchCriteria<T> criteria) {
 		List<?> output = new ArrayList();
 		String cr = (String)criteria.getWhere();
-		
-		Document commndResult = getMongoOps().executeCommand(cr);
-				
-		if (commndResult != null && commndResult.get(Constants.SEARCH_NAMED_QUERY_RESULT.code) instanceof List) {
-			List<Document> result = (List<Document>)commndResult.get(Constants.SEARCH_NAMED_QUERY_RESULT.code);
+		Document query = Document.parse(cr);
+		List<Document> pipeline = (List<Document>)query.get(Constants.SEARCH_REQ_AGGREGATE_PIPELINE.code);
+		String aggregateCollection = query.getString(Constants.SEARCH_REQ_AGGREGATE_MARKER.code);
+		List<Document> result = new ArrayList<Document>();
+		getMongoOps().getCollection(aggregateCollection).aggregate(pipeline).iterator().forEachRemaining(a -> result.add(a));
+		if(CollectionUtils.isNotEmpty(result)) {
 			GenericType gt = getMongoOps().getConverter().read(GenericType.class, new org.bson.Document(GenericType.CONTENT_KEY, result));
 			output.addAll(gt.getContent());
 		}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
@@ -602,6 +602,22 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		List<Output<?>> ops  = multiOp.getOutputs();
 		
 		assertNotNull(ops);
+		
+		
+	}
+	
+	@Test
+	public void t21_testSearchByQueryAggregation() {
+		cleanInsertSampleCoreAccess(new String[] {"1","2","3","4","5","6"});
+		
+		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/sample_core_access/_search?fn=query&where={aggregate:\"sample_core_access\",pipeline:[{$match:{\"attr_String\":{$eq:\"1\"}}}]}");
+		
+		MultiOutput multiOp = this.commandGateway.execute(cmdMsg);
+		List<Output<?>> ops  = multiOp.getOutputs();
+		assertNotNull(ops);
+		List<SampleCoreEntityAccess> response = (List<SampleCoreEntityAccess>)ops.get(0).getValue();
+		assertNotNull(response);
+		assertEquals("1", response.get(0).getAttr_String());		
 	}
 
 	private void getFirstPage() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.runners.MethodSorters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
@@ -60,6 +61,7 @@ public class MessageEventHandlerTest extends AbstractFrameworkIngerationPersista
 	}
 	
 	@Test
+	@WithMockUser(username="user", password="pwd")
 	public void t00_messageState_json_get() throws Exception{
 		domainRoot_refId = createOrGetDomainRoot_RefId();
 		assertNotNull(domainRoot_refId);
@@ -99,6 +101,7 @@ public class MessageEventHandlerTest extends AbstractFrameworkIngerationPersista
 	}
 	
 	@Test
+	@WithMockUser(username="user", password="pwd")
 	public void t02_messageState_json_onload() throws Exception{
 		MockHttpServletRequest home_newReq = createRequest(VIEW_PARAM_ROOT, Action._new);
 		mvc.perform(get(home_newReq.getRequestURI())


### PR DESCRIPTION
# Description
Changed mongo aggregate query call to use the **aggregate** method instead of **executeCommand** method from MongoTemplate. The executeCommand method executes queries with Inline cursor. With Mongo 3.6, inline cursors are not supported for aggregate queries. MongoTemplate's aggregate method uses appropriate cursor for querying the database

# Overview of Changes
MongoSearchByQuery.searchByAggregation updated to use aggregate method from MongoTemplate

N/A

# Type of Change
- [ ] New feature

N/A

# Test Details
DefaultActionExecutorSearchTest.t21_testSearchByQueryAggregation

N/A

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
