### PR TITLE
NIMBUS::103 fix to address state being reset using valuesconditional

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandler.java
@@ -98,9 +98,9 @@ public class ValuesConditionalStateEventHandler extends EvalExprWithCrudDefaults
 			// if there are no values set (default config values) OR
 			// if previously selected targetParam state is not in the list of
 			// new values. then reset to null.
-			String stateAsString = targetParam.getState() != null ? targetParam.getState().toString() : null;
-			if (null == targetParam.getValues() || (null != targetParam.getState() && !targetParam.getValues().stream()
-					.map(ParamValue::getCode).collect(Collectors.toList()).contains(stateAsString))) {
+			Object state = targetParam.getState() != null ? targetParam.getState() : null;
+			if (state instanceof String && (null == targetParam.getValues() || (null != targetParam.getState() && !targetParam.getValues().stream()
+					.map(ParamValue::getCode).collect(Collectors.toList()).contains(state.toString())))) {
 
 				targetParam.setState(null);
 			}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreValuesEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreValuesEntity.java
@@ -87,10 +87,17 @@ public class SampleCoreValuesEntity {
 		@ValuesConditional(targetPath = "/../contactStatus", resetOnChange = false, condition = {
 			@ValuesConditional.Condition(when = "state == 'changeit'", then = @Values(StatusPast.class))
 		})
+		@ValuesConditional(targetPath = "/../multiSelect", resetOnChange = false, condition = {
+				@ValuesConditional.Condition(when = "state == null", then = @Values(StatusFuture.class)),
+				@ValuesConditional.Condition(when = "state != null", then = @Values(StatusList.class))
+			})
 		private String contactType;
 		
 		@Values(StatusAll.class)
 		private Status contactStatus;
+		
+		@Values(StatusAll.class)
+		private String[] multiSelect;
 	}
 	
 	public static class SR_DEFAULT implements Source {
@@ -141,6 +148,26 @@ public class SampleCoreValuesEntity {
 		public List<ParamValue> getValues(String paramCode) {
 			final List<ParamValue> values = new ArrayList<>();
 			values.add(new ParamValue("PAST", "Past"));
+			return values;
+		}
+	}
+	
+	public static class StatusFuture implements Source {
+		@Override
+		public List<ParamValue> getValues(String paramCode) {
+			final List<ParamValue> values = new ArrayList<>();
+			values.add(new ParamValue("FUTURE", "Future"));
+			return values;
+		}
+	}
+	
+	public static class StatusList implements Source {
+		@Override
+		public List<ParamValue> getValues(String paramCode) {
+			final List<ParamValue> values = new ArrayList<>();
+			values.add(new ParamValue("FUTURE", "Future"));
+			values.add(new ParamValue("PAST", "Past"));
+			values.add(new ParamValue("CURRENT", "Current"));
 			return values;
 		}
 	}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
@@ -274,4 +274,23 @@ public class ValuesConditionalStateEventHandlerIntegTest extends AbstractStateEv
 		
 		Assert.assertEquals(Status.PAST, statusForm.findParamByPath("/contactStatus").getState());
 	}
+	
+	@Test
+	public void t12_arrayState() {
+		final Param<?> statusForm = _q.getRoot().findParamByPath(STATUS_FORM);
+		assertNotNull(statusForm);
+		
+		Assert.assertNotNull(statusForm.findParamByPath("/contactStatus").getValues());
+		Assert.assertNull(statusForm.findParamByPath("/contactStatus").getState());
+		String[] defaultState = {"FUTURE"};
+		statusForm.findParamByPath("/multiSelect").setState(defaultState);
+		
+		statusForm.findParamByPath("/contactType").setState("changeit");
+		Assert.assertEquals(3, statusForm.findParamByPath("/multiSelect").getValues().size());
+		Assert.assertEquals("FUTURE", statusForm.findParamByPath("/multiSelect").getValues().get(0).getCode());
+		Assert.assertEquals("PAST", statusForm.findParamByPath("/multiSelect").getValues().get(1).getCode());
+		Assert.assertEquals("CURRENT", statusForm.findParamByPath("/multiSelect").getValues().get(2).getCode());
+
+		Assert.assertEquals(defaultState, statusForm.findParamByPath("/multiSelect").getState());
+	}
 }


### PR DESCRIPTION
# Description
Param state was being reset when the dataType is String[] as there was code that was assuming that state is always string.


# Overview of Changes
Changed the logic to run for only string datatypes as for array list we might have to run through the scenarios and see If we want to do the same as well. If so, will create a separate feature and PR for it.

# Type of Change
- [ ] Bug fix

# Test Details
added test case t12_arrayState in the ValuesConditionalStateEventHandlerIntegTest class to depict this scenario.