### PR TITLE
NIMBUS-51: Display Labels when not decorated with @Label

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultFrameworkExtensionsConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultFrameworkExtensionsConfig.java
@@ -22,7 +22,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandPathVariableResolver;
 import com.antheminc.oss.nimbus.domain.defn.extension.ValidateConditional.ValidationScope;
+import com.antheminc.oss.nimbus.domain.model.config.extension.GridStateLoadHandler;
 import com.antheminc.oss.nimbus.domain.model.config.extension.LabelStateEventHandler;
 import com.antheminc.oss.nimbus.domain.model.state.extension.AccessConditionalStateEventHandler;
 import com.antheminc.oss.nimbus.domain.model.state.extension.ActivateConditionalStateEventHandler;
@@ -57,8 +59,13 @@ import com.antheminc.oss.nimbus.domain.model.state.internal.IdParamConverter;
 public class DefaultFrameworkExtensionsConfig {
 	
 	@Bean
-	public LabelStateEventHandler labelConfigEventHandler() {
-		return new LabelStateEventHandler();
+	public LabelStateEventHandler labelConfigEventHandler(CommandPathVariableResolver cmdPathResolver) {
+		return new LabelStateEventHandler(cmdPathResolver);
+	}
+	
+	@Bean
+	public GridStateLoadHandler gridStateLoadHandler(LabelStateEventHandler labelStateLoadHandler) {
+		return new GridStateLoadHandler(labelStateLoadHandler);
 	}
 	
 	@Bean

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/ViewConfig.java
@@ -25,10 +25,10 @@ import javax.validation.constraints.Future;
 import javax.validation.constraints.Past;
 
 import com.antheminc.oss.nimbus.domain.Event;
-import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
-import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Autocomplete;
+import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values;
 import com.antheminc.oss.nimbus.domain.defn.event.StateEvent.OnStateLoad;
 import com.antheminc.oss.nimbus.domain.defn.extension.ParamContext;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.ListParam;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -657,7 +657,6 @@ public class ViewConfig {
 	 * 
 	 * @since 1.3
 	 */
-	
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.FIELD })
 	@ViewStyle
@@ -1172,6 +1171,12 @@ public class ViewConfig {
 	 * following components: <ul> <li>{@link Form}</li> <li>{@link Section}</li>
 	 * </ul>
 	 * 
+	 * <p><b>Labels</b>
+	 * 
+	 * <p>Any labels defined within the <i>collection element</i> configuration
+	 * will be assigned to the decorated param and available via
+	 * {@link ListParam#getElemLabels()}.
+	 * 
 	 * <p><b>Configuring Row Item Display</b>
 	 * 
 	 * <p>The class being used in the decorated collection's parameterized type
@@ -1186,6 +1191,7 @@ public class ViewConfig {
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.FIELD })
 	@ViewStyle
+	@OnStateLoad
 	public @interface Grid {
 		String alias() default "Grid";
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/extension/GridStateLoadHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/extension/GridStateLoadHandler.java
@@ -1,0 +1,63 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.config.extension;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Grid;
+import com.antheminc.oss.nimbus.domain.model.config.ParamConfig;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.LabelState;
+import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnStateLoadHandler;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@RequiredArgsConstructor
+@Getter
+public class GridStateLoadHandler extends AbstractConfigEventHandler implements OnStateLoadHandler<Grid> {
+
+	private final LabelStateEventHandler labelStateLoadHandler;
+
+	public void onStateLoad(Grid configuredAnnotation, Param<?> param) {
+		// set the labels retrieved from collection elements
+		Map<String, Set<LabelState>> elemLabels = new HashMap<>();
+		ParamConfig<?> p = param.getConfig().getType().findIfCollection().getElementConfig();
+
+		if (!p.isLeaf()) {
+			for (ParamConfig<?> colElemParamConfig : p.getType().findIfNested().getModelConfig().getParamConfigs()) {
+				if (CollectionUtils.isNotEmpty(colElemParamConfig.getLabels())) {
+					Set<LabelState> listParamLabels = new HashSet<>();
+					colElemParamConfig.getLabels()
+							.forEach((label) -> listParamLabels.add(getLabelStateLoadHandler().convert(label, param)));
+					elemLabels.put(colElemParamConfig.getId(), listParamLabels);
+				}
+			}
+		}
+
+		param.findIfCollection().setElemLabels(elemLabels);
+	}
+
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/extension/LabelStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/extension/LabelStateEventHandler.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandPathVariableResolver;
@@ -34,14 +33,17 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.LabelState;
 import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnStateLoadHandler;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * @author Soham Chakravarti
- *
+ * @author Swetha Vemuri
+ * @author Tony Lopez
  */
+@RequiredArgsConstructor
 public class LabelStateEventHandler extends AbstractConfigEventHandler implements OnStateLoadHandler<Label> {
 
-	@Autowired
-	CommandPathVariableResolver cmdPathResolver;
+	private final CommandPathVariableResolver cmdPathResolver;
 
 	/**
 	 * <p>Add the label from {@code configuredAnnotation} to the label state of
@@ -112,9 +114,7 @@ public class LabelStateEventHandler extends AbstractConfigEventHandler implement
 	 * <p>Add {@code labelState} to the label state of {@code targetParam}.
 	 * <p>The argument {@code contextParam} is used to provide the "context"
 	 * from which to retrieve pathing details when resolving any framework or
-	 * placeholders within the previously provided {@link Label}. If this level
-	 * of control is not needed, consider using
-	 * {@link #validateAndAdd(LabelState, Param)}.
+	 * placeholders within the previously provided {@link Label}.
 	 * @param labelState the label state to add
 	 * @param contextParam the "context" from which any param path information
 	 *            should be retrieved
@@ -139,23 +139,6 @@ public class LabelStateEventHandler extends AbstractConfigEventHandler implement
 		Set<LabelState> labels = new HashSet<>();
 		if (!CollectionUtils.isEmpty(targetParam.getLabels()))
 			labels.addAll(targetParam.getLabels());
-
-		if (targetParam.isCollection()) {
-			Map<String, Set<LabelState>> elemLabels = new HashMap<>();
-			ParamConfig<?> p = targetParam.getConfig().getType().findIfCollection().getElementConfig();
-			
-			if (!p.isLeaf()) {
-				for(ParamConfig<?> paramConfig : p.getType().findIfNested().getModelConfig().getParamConfigs()) {
-					if (CollectionUtils.isNotEmpty(paramConfig.getLabels())) {
-						Set<LabelState> listParamLabels = new HashSet<>();
-						paramConfig.getLabels().forEach((label) -> listParamLabels.add(convert(label, contextParam)));
-						elemLabels.put(paramConfig.getId(), listParamLabels);
-					}
-				}
-			}
-
-			targetParam.findIfCollection().setElemLabels(elemLabels);
-		}
 
 		labels.add(labelState);
 		targetParam.setLabels(labels);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
@@ -566,6 +566,11 @@ public interface EntityState<T> {
 				this.locale = Locale.getDefault().toLanguageTag();
 			}
 			
+			public LabelState(String text) {
+				this();
+				this.text = text;
+			}
+			
 			@Override
 			public boolean equals(Object obj) {
 				if(obj==null && this.text==null)

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/labelstate/view/Sample_View_Label_Entity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/labelstate/view/Sample_View_Label_Entity.java
@@ -85,6 +85,9 @@ public class Sample_View_Label_Entity {
 	@Path("/attr1")
 	private String label_replace;
 	
+	@Grid
+	private List<Sample_View_Entity_2> collectionNoParentLabel; 
+	
 	@Model @Getter @Setter
 	public static class Sample_View_Nested_Label {
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelStateOnLoadEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelStateOnLoadEventHandlerTest.java
@@ -43,15 +43,18 @@ import com.antheminc.oss.nimbus.domain.defn.MapsTo.Type;
 import com.antheminc.oss.nimbus.domain.defn.Model;
 import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
 import com.antheminc.oss.nimbus.domain.model.config.ParamConfig;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.ListParam;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.LabelState;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ParamUtils;
 import com.antheminc.oss.nimbus.test.scenarios.labelstate.core.Sample_Core_Label_Entity;
 import com.antheminc.oss.nimbus.test.scenarios.labelstate.core.Sample_Core_Label_Entity.Nested_Attr;
 import com.antheminc.oss.nimbus.test.scenarios.labelstate.core.Sample_Core_Label_Entity.Nested_Attr_Level2;
 import com.antheminc.oss.nimbus.test.scenarios.labelstate.view.Sample_View_Label_Entity;
+import com.antheminc.oss.nimbus.test.scenarios.labelstate.view.Sample_View_Label_Entity.Sample_View_Entity_2;
 import com.antheminc.oss.nimbus.test.scenarios.labelstate.view.Sample_View_Label_Entity.Sample_View_Nested_Label;
 
 import lombok.Getter;
@@ -289,19 +292,7 @@ public class LabelStateOnLoadEventHandlerTest extends AbstractFrameworkIntegrati
 		assertNull(nested_coll_p.findParamByPath("/1").getLabels());	
 		
 		/*Elem labels*/
-		assertNotNull(nested_coll_p.findIfCollection().getElemLabels());
-		assertEquals(2,nested_coll_p.findIfCollection().getElemLabels().size());
-		ParamConfig<?> elemConfig_attr1 = getElemConfigByCode(nested_coll_p, "attr_nested_1");
-		ParamConfig<?> elemConfig_attr2 = getElemConfigByCode(nested_coll_p, "attr_nested_2");
-		
-		assertNotNull(nested_coll_p.findIfCollection().getElemLabels().get(Optional.ofNullable(elemConfig_attr1.getId()).orElse(null)));
-		assertTrue(nested_coll_p.findIfCollection().getElemLabels().containsKey(elemConfig_attr1.getId()));
-		assertEquals("Test label nested attr", getElemLabelState(nested_coll_p, Locale.getDefault(), elemConfig_attr1.getId()).getText());
-
-		assertNotNull(nested_coll_p.findIfCollection().getElemLabels().get(Optional.ofNullable(elemConfig_attr2.getId()).orElse(null)));
-		assertTrue(nested_coll_p.findIfCollection().getElemLabels().containsKey(elemConfig_attr2.getId()));
-		assertEquals("Test label nested level 2", getElemLabelState(nested_coll_p, Locale.getDefault(), elemConfig_attr2.getId()).getText());
-		
+		assertNull(nested_coll_p.findIfCollection().getElemLabels());		
 	}
 	
 	@Test
@@ -545,11 +536,28 @@ public class LabelStateOnLoadEventHandlerTest extends AbstractFrameworkIntegrati
 		assertEquals("This label color is null",getLabelState(label_a_p, Locale.getDefault()).getText());
 	}
 	
+	/**
+	 * https://anthemopensource.atlassian.net/browse/NIMBUS-51 When a collection
+	 * has a collection element that contains variables decorated with Label
+	 * then all the grid's columns should render the corresponding column labels
+	 */
 	@Test
-	public void t14_multiple_nested_coll_withstate() {}
-	
-	@Test
-	public void t14_multiple_nested_coll_withoutstate() {}
+	public void testCollectionElemLabels() {
+		Object response = prepareParam(VIEW_ROOT);
+		Param<Sample_View_Label_Entity> viewParam = ParamUtils.extractResponseByParamPath(response, "sample_view_label");
+		assertNotNull(viewParam);
+		
+		LabelState expected = new LabelState();
+		expected.setText("Test Label Nested level 2 attr");
+		
+		Param<Sample_View_Entity_2> collectionParam = viewParam.findParamByPath("/collectionNoParentLabel");
+		assertNull("Found labels but expected none.", collectionParam.getLabels());
+		assertNotNull("Collection element labels were expected but none were found.", collectionParam.findIfCollection().getElemLabels());
+		
+		ParamConfig<?> elemConfig = getElemConfigByCode(collectionParam, "label_nested_attr_level2");
+		assertEquals("Number of collection element labels was not correct.", 1, collectionParam.findIfCollection().getElemLabels().size());
+		assertEquals("Collection element label was not found in elemLabels.", expected, getElemLabelState(collectionParam, Locale.US, elemConfig.getId()));
+	}
 	
 	private static LabelState getLabelState(Param<?> p, Locale expectedLocale) {	
 		if(CollectionUtils.isNotEmpty(p.getLabels())) {


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* Fixes an issue where configuring a `@Grid` without a `@Label` results in the title row of the grid not rendering labels

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

Considering the logic for `elemLabels` is only needed for `@Grid` params and not all collection params, I've refactored `LabelStateEventHandler` logic into `GridStateLoadHandler`

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

*`LabelStateOnLoadEventHandlerTest`
  * testCollectionElemLabels`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
