### PR TITLE
NIMBUS-164:: call error endpoint for usecases like db is down

### DIFF
--- a/nimbus-ui/nimbusui/src/app/services/httpclient-interceptor.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/httpclient-interceptor.service.ts
@@ -26,6 +26,7 @@ import { ConfigService } from './config.service';
 import { SessionStoreService } from './session.store';
 import { RedirectHandle } from '../shared/app-redirecthandle.interface';
 import { NmMessageService } from './toastmessage.service';
+import { Action } from '../shared/command.enum';
 /**
  * \@author Swetha.Vemuri
  * \@whatItDoes
@@ -79,6 +80,10 @@ export class CustomHttpClientInterceptor implements HttpInterceptor {
                     const execResp  = new ExecuteResponse(this.configSvc).deserialize(err.error);
                     if (execResp != null && execResp.result != null && execResp.result[0] != null) {
                         const exception: ExecuteException = execResp.result[0].executeException;
+                        if(req.url.search(Action._new.toString()) && err.status === 500){
+                            this.sessionStore.removeAll();
+                            window.location.href = `${ServiceConstants.ERROR_URL}`+'?uniqueId='+encodeURIComponent(exception.uniqueId)+'&code='+encodeURIComponent(exception.code);
+                        }
                         this.msgSvc.notifyErrorEvent(exception);
                     }
                 }

--- a/nimbus-ui/nimbusui/src/app/services/service.constants.ts
+++ b/nimbus-ui/nimbusui/src/app/services/service.constants.ts
@@ -45,6 +45,8 @@ export class ServiceConstants {
     public static get LOGIN_URL(): string { return this.APP_HOST_URL+this.APP_PORT+'/'+this.APP_CONTEXT+'/login'; }
     public static get IMAGE_URL(): string { return this.APP_HOST_URL+this.APP_PORT+'/'+this.APP_CONTEXT+'/'; }
     public static get LOGOUT_URL(): string { return this.APP_HOST_URL+this.APP_PORT+'/'+this.APP_CONTEXT+'/logout'; }
+    public static get ERROR_URL(): string { return this.APP_HOST_URL+this.APP_PORT+'/'+this.APP_CONTEXT+'/app/error'; }
+
     public static get APP_REFRESH(): string { return this.APP_HOST_URL+this.APP_PORT+'/'+this.APP_CONTEXT+'/processLogin'; }
     public static get PLATFORM_BASE_URL(): string    { return this.APP_BASE_URL + this.APP_COMMAND_URL + this.PLATFORM_SEPARATOR; }
     public static get CLIENT_BASE_URL(): string    { return this.APP_HOST_URL+this.APP_PORT+'/'; }

--- a/nimbus-ui/nimbusui/src/app/shared/app-config.interface.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/app-config.interface.ts
@@ -235,9 +235,11 @@ export class MultiOutput implements Serializable<MultiOutput,string> {
 export class ExecuteException implements Serializable<ExecuteException, string> {
     code: string;
     message: string;
+    uniqueId: string;
     deserialize( inJson ) {
         this.code = inJson.code;
         this.message = inJson.message;
+        this.uniqueId = inJson.uniqueId;
         return this;
     }
 }


### PR DESCRIPTION
# Description
Ability to configure an error page for certain use cases when server fails

# Overview of Changes
Ui would call /apperror endpoint when there is an error when config gets returns to UI when app url is hit for the first time.


# Type of Change
- [ ] New feature