### PR TITLE
URL Based Function Handler Fix for "p" alias calls

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/process/URLBasedAssignmentFunctionHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/process/URLBasedAssignmentFunctionHandler.java
@@ -47,14 +47,13 @@ abstract public class URLBasedAssignmentFunctionHandler<T,R,S> implements Functi
 	@SuppressWarnings("unchecked")
 	@Override
 	public R execute(ExecutionContext executionContext, Param<T> actionParameter) {
-		CommandMessage commandFromContext = null;
 		S state = null;
 		//TODO - Expose 2 other flavors for _set. 1. Set by value 2. Set by executing rule file.
 		//TODO - When we set by value, if the value is something like Status.INACTIVE, have to use querydsl replace or come up with some other approach
 		Param<S> targetParameter = findTargetParam(executionContext);
-		if(StringUtils.isNotBlank(executionContext.getCommandMessage().getCommand().getFirstParameterValue("value"))) {
-			commandFromContext =  executionContext.getCommandMessage();
-			state = (S) commandFromContext.getCommand().getFirstParameterValue("value");
+		String value = executionContext.getCommandMessage().getCommand().getFirstParameterValue(Constants.REQUEST_PARAMETER_VALUE_MARKER.code);
+		if (!StringUtils.isBlank(value)) {
+			state = (S) value;
 		} else {
 			state = isInternal(executionContext.getCommandMessage()) ? getInternalState(executionContext): getExternalState(executionContext);
 		}
@@ -102,7 +101,7 @@ abstract public class URLBasedAssignmentFunctionHandler<T,R,S> implements Functi
 
 	protected boolean isInternal(CommandMessage commandMessage){
 		String url = commandMessage.getCommand().getFirstParameterValue(Constants.REQUEST_PARAMETER_URL_MARKER.code);
-		if(StringUtils.startsWith(url, Constants.SEPARATOR_URI_PLATFORM.code)) {
+		if(StringUtils.startsWith(url, Constants.SEGMENT_PLATFORM_MARKER.code)) {
 			return false;
 		}
 		return true;

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
@@ -91,6 +91,7 @@ public enum Constants {
 	CLIENT_USER_KEY("client-user-key"),
 	
 	REQUEST_PARAMETER_URL_MARKER("url"),
+	REQUEST_PARAMETER_VALUE_MARKER("value"),
 	REQUEST_PARAMETER_DELIMITER("&"),
 	PARAM_ASSIGNMENT_MARKER("="),
 	


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* Fixed an issue where calling a `URLBasedFunctionHandler` with `url` starting with a domain alias like: `"/petclinic"` was inappropriately doing a cross domain fetch.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Replaced external check from`"/p"` to `"/p/"`
* Minor code cleanup

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

TODO

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
