### PR TITLE
NIMBUS-101:: selected attribute for tab component

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/content/tab.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/content/tab.component.ts
@@ -33,9 +33,9 @@ import { ViewComponent } from './../../../shared/param-annotations.enum';
     providers: [WebContentSvc],
     template: `    
                 <p-tabView *ngIf="element?.visible">  
-                   <ng-template ngFor let-tabPanel [ngForOf]="nestedParams">
+                   <ng-template ngFor let-tabPanel let-tabIndex="index" [ngForOf]="nestedParams">
                         <p-tabPanel *ngIf="tabPanel?.visible" [disabled]="!tabPanel?.enabled"
-                        [closable]="tabPanel?.config?.uiStyles?.attributes?.closable">
+                        [closable]="tabPanel?.config?.uiStyles?.attributes?.closable" [selected]="tabIndex == 0">
                         
                             <ng-template  pTemplate="header" > 
                                 <nm-label [element]="tabPanel"></nm-label>


### PR DESCRIPTION
# Description
There is a known issue with primeNG when dynamically creating tab panels.  Per their documentation we should have the selected property to avoid improper behavior.

The author of this pull request failed to include a description or DELETE this line.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

N/A

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

N/A

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

N/A

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
