### PR TITLE
NIMBUS-121:: setState fix for unmapped nested entities with mapped children

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/ParamStateGateway.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/ParamStateGateway.java
@@ -27,7 +27,19 @@ public interface ParamStateGateway extends ParamStateRepository {
 	public <T> T getValue(ValueAccessor pd, Object target);	
 	public <T> void setValue(ValueAccessor pd, Object target, T value);
 	public <T> T instantiate(Class<T> clazz);
-
+	
+	/**
+	 * <p>Remove the state of the {@code param}. <p>This implementation will
+	 * simply sever the connection between the associated object stored in the
+	 * {@code param} state. If the state of {@code param} is an instance of
+	 * {@link Object}, then the state is nullified, allowing the garbage
+	 * collector to take over. If the state of {@code param} is a primitive
+	 * type, then the state is reset to it's default value (as defined by the
+	 * JVM for the provided primitive type).
+	 * @param param the {@link Param} instance to uninstantiate
+	 */
+	public <T> void uninstantiate(Param<T> param);
+	
 	default <M> M _instantiateOrGet(Param<M> param) {
 		M existing = _getRaw(param);
 		return (existing==null) ? _instantiateAndSet(param) : existing;

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/PrimitiveUtils.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/PrimitiveUtils.java
@@ -1,0 +1,63 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.support;
+
+/**
+ * <p>A utility class that provides support for primitive Java types.
+ * 
+ * @author Tony Lopez
+ *
+ */
+public class PrimitiveUtils {
+
+	private PrimitiveUtils() {
+	}
+
+	private static boolean DEFAULT_BOOLEAN;
+	private static byte DEFAULT_BYTE;
+	private static short DEFAULT_SHORT;
+	private static int DEFAULT_INT;
+	private static long DEFAULT_LONG;
+	private static float DEFAULT_FLOAT;
+	private static double DEFAULT_DOUBLE;
+
+	/**
+	 * <p>Get the default value as defined by the JVM for {@code clazz}, if it
+	 * is supported. If the provided type for {@code clazz} is not supported, an
+	 * {@link IllegalArgumentException} will be thrown.
+	 * @param clazz the type for which to retrieve the default value
+	 * @return the default value for {@code clazz}.
+	 */
+	public static Object getDefaultValue(Class<?> clazz) {
+		if (clazz.equals(boolean.class)) {
+			return DEFAULT_BOOLEAN;
+		} else if (clazz.equals(byte.class)) {
+			return DEFAULT_BYTE;
+		} else if (clazz.equals(short.class)) {
+			return DEFAULT_SHORT;
+		} else if (clazz.equals(int.class)) {
+			return DEFAULT_INT;
+		} else if (clazz.equals(long.class)) {
+			return DEFAULT_LONG;
+		} else if (clazz.equals(float.class)) {
+			return DEFAULT_FLOAT;
+		} else if (clazz.equals(double.class)) {
+			return DEFAULT_DOUBLE;
+		} else {
+			throw new IllegalArgumentException("Class type " + clazz + " not supported");
+		}
+	}
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreEntity.java
@@ -196,4 +196,10 @@ public class SampleCoreEntity extends IdLong {
 	private String testEntry;
 	
 	private List<String> attr_list_2_simple;
+	
+	private String p1;
+	
+	private String p2;
+	
+	private int p3;
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
@@ -23,6 +23,7 @@ import com.antheminc.oss.nimbus.domain.defn.MapsTo.Path;
 import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values;
 import com.antheminc.oss.nimbus.domain.defn.ViewConfig.ComboBox;
 import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Form;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.FormElementGroup;
 import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Grid;
 import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Section;
 import com.antheminc.oss.nimbus.domain.defn.ViewConfig.TextBox;
@@ -35,6 +36,7 @@ import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity.SampleForm;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreLevel1_Entity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleEntity;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -113,6 +115,40 @@ public class VPSampleViewPageGreen {
 		@ComboBox
 		@Values(url = "a/b/p/sampletask/_search?fn=lookup&orderby=sampletask.taskName.asc()&projection.mapsTo=code:id,label:taskName")
 		private List<String> sortedDynamicValues;
+		
+		@TextBox(postEventOnChange = true)
+		@Path
+		@ActivateConditional(when = "state == 'showit'", targetPath = "/../unmappedNested")
+		private String p1;
+		
+		@FormElementGroup
+		private SampleNestedGroup unmappedNested;
+	}
+	
+	@MapsTo.Type(SampleCoreEntity.class)
+	@Getter @Setter
+	public static class SampleNestedGroup {
+		
+		@TextBox(postEventOnChange = true)
+		@Path
+		private String p2;
+		
+		@TextBox(postEventOnChange = true)
+		@Path
+		private int p3;
+		
+		@FormElementGroup
+		@Path(linked = false)
+		private Group1 group1;
+		
+		@MapsTo.Type(SampleEntity.class)
+		@Getter @Setter
+		public static class Group1 {
+			
+			@TextBox
+			@Path("test_name")
+			private String p4;
+		}
 	}
 	
 	@MapsTo.Type(SampleCoreEntity.class)

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalNoConversionTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalNoConversionTest.java
@@ -15,8 +15,10 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -31,6 +33,7 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
 import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
+import com.antheminc.oss.nimbus.test.scenarios.s0.view.VPSampleViewPageGreen.SampleNestedGroup;
 
 /**
  * @author Soham Chakravarti
@@ -153,5 +156,85 @@ public class ActivateConditionalNoConversionTest extends AbstractStateEventHandl
 		
 		formwithgridsection.findParamByPath("/vfSearchForm/testEntry").setState("flip");
 		checkIsInactive(formwithgridsection.findParamByPath("/testGrid"));
+	}
+	
+	/**
+	 * <a href="https://anthemopensource.atlassian.net/browse/NIMBUS-121">https://anthemopensource.atlassian.net/browse/NIMBUS-121</a>
+	 * <p>Checks to ensure activate conditional works when targetting an unmapped nested param
+	 * that has children params in it's tree that are mapped.
+	 */
+	@Test
+	public void testUnmappedNestedParamWithMappedChildren() {
+		Param<String> p1 = _q.getRoot().findParamByPath("/sample_view/page_green/tile/view_sample_form/p1");
+		Param<SampleNestedGroup> unmappedNested = _q.getRoot().findParamByPath("/sample_view/page_green/tile/view_sample_form/unmappedNested");
+		Param<String> p2 = _q.getRoot().findParamByPath("/sample_view/page_green/tile/view_sample_form/unmappedNested/p2");
+		
+		checkIsInactive(unmappedNested);
+		checkIsInactive(p2);
+		assertNull(unmappedNested.getState());
+		assertNull(p2.getState());
+		
+		p1.setState("showit");
+		checkIsActive(unmappedNested);
+		checkIsActive(p2);
+		assertNull(unmappedNested.getState());
+		assertNull(p2.getState());
+		
+		p2.setState("p2 is set");
+		assertEquals("p2 is set", p2.getState());
+		
+		p1.setState(null);
+		checkIsInactive(unmappedNested);
+		checkIsInactive(p2);
+		assertNull(unmappedNested.getState());
+		assertNull(p2.getState());
+	}
+	
+	/**
+	 * <p>Checks to ensure activate conditional works when targetting an unmapped nested param
+	 * that has children params in it's tree that are mapped to a different domain than the parent mapping.
+	 */
+	@Test
+	public void testUnmappedNestedParamWithMultipleDomainMappedChildren() {
+		Param<String> p1 = _q.getRoot().findParamByPath("/sample_view/page_green/tile/view_sample_form/p1");
+		Param<String> p4 = _q.getRoot().findParamByPath("/sample_view/page_green/tile/view_sample_form/unmappedNested/group1/p4");
+		
+		checkIsInactive(p4);
+		assertNull(p4.getState());
+		
+		p1.setState("showit");
+		checkIsActive(p4);
+		assertNull(p4.getState());
+		
+		p4.setState("p4 is set");
+		assertEquals("p4 is set", p4.getState());
+		
+		p1.setState(null);
+		checkIsInactive(p4);
+		assertNull(p4.getState());
+	}
+	
+	/**
+	 * <p>Checks to ensure activate conditional works when targetting an unmapped nested param
+	 * that has children params in it's tree that are mapped to primitive types
+	 */
+	@Test
+	public void testUnmappedNestedParamWithMappedChildrenPrimitives() {
+		Param<String> p1 = _q.getRoot().findParamByPath("/sample_view/page_green/tile/view_sample_form/p1");
+		Param<Integer> p3 = _q.getRoot().findParamByPath("/sample_view/page_green/tile/view_sample_form/unmappedNested/p3");
+		
+		checkIsInactive(p3);
+		assertEquals(Integer.valueOf(0), p3.getState());
+		
+		p1.setState("showit");
+		checkIsActive(p3);
+		assertEquals(Integer.valueOf(0), p3.getState());
+		
+		p3.setState(42);
+		assertEquals(Integer.valueOf(42), p3.getState());
+		
+		p1.setState(null);
+		checkIsInactive(p3);
+		assertEquals(Integer.valueOf(0), p3.getState());
 	}
 }		


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* Fixes #393
* Fixes an issue where using an `@ActivateConditional` that targets a nested parameter having mapped children parameters would not reset the state of the children.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Adds a condition for invoking `setState` on all mapped children living under a view param when that view param's `setState` is invoked

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature

- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* See `ActivateConditionalNoConversionTest#testUnmappedNestedParamWithMappedChildren()`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A