### PR TITLE
Function Handler: Filter

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultProcessConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultProcessConfig.java
@@ -31,6 +31,7 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.internal.nav.DefaultActionNewIni
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.nav.PageIdEchoNavHandler;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.AddFunctionHandler;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.EvalFunctionHandler;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.FilterFunctionHandler;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.SetByRuleFunctionalHandler;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.SetFunctionHandler;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.StatelessBPMFunctionHanlder;
@@ -129,5 +130,10 @@ public class DefaultProcessConfig {
 	@Bean(name="default._process$execute?fn=_eval")
 	public EvalFunctionHandler<?,?> evalFunctionHandler(ExpressionManager expressionManager){
 		return new EvalFunctionHandler(expressionManager);
+	}
+
+	@Bean(name="default._process$execute?fn=_filter")
+	public FilterFunctionHandler filterFunctionHandler() {
+		return new FilterFunctionHandler();
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/process/FilterFunctionHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/process/FilterFunctionHandler.java
@@ -1,0 +1,193 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.cmd.exec.internal.process;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.util.StringUtils;
+
+import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
+import com.antheminc.oss.nimbus.domain.cmd.exec.FunctionHandler;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+
+/**
+ * <p> Sets the state of a specified parameter to the result set consisting of
+ * the action parameter's collection elements that match the given SpEL
+ * predicate. The action parameter must be a collection or array typed
+ * parameter.
+ * 
+ * <p>The expected SpEL predicate syntax is slightly different when the action
+ * parameter's collection element type is complex versus when it is not.
+ * Non-complex elements will simply expose each collection element's state to
+ * the SpEL expression context, while complex elements will expose the entire
+ * Param for the collection element. In this way, greater filtering support is
+ * available for complex elements.
+ * 
+ * <p>Unless set via {@code targetParam}, the default behavior is to set the
+ * resulting state into the action parameter.
+ * 
+ * @author Lance Staley
+ * @author Tony Lopez
+ */
+public class FilterFunctionHandler implements FunctionHandler<Object, Param<Object>> {
+
+	public static final String ARG_EXPRESSION = "expr";
+	public static final String ARG_TARGET_PARAM = "targetParam";
+	public static final String COL_ONLY_MSG = "Filter is only supported for collection or array typed parameters.";
+
+	/**
+	 * <p>Adds the context object to the provided list when the given expression
+	 * evaluates to {@code true}.
+	 * 
+	 * @param list the list to add to when the expression is true
+	 * @param context the object to add as a context when evaluating the
+	 * expression
+	 * @param expression the expression to evaluate
+	 */
+	private void addWhenExpressionIsTrue(List<Object> list, Object context, Expression expression) {
+		addWhenExpressionIsTrue(list, context, context, expression);
+	}
+
+	/**
+	 * <p>Adds the context object to the provided list when the given expression
+	 * evaluates to {@code true}.
+	 * 
+	 * @param list the list to add to when the expression is true
+	 * @param context the object to add as a context when evaluating the
+	 * expression
+	 * @param toAdd the object to add into the list
+	 * @param expression the expression to evaluate
+	 */
+	private void addWhenExpressionIsTrue(List<Object> list, Object context, Object toAdd, Expression expression) {
+		StandardEvaluationContext evalContext = new StandardEvaluationContext(context);
+		if (expression.getValue(evalContext, Boolean.class)) {
+			list.add(toAdd);
+		}
+	}
+
+	@Override
+	public Param<Object> execute(ExecutionContext eCtx, Param<Object> actionParameter) {
+		validate(eCtx, actionParameter);
+
+		final Expression expression = new SpelExpressionParser()
+				.parseExpression(eCtx.getCommandMessage().getCommand().getFirstParameterValue(ARG_EXPRESSION));
+
+		final Object filteredState;
+		if (null == actionParameter.getState()) {
+			filteredState = null;
+		} else if (actionParameter.isCollection()) {
+			filteredState = getListFilteredState(actionParameter, expression);
+		} else if (actionParameter.getType().isArray()) {
+			filteredState = getArrayFilteredState(actionParameter, expression);
+		} else {
+			throw new InvalidConfigException(COL_ONLY_MSG);
+		}
+
+		Param<Object> targetParam = getTargetParam(eCtx, actionParameter);
+		targetParam.setState(filteredState);
+
+		return targetParam;
+	}
+
+	/**
+	 * <p> Get the filtered state of the given action param with the provided
+	 * SpEL expression by applying that expression to each collection element of
+	 * the action param.
+	 * 
+	 * @param actionParameter the action param
+	 * @param expression the expression to evaluate
+	 * @return the filtered state
+	 */
+	private Object[] getArrayFilteredState(Param<Object> actionParameter, Expression expression) {
+		List<Object> filtered = new ArrayList<>();
+		Object[] array = (Object[]) actionParameter.getState();
+		for (Object arrayElement: array) {
+			addWhenExpressionIsTrue(filtered, arrayElement, expression);
+		}
+		Class<?> referredClass = actionParameter.getConfig().getReferredClass();
+		Object[] result = (Object[]) Array.newInstance(referredClass, filtered.size());
+		for (int i = 0; i < filtered.size(); i++) {
+			result[i] = filtered.get(i);
+		}
+		return result;
+	}
+
+	/**
+	 * <p> Get the filtered state of the given action param with the provided
+	 * SpEL expression by applying that expression to each collection element of
+	 * the action param.
+	 * 
+	 * @param actionParameter the action param
+	 * @param spelExpression the expression to evaluate
+	 * @return the filtered state
+	 */
+	@SuppressWarnings("unchecked")
+	private List<Object> getListFilteredState(Param<Object> actionParameter, Expression expression) {
+		List<Object> result = new ArrayList<>();
+		if (actionParameter.isLeaf()) {
+			List<Object> collection = (List<Object>) actionParameter.getState();
+			for (Object collectionElement: collection) {
+				addWhenExpressionIsTrue(result, collectionElement, expression);
+			}
+		} else {
+			actionParameter.traverseChildren(p -> addWhenExpressionIsTrue(result, p, p.getState(), expression));
+		}
+		return result;
+	}
+
+	/**
+	 * <p> Get the target param to set the state into. If a {@code targetParam}
+	 * path is provided, return the found param relative from the
+	 * actionParameter.
+	 * 
+	 * @param eCtx the execution context
+	 * @param actionParameter the action param
+	 * @return the targetParam to set
+	 */
+	private Param<Object> getTargetParam(ExecutionContext eCtx, Param<Object> actionParameter) {
+		String targetParamPath = eCtx.getCommandMessage().getCommand().getFirstParameterValue(ARG_TARGET_PARAM);
+		if (StringUtils.isEmpty(targetParamPath)) {
+			return actionParameter;
+		}
+		return actionParameter.findParamByPath(targetParamPath);
+	}
+
+	/**
+	 * <p> Validate that the necessary information has been provided.
+	 * 
+	 * @param eCtx the execution context
+	 * @param actionParameter the action param
+	 */
+	private void validate(ExecutionContext eCtx, Param<Object> actionParameter) {
+		if (null == actionParameter) {
+			throw new InvalidConfigException("The value provided for actionParameter must be non-null.");
+		}
+		
+		if (!actionParameter.isCollection() && !actionParameter.getType().isArray()) {
+			throw new InvalidConfigException(COL_ONLY_MSG);
+		}
+
+		if (StringUtils.isEmpty(eCtx.getCommandMessage().getCommand().getFirstParameterValue(ARG_EXPRESSION))) {
+			throw new InvalidConfigException("The argument \"" + ARG_EXPRESSION + "\" is required for Filter.");
+		}
+	}
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRSampleViewRootEntity.java
@@ -61,5 +61,9 @@ public class VRSampleViewRootEntity {
 	@Path
 	private List<String> attr_list_2_simple;
 	
+	private List<String> tmp;
+	
+	private String[] arr;
+	
 	private SampleParamStateHolders paramStateHolders;
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/process/FilterFunctionHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/process/FilterFunctionHandlerTest.java
@@ -1,0 +1,177 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.cmd.exec.internal.process;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity;
+
+/**
+ * 
+ * @author Lance Staley
+ * @author Tony Lopez
+ *
+ */
+public class FilterFunctionHandlerTest extends AbstractFrameworkIngerationPersistableTests {
+
+	@Autowired
+	private CommandExecutorGateway commandExecutorGateway;
+
+	// /sample_view/attr_list_2_simple/_process?fn=_filter&expr=contains('pickme')
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSimpleCollection() {
+		Long refId = createOrGetDomainRoot_RefId();
+
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(refId)
+				.addNested("/attr_list_2_simple").addAction(Action._get).getMock();
+		Holder<MultiOutput> resp = (Holder<MultiOutput>) controller.handleGet(req, null);
+		Param<List<String>> collectionParam = (Param<List<String>>) resp.getState().getSingleResult();
+
+		List<String> initial = new ArrayList<>();
+		initial.add("you should pickme");
+		initial.add("should should not pick me");
+		initial.add("you should also pickme");
+		collectionParam.setState(initial);
+
+		Command cmd = CommandBuilder.withUri(
+				VIEW_PARAM_ROOT + ":" + refId + "/attr_list_2_simple/_process?fn=_filter&expr=contains('pickme')")
+				.getCommand();
+		commandExecutorGateway.execute(new CommandMessage(cmd, null));
+
+		Assert.assertEquals(2, collectionParam.getState().size());
+		Assert.assertFalse(collectionParam.getState().contains(initial.get(1)));
+	}
+
+	// /sample_view/arr/_process?fn=_filter&expr=contains('pickme')
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSimpleArray() {
+		Long refId = createOrGetDomainRoot_RefId();
+
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(refId).addNested("/arr")
+				.addAction(Action._get).getMock();
+		Holder<MultiOutput> resp = (Holder<MultiOutput>) controller.handleGet(req, null);
+		Param<String[]> collectionParam = (Param<String[]>) resp.getState().getSingleResult();
+
+		String[] initial = new String[] { "you should pickme", "should should not pick me", "you should also pickme" };
+		collectionParam.setState(initial);
+
+		Command cmd = CommandBuilder
+				.withUri(VIEW_PARAM_ROOT + ":" + refId + "/arr/_process?fn=_filter&expr=contains('pickme')")
+				.getCommand();
+		commandExecutorGateway.execute(new CommandMessage(cmd, null));
+
+		Assert.assertEquals(2, collectionParam.getState().length);
+		Assert.assertFalse(ArrayUtils.contains(collectionParam.getState(), initial[1]));
+	}
+
+	// /sample_view/attr_list_1_NestedEntity/_process?fn=_filter&expr=state.nested_attr_String.contains('pickme')
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testComplexCollection() {
+		Long refId = createOrGetDomainRoot_RefId();
+
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(refId)
+				.addNested("/attr_list_1_NestedEntity").addAction(Action._get).getMock();
+		Holder<MultiOutput> resp = (Holder<MultiOutput>) controller.handleGet(req, null);
+		Param<List<SampleCoreNestedEntity>> collectionParam = (Param<List<SampleCoreNestedEntity>>) resp.getState()
+				.getSingleResult();
+
+		List<SampleCoreNestedEntity> initial = new ArrayList<>();
+		initial.add(new SampleCoreNestedEntity());
+		initial.get(0).setNested_attr_String("you should pickme");
+		initial.add(new SampleCoreNestedEntity());
+		initial.get(1).setNested_attr_String("should should not pick me");
+		initial.add(new SampleCoreNestedEntity());
+		initial.get(2).setNested_attr_String("you should also pickme");
+		collectionParam.setState(initial);
+
+		Command cmd = CommandBuilder
+				.withUri(VIEW_PARAM_ROOT + ":" + refId
+						+ "/attr_list_1_NestedEntity/_process?fn=_filter&expr=state.nested_attr_String.contains('pickme')")
+				.getCommand();
+		commandExecutorGateway.execute(new CommandMessage(cmd, null));
+
+		Assert.assertEquals(2, collectionParam.getState().size());
+		Assert.assertFalse(collectionParam.getState().contains(initial.get(1)));
+	}
+
+	// /sample_view/attr_list_2_simple/_process?fn=_filter&expr=contains('pickme')&targetParam=/../tmp
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testTargetParam() {
+		Long refId = createOrGetDomainRoot_RefId();
+
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(refId)
+				.addNested("/attr_list_2_simple").addAction(Action._get).getMock();
+		Holder<MultiOutput> resp = (Holder<MultiOutput>) controller.handleGet(req, null);
+		Param<List<String>> collectionParam = (Param<List<String>>) resp.getState().getSingleResult();
+
+		List<String> initial = new ArrayList<>();
+		initial.add("you should pickme");
+		initial.add("should should not pick me");
+		initial.add("you should also pickme");
+		collectionParam.setState(initial);
+
+		Command cmd = CommandBuilder
+				.withUri(VIEW_PARAM_ROOT + ":" + refId
+						+ "/attr_list_2_simple/_process?fn=_filter&expr=contains('pickme')&targetParam=/../tmp")
+				.getCommand();
+		commandExecutorGateway.execute(new CommandMessage(cmd, null));
+
+		Param<List<String>> tmp = collectionParam.findParamByPath("/../tmp");
+		Assert.assertEquals(2, tmp.getState().size());
+		Assert.assertFalse(tmp.getState().contains(initial.get(1)));
+	}
+
+	// /sample_view/attr_list_2_simple/_process?fn=_filter&expr=true
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGivenParamHasNullState() {
+		Long refId = createOrGetDomainRoot_RefId();
+
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addRefId(refId)
+				.addNested("/attr_list_2_simple").addAction(Action._get).getMock();
+		Holder<MultiOutput> resp = (Holder<MultiOutput>) controller.handleGet(req, null);
+		Param<List<String>> collectionParam = (Param<List<String>>) resp.getState().getSingleResult();
+
+		Command cmd = CommandBuilder
+				.withUri(VIEW_PARAM_ROOT + ":" + refId
+						+ "/attr_list_2_simple/_process?fn=_filter&expr=contains('pickme')&targetParam=/../tmp")
+				.getCommand();
+		commandExecutorGateway.execute(new CommandMessage(cmd, null));
+
+		Assert.assertNull(collectionParam.getState());
+	}
+}


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

Adding a Filter function handler for collection/array typed parameters.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

```java
@Domain(value = "sample_view", includeListeners={ ListenerType.websocket })
@MapsTo.Type(SampleCoreEntity.class)
@Repo(Database.rep_none)
@Getter @Setter
public class VRSampleViewRootEntity {

    private String[] arr;
    private List<String> simple_list;
    private List<ComplexObject> complex_list;

    @Config(url = "/arr/_process?fn=_filter&expr=contains('pickme')")
    @Config(url = "/simple_list/_process?fn=_filter&expr=contains('pickme')")
    @Config(url = "/complex_list/_process?fn=_filter&expr=state.p1.contains('pickme')")
    private String action_demoFilter;

    @Model 
    @Data 
    public static class ComplexObject {
        private String p1;
    }
}
```

## Filtering complex vs non-complex typed collections
The expected SpEL predicate syntax is slightly different when the action parameter's collection element type is complex versus when it is not. Non-complex elements will simply expose each collection element's state to the SpEL expression context, while complex elements will expose the entire Param for the collection element.

### Non-complex typed collection
`@Config(url = "/simple_list/_process?fn=_filter&expr=contains('pickme')")`

Since `simple_list` has type `String`, it is non-complex. Notice in this example that `expr` is making use of the `String.contains` method. This is because the state of the collection element (type `String`) is exposed as the _context_ for the SpEL expression.

### Complex typed collection
`@Config(url = "/complex_list/_process?fn=_filter&expr=state.p1.contains('pickme')")`

Since `complex_list` has type `ComplexObject`, it is complex. For complex typed collections, the `Param` interface for the collection element parameter is exposed as the _context_ for the SpEL expression, which offers the ability to reference `state`. In this way, greater filtering support is available for complex elements.

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--

- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature
- [ ] Documentation Update

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* `FilterFunctionHandlerTest`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
