### PR TITLE
NIMBUS-140:: Adding non-transient ability for messages

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/MessageConditional.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/MessageConditional.java
@@ -55,6 +55,12 @@ public @interface MessageConditional {
 	Context context() default Context.INLINE;
 
 	/**
+	 * <p>When {@code true}, the message will NOT be preserved on the server and
+	 * UI on successive retrievals. Set this value to {@code false} when needing
+	 * to always display a message.
+	 */
+	boolean isTransient() default true;
+	/**
 	 * <p>CSS class to override UI default class.
 	 */
 	String cssClass() default "";

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/EntityState.java
@@ -641,7 +641,7 @@ public interface EntityState<T> {
 			private final Context context;
 			private final String styleClass;
 			
-			
+			private boolean isTransient = true;
 
 			@Override
 			public boolean equals(Object obj) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalHandler.java
@@ -68,7 +68,8 @@ public class MessageConditionalHandler extends EvalExprWithCrudActions<MessageCo
 		// The unevaluated msg is considered unique as we dont want to show the same msg twice in different contexts or Types
 		// TODO: The same msg should not be added accross two Message Conditionals -Add a static validation for it in future
 		Message msg = new Message(configuredAnnotation.message(), message, configuredAnnotation.messageType(), configuredAnnotation.context(),configuredAnnotation.cssClass());
-
+		msg.setTransient(configuredAnnotation.isTransient());
+		
 		Set<Message> newMsgs = new HashSet<>();
 		if(!CollectionUtils.isEmpty(param.getMessages())) 
 			newMsgs.addAll(param.getMessages());

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/support/DefaultJsonParamSerializer.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/support/DefaultJsonParamSerializer.java
@@ -16,8 +16,10 @@
 package com.antheminc.oss.nimbus.domain.model.state.support;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -29,6 +31,7 @@ import com.antheminc.oss.nimbus.domain.defn.extension.ValidateConditional.Valida
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.ListElemParam;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Model;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.Message;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -112,10 +115,19 @@ public class DefaultJsonParamSerializer extends JsonSerializer<Param<?>> {
 			
 			if(CollectionUtils.isNotEmpty(p.getMessages())) {
 				writer.writeObjectIfNotNull(K_MESSAGE, p::getMessages);
+				
+				Set<Message> nonTransientMessages = p.getMessages().stream()
+						.filter(m -> !m.isTransient()).collect(Collectors.toSet());
+				
 				// Resetting the message in param, so that once the message is read through the http response, it is removed from param state.
 				/* TODO Scenarios where further conditional processing is done based on the message text needs to be addressed,
 				 since the message state has been reset. There will be a sync issue until a state is reloaded and message is set.*/
 				p.setMessages(null);
+				
+				// Keep non-transient messages (see MessageConditional#isTransient)
+				if (!nonTransientMessages.isEmpty()) {
+					p.setMessages(nonTransientMessages);
+				}
 			}
 			writer.writeObjectIfNotNull(K_VALUES, p::getValues);
 			writer.writeObjectIfNotNull(K_LABELS, p::getLabels);

--- a/nimbus-ui/nimbusui/src/app/components/platform/base-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/base-element.component.ts
@@ -1,3 +1,4 @@
+import { Message } from './../../shared/message';
 /**
  * @license
  * Copyright 2016-2018 the original author or authors.
@@ -239,9 +240,9 @@ export class BaseElement {
     }
 
     ngOnDestroy(){
-        if(this.element.message)                 
-        this.element.message = [];              
+        if(this.element.message) {
+            this.element.message = this.element.message.filter(m => !m.transient);
+        }
     }
-    
 }
 

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
@@ -45,7 +45,6 @@ var counter = 0;
 
 export class FormElement extends BaseElement {
 
-    @Input() element: Param;
     @Input() form: FormGroup;
     elemMessages: Message[];
     id: String = 'form-control' + counter++;

--- a/nimbus-ui/nimbusui/src/app/shared/message.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/message.ts
@@ -29,6 +29,7 @@ export class Message implements Serializable<Message, string> {
     type: string;
     text: string;
     context: string;
+    transient: boolean = true;
     messageArray: any[] = [];
     life: number;
     styleClass: string;
@@ -40,7 +41,7 @@ export class Message implements Serializable<Message, string> {
         obj = Converter.convert(inJson,obj);
 
         if(this.context !== undefined && this.text){
-            obj = Message.createMessage(this.type, this.context, this.text, this.life, this.styleClass);
+            obj = Message.createMessage(this.type, this.context, this.text, this.life, this.styleClass, inJson.transient);
         }
 
         return obj;
@@ -53,7 +54,7 @@ export class Message implements Serializable<Message, string> {
      * \@howToUse 
      *      Call this createMessage method by providing it with 4 variables
      */
-    public static createMessage( type, context, detail, life, styleClass): Message {
+    public static createMessage( type, context, detail, life, styleClass, transient? : boolean): Message {
         let severity: string, summary: string, updatedLife: number;
         
         let message = new Message();
@@ -61,6 +62,7 @@ export class Message implements Serializable<Message, string> {
         message.type = type;
         message.styleClass = styleClass;
         updatedLife = life;
+        message.transient = transient;
         
         switch (type) {               
 


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

* Added `isTransient` attribute to `MessageConditional` to support messages that are retained between successive serverside and UI requests

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

See above

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--

- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature
- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Existing test cases

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A