### PR TITLE
NIMBUS-137: StackOverflow Error when a OnStateLoad event triggers a state change handler

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
@@ -114,21 +114,7 @@ public class DefaultActionExecutorGet extends AbstractCommandExecutor<Object> {
 		// create quad-model
 		ExecutionEntity<?, ?> e = ExecutionEntity.resolveAndInstantiate(entity, null);
 		
-		return executeCb(eCtx, e);
-	}
-
-	// TODO: [SOHAM] interim solution
-	public static final ThreadLocal<Action> TH_ACTION = new ThreadLocal<>();
-	
-	private QuadModel<?, ?> executeCb(ExecutionContext eCtx, ExecutionEntity<?, ?> e) {
-		try {
-			TH_ACTION.set(Action._get);
-			QuadModel<?, ?> q = getQuadModelBuilder().build(eCtx.getCommandMessage().getCommand(), e);
-			q.getRoot().initState();
-			return q;
-		} finally {
-			TH_ACTION.set(null);
-		}
+		return getQuadModelBuilder().build(eCtx.getCommandMessage().getCommand(), e);
 	}
 
 	protected QuadModel<?, ?> handleMapped(ModelConfig<?> rootDomainConfig, ExecutionContext eCtx, Object mapped, Action action) {
@@ -143,7 +129,6 @@ public class DefaultActionExecutorGet extends AbstractCommandExecutor<Object> {
 								.orElseThrow(()->new InvalidStateException("Expected first response from command gateway to return mapsTo core parm, but not found for mapsToCmd: "+mapsToCmd));
 		
 		QuadModel<?, ?> q = getQuadModelBuilder().build(eCtx.getCommandMessage().getCommand(), mapped, coreParam);
-		q.getRoot().initState();
 		return q;
 	}
 	

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
-import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultActionExecutorGet;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultExecutionContextLoader;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Model;
@@ -31,7 +31,6 @@ import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
 import com.antheminc.oss.nimbus.domain.model.state.internal.AbstractEvent.PersistenceMode;
 import com.antheminc.oss.nimbus.domain.model.state.repo.ModelPersistenceHandler;
 import com.antheminc.oss.nimbus.domain.model.state.repo.ModelRepositoryFactory;
-import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -61,7 +60,7 @@ public class ParamStateAtomicPersistenceEventListener extends ParamStatePersiste
 	
 	@Override
 	public boolean listen(ModelEvent<Param<?>> event) {
-		if(DefaultActionExecutorGet.TH_ACTION.get() == Action._get)
+		if(DefaultExecutionContextLoader.TH_ACTION.get() == Action._get)
 			return false;
 		
 		Param<?> p = (Param<?>) event.getPayload();

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/core/StChangeOnStLoadCore.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/core/StChangeOnStLoadCore.java
@@ -1,3 +1,21 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * 
+ */
 package com.antheminc.oss.nimbus.test.scenarios.s14.core;
 
 import com.antheminc.oss.nimbus.domain.defn.Domain;

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/core/StChangeOnStLoadCore.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/core/StChangeOnStLoadCore.java
@@ -1,0 +1,23 @@
+package com.antheminc.oss.nimbus.test.scenarios.s14.core;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Jayant Chaudhuri
+ *
+ */
+@Domain(value="stchangeonstloadcore", includeListeners={ListenerType.persistence})
+@Repo(Database.rep_mongodb)
+@Getter @Setter
+public class StChangeOnStLoadCore extends IdLong{
+	private static final long serialVersionUID = 1L;
+	private String parameter0;
+	
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/view/StChangeOnStLoadModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/view/StChangeOnStLoadModel.java
@@ -1,0 +1,52 @@
+package com.antheminc.oss.nimbus.test.scenarios.s14.view;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo.Type;
+import com.antheminc.oss.nimbus.domain.defn.Model;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.defn.event.EventType;
+import com.antheminc.oss.nimbus.domain.defn.extension.ConfigConditional;
+import com.antheminc.oss.nimbus.domain.defn.extension.Script;
+import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
+import com.antheminc.oss.nimbus.test.scenarios.s14.core.StChangeOnStLoadCore;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Jayant Chaudhuri
+ *
+ */
+@Domain(value="stchangeonstloadview")
+@Repo(Database.rep_none)
+@Getter @Setter
+@Type(StChangeOnStLoadCore.class)
+public class StChangeOnStLoadModel extends IdLong{
+	private static final long serialVersionUID = 1L;
+	
+	private SubModel inline_para;
+	
+
+	@Model
+	@Getter @Setter
+	public static class SubModel{
+		@Script(type=Script.Type.SPEL_INLINE, value="findParamByPath('/../parameter3').setState('Value3')", eventType=EventType.OnStateLoad)
+		private String parameter2;
+		
+		@ConfigConditional(
+				config= {@Config(url="/.d/inline_para/parameter4/_replace?rawPayload={\"name\":\"Test\"}")}
+		)
+		private String parameter3;
+		
+		private SubModel2 parameter4;
+	}
+	
+	@Model
+	@Getter @Setter
+	public static class SubModel2{
+		private String name;
+	}
+	
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/view/StChangeOnStLoadModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s14/view/StChangeOnStLoadModel.java
@@ -1,3 +1,21 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * 
+ */
 package com.antheminc.oss.nimbus.test.scenarios.s14.view;
 
 import com.antheminc.oss.nimbus.domain.defn.Domain;

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s14/StateChangeOnStateLoadTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s14/StateChangeOnStateLoadTest.java
@@ -1,0 +1,64 @@
+/**
+ *  Copyright 2016-2018 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s14;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.session.SessionProvider;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+
+/**
+ * @author Jayant Chaudhuri
+ *
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class StateChangeOnStateLoadTest extends AbstractFrameworkIngerationPersistableTests {
+	
+	@Autowired
+	SessionProvider sessionProvider;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void t01_initEntity() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/stchangeonstloadview")
+					.addAction(Action._new)
+					.getMock();
+		Holder<MultiOutput> holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		Param param = (Param)holder.getState().getSingleResult();
+		sessionProvider.removeAttribute("{/stchangeonstloadview:1}");
+		request = MockHttpRequestBuilder.withUri(PLATFORM_ROOT+"/stchangeonstloadview:1")
+				.addAction(Action._get)
+				.getMock();
+		holder = (Holder<MultiOutput>)controller.handlePost(request, null);
+		param = (Param)holder.getState().getSingleResult();
+		assertNotNull(param.findStateByPath("/inline_para/parameter4"));
+	}
+	
+}
+		
+	
+


### PR DESCRIPTION

# Description
When we have a OnStateLoad event on a parameter that triggers a State Change event on any other parameter in the same root domain, it gives a stack overflow error. In the current code, the quad model gets cached in the session after the state load event is triggered. If the state load event triggers a state change event on the same root domain, then framework does not find the quad model in cache and tries to instantiate the model and the cycle continues. 


# Overview of Changes
Change has been made to execute the initState() method only after the quad model is cached


# Type of Change
Bug fix


# Test Details
StateChangeOnStateLoadTest


# Additional Notes
There might be a need to re-evaluate how to sequence event execution. The change above will resolve entities that are cached. For the entities that are not cached, the stack overflow issue would still continue
