### PR TITLE
NIMBUS-182: repo alias persistence fix

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
@@ -17,11 +17,13 @@ package com.antheminc.oss.nimbus.domain.model.state.repo.db;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.DefaultExecutionContextLoader;
+import com.antheminc.oss.nimbus.domain.defn.Domain;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.model.config.ModelConfig;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState;
@@ -82,7 +84,16 @@ public class ParamStateAtomicPersistenceEventListener extends ParamStatePersiste
 			return true;
 		}
 		
-		modelRepo._update(rootModel.getConfig().getAlias(), coreStateId, rootModel.getBeanPath(), rootModel.getState());
+		String repoAlias = repo.alias();
+		if (StringUtils.isBlank(repoAlias)) {
+			repoAlias = rootModel.getConfig().getAlias();
+			if (StringUtils.isBlank(repoAlias)) {
+				throw new InvalidConfigException("Core Persistent entity must be configured with "
+						+ Domain.class.getSimpleName() + " annotation. Not found for root model: " + rootModel);
+			}
+		}
+		
+		modelRepo._update(repoAlias, coreStateId, rootModel.getBeanPath(), rootModel.getState());
 		return true;
 	}
 

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/core/SampleRepoDifferentAlias.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/core/SampleRepoDifferentAlias.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.repo.core;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Domain(value="sample_repo_diff_alias", includeListeners={ListenerType.persistence})
+@Repo(alias = "person_of_interest", value = Database.rep_mongodb)
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@Data
+public class SampleRepoDifferentAlias extends IdLong {
+
+	private static final long serialVersionUID = 1L;
+	
+	private String firstName;
+	private String lastName;
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListenerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListenerTest.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.repo.db;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
+import com.antheminc.oss.nimbus.support.CommandUtils;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
+import com.antheminc.oss.nimbus.test.scenarios.repo.core.SampleRepoDifferentAlias;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@EnableAutoConfiguration
+public class ParamStateAtomicPersistenceEventListenerTest extends AbstractFrameworkIntegrationTests {
+
+	@Autowired
+	@Qualifier("default.processGateway")
+	private CommandExecutorGateway commandGateway;
+
+	@Autowired
+	private ObjectMapper om;
+
+	@Autowired
+	private MongoTemplate mongo;
+
+	@Test
+	public void testDomainRepoAliasMismatchPersistence() throws JsonProcessingException {
+		final String requestUri = "app/org/p/sample_repo_diff_alias/_new";
+		final String expectedCollectionName = "person_of_interest";
+		SampleRepoDifferentAlias expected = new SampleRepoDifferentAlias("Oscar", "Grouch");
+
+		Command cmd = CommandUtils.prepareCommand(requestUri);
+		final String jsonPayload = this.om.writeValueAsString(expected);
+		CommandMessage cmdMsg = new CommandMessage(cmd, jsonPayload);
+		this.commandGateway.execute(cmdMsg);
+
+		// ensure the persisted entity is matching the value provided for
+		// @Repo.alias, not @Domain.value
+		Assert.assertEquals(expected, mongo.findById(1L, SampleRepoDifferentAlias.class, expectedCollectionName));
+	}
+}


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #459 

* Fixed an isolated issue in 1.3 versions where a domain entity was ALWAYS being persisted under the `@Domain` alias, instead of the `@Repo` alias. This issue was introduced with a previous merge of the repo changes from 2.0.x.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Added logic for Mongo persistence where `@Repo` is checked first and used. This code was missed during a merge.

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* `ParamStateAtomicPersistenceEventListenerTest`
  * `testDomainRepoAliasMismatchPersistence()`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
