### PR TITLE
NIMBUS-135:: _get call to start bpm if not yet started

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebCommandBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebCommandBuilder.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.cmd.Command.ProviderType;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
 import com.antheminc.oss.nimbus.support.JustLogit;
@@ -62,7 +63,10 @@ public class WebCommandBuilder {
 	}
 	
 	public Command handleInternal(String uri, Map<String, String[]> rParams) {
-		Command cmd = CommandBuilder.withUri(uri).addParams(rParams).getCommand();
+		Command cmd = CommandBuilder.withUri(uri)
+				.withProviderType(ProviderType.WEB_DISPATCHER)
+				.addParams(rParams)
+				.getCommand();
 		return cmd;
 	} 
 	

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/Command.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/Command.java
@@ -63,6 +63,13 @@ public class Command implements Serializable {
 	
 	private Map<String, String[]> requestParams;
 	
+	private ProviderType providerType = ProviderType.INTERNAL;
+	
+	public static enum ProviderType {
+		WEB_DISPATCHER,
+		INTERNAL;
+	}
+	
 	@JsonIgnore
 	private final Instant createdInstant = Instant.now();
 	

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilder.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.antheminc.oss.nimbus.InvalidArgumentException;
 import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.domain.cmd.Command.ProviderType;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.support.JustLogit;
@@ -261,6 +262,11 @@ public class CommandBuilder {
 	
 	public CommandBuilder setBehaviors(List<Behavior> behaviors) {
 		cmd.setBehaviors(behaviors);
+		return withCommand(cmd);
+	}
+	
+	public CommandBuilder withProviderType(ProviderType providerType) {
+		cmd.setProviderType(providerType);
 		return withCommand(cmd);
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/AbstractCommandExecutor.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/AbstractCommandExecutor.java
@@ -185,7 +185,7 @@ public abstract class AbstractCommandExecutor<R> extends BaseCommandExecutorStra
 		return refId;
 	}
 	
-	protected ProcessFlow startBusinessProcess(Param<?> rootDomainParam){
+	protected ProcessFlow startBusinessProcessIfApplicable(Param<?> rootDomainParam){
 		String lifecycleKey = rootDomainParam.findIfNested().getConfig().getDomainLifecycle();
 		
 		if(StringUtils.isEmpty(lifecycleKey))

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNew.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNew.java
@@ -109,7 +109,7 @@ public class DefaultActionExecutorNew extends AbstractCommandExecutor<Param<?>> 
 		
 		// hook up BPM
 		Param<?> rootDomainParam = getRootDomainParam(eCtx);
-		ProcessFlow processEntityState = startBusinessProcess(rootDomainParam);
+		ProcessFlow processEntityState = startBusinessProcessIfApplicable(rootDomainParam);
 		
 		if(processEntityState==null)
 			return eCtx;

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGetTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGetTest.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.internal.DefaultParamState;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@AutoConfigureMockMvc
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class DefaultActionExecutorGetTest extends AbstractFrameworkIngerationPersistableTests {
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testStartBPMOnGet() {
+		
+		// Insert a new "sampleCore" object by invoking "_new" command like "/p/sampleCore/_new?rawPayload=xyz"
+		MockHttpServletRequest coreNewRequest = MockHttpRequestBuilder.withUri(CORE_PARAM_ROOT)
+				.addAction(Action._new).getMock();
+		final Holder<MultiOutput> coreNewResponse = (Holder<MultiOutput>) controller.handleGet(coreNewRequest, null);
+		Long refID = coreNewResponse.getState().findFirstParamOutputEndingWithPath("/sample_core").getRootDomainId();
+		
+		// Perform the "_get" operation on the view
+		MockHttpServletRequest sampleTask2Request = MockHttpRequestBuilder.withUri(VIEW_WITHBPMN_PARAM_ROOT).addRefId(refID)
+				.addAction(Action._get).getMock();
+		Holder<MultiOutput> sampleTask2Response = (Holder<MultiOutput>) controller.handleGet(sampleTask2Request,null);
+		assertNotNull(sampleTask2Response);
+		
+		// Execute preconditions for bpmn logic
+		MockHttpServletRequest evalBpmn2Request = MockHttpRequestBuilder.withUri(VIEW_WITHBPMN_PARAM_ROOT).addRefId(refID)
+				.addNested("/attr_task1").addAction(Action._update).getMock();
+		Holder<MultiOutput> evalBpmn2Response = (Holder<MultiOutput>) controller.handlePut(evalBpmn2Request, null, converter.toJson("Complete"));
+		assertNotNull(evalBpmn2Response);
+		
+		// Validate the bpmn logic was executed
+		Param<?> currentTaskNameParam = (Param<?>) evalBpmn2Response.getState().findFirstParamOutputEndingWithPath("/currentTaskName").getValue();
+		assertEquals("task2", currentTaskNameParam.getState());
+	}
+}


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* Fixes #425

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Added `ProviderType` to `Command`: telsl the story of where the command originated
* Refactored existing bpm start logic from `_new` executor to the abstract executor
* Added change in `_get` executor to start and attach the bpm if not started

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* `DefaultActionExecutorGetTest`
  * `testStartBPMOnGet()`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

Needs review
