### PR TITLE
Test support

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/CommandExecution.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/CommandExecution.java
@@ -15,6 +15,7 @@
  */
 package com.antheminc.oss.nimbus.domain.cmd.exec;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -22,10 +23,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.poi.ss.formula.functions.T;
 import org.springframework.util.CollectionUtils;
 
 import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.cmd.Behavior;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.ParamEvent;
 import com.antheminc.oss.nimbus.support.pojo.CollectionsTemplate;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -161,6 +165,25 @@ public final class CommandExecution {
 //				throw new IllegalStateException("Multi output contains more than one output elements: "+getOutputs());
 			
 			return getOutputs().get(0).getValue();
+		}
+		
+		@JsonIgnore
+		public List<Output<?>> findParamOutputsEndingWithPath(String path) {
+			List<Output<?>> result = new ArrayList<>();
+			for (Output<?> output : getOutputs()) {
+				if (output.getValue() instanceof Param) {
+					Param<?> param = (Param<?>) output.getValue();
+					if (!StringUtils.isEmpty(param.getPath()) && param.getPath().endsWith(path)) {
+						result.add(output);
+					}
+				}
+			}
+			return result;
+		}
+		
+		@JsonIgnore
+		public Output<?> findFirstParamOutputEndingWithPath(String path) {
+			return Optional.ofNullable(findParamOutputsEndingWithPath(path).get(0)).orElse(null);
 		}
 		
 	}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/pageobject/UnitTestPage.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/pageobject/UnitTestPage.java
@@ -258,14 +258,10 @@ public abstract class UnitTestPage {
 		}
 
 		final String sPayload;
-		if (payload.getClass().equals(String.class)) {
-			sPayload = (String) payload;
-		} else {
-			try {
-				sPayload = this.objectMapper.writeValueAsString(payload);
-			} catch (JsonProcessingException e) {
-				throw new RuntimeException("Failed to convert payload to string.", e);
-			}
+		try {
+			sPayload = this.objectMapper.writeValueAsString(payload);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Failed to convert payload to string.", e);
 		}
 
 		return sPayload;


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* Added changes for test support

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Added helper methods for test support
  * `MultiOutput#findFirstParamOutputEndingWithPath(String path)`
  * `MultiOutput#findParamOutputsEndingWithPath(String path)`
* Modified `ParamUtils#convertToStringPayload(Object payload)` to transform `String` types to their JSON equivalent. (e.g. the string `foo` should be transformed to `"foo"`)

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--

- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* Used in petclinic, will add a test case for this in framework later.

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

Introduced `findParamOutputsEndingWithPath(String path)` method to `MultiOutput` to help avoid brittle test cases where the `refId` was being retrieved in test cases by using either `getSingleResult()` or `getOutputs.get(HARD_CODED_INDEX)`.

**Sample Code Snippet:**
```java
Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handlePost(request, null);
Long refId = response.getState().findFirstParamOutputEndingWithPath("/petview").getRootDomainId();
```
