### PR TITLE
NIMBUS-163  log encoding (veracode vulnerability)

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/JustLogit.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/JustLogit.java
@@ -17,6 +17,7 @@ package com.antheminc.oss.nimbus.support;
 
 import java.util.function.Supplier;
 
+import org.owasp.esapi.codecs.HTMLEntityCodec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +31,10 @@ import lombok.Getter;
 public class JustLogit {
 
 	private final Logger log;
+	
+	private static HTMLEntityCodec htmlCodec = new HTMLEntityCodec(); 
+	
+	final char[] IMMUNE_HTML = { ',', '.', '-', '_', ' ', '*','[',']', '(', ')', '$', '=', '+', '\n','/',':', '?', '&', '\"', '{','}', '#', '!', '@', '\'' };
 	
 	public JustLogit() {
 		this.log = LoggerFactory.getLogger(this.getClass());
@@ -95,11 +100,11 @@ public class JustLogit {
 	}
 	
 	private String nuetralizeLog(Supplier<String> msg) {
-//		if(msg.get() != null) {
-//			return SecurityUtils.scanObjectForSecureLogging(msg.get(), SecurityUtils.SECURE);
-//		}
+		if(msg.get() != null) {
+			return htmlCodec.encode( IMMUNE_HTML, msg.get());
+		}
 		
-		return msg.get();		                     
+		return null;	                     
 	}
 	
 }


### PR DESCRIPTION
# Description
Encoding logs as attackers could inject malicious content using tags like '<'.   This could be dangerous if the logs are integrated and viewed using a website in a browser where javascript can run.

Encoding is little bit relaxed for certain symbols as we use them a lot while logging. (But definitely not '<' and '>' tags)
Eg:   arg[0]: Command(absoluteUri=/test/test/p/test/_new, clientUserId=null, action=_new, behaviors=[$execute])

