### PR TITLE
NIMBUS-187: external link nav via config

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNav.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNav.java
@@ -15,28 +15,55 @@
  */
 package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
+import org.drools.core.util.StringUtils;
+
+import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.exec.AbstractCommandExecutor;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.nav.PageNavigationResponse;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.nav.PageNavigationResponse.Type;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 /**
  * @author Soham Chakravarti
+ * @author Tony Lopez
  *
  */
 @EnableLoggingInterceptor
-public class DefaultActionExecutorNav<T> extends AbstractCommandExecutor<String> {
-	
+public class DefaultActionExecutorNav<T> extends AbstractCommandExecutor<PageNavigationResponse> {
+
 	public DefaultActionExecutorNav(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
 	}
 
 	@Override
-	protected Output<String> executeInternal(Input input) {
-		String pageId = input.getContext().getCommandMessage().getCommand().getFirstParameterValue(Constants.KEY_NAV_ARG_PAGE_ID.code);
-		return Output.instantiate(input, input.getContext(), pageId);		
+	protected Output<PageNavigationResponse> executeInternal(Input input) {
+		PageNavigationResponse response = buildResponse(input); 
+		if (null == response) {
+			throw new InvalidConfigException(
+					"Unable to determine a navigation strategy from the provided command message. Please ensure the correct parameters were sent: "
+							+ input.getContext().getCommandMessage());
+		}
+		
+		return Output.instantiate(input, input.getContext(), response);
 	}
 	
+	protected PageNavigationResponse buildResponse(Input input) {
+		String pageId = input.getContext().getCommandMessage().getCommand()
+				.getFirstParameterValue(Constants.KEY_NAV_ARG_PAGE_ID.code);
+		if (!StringUtils.isEmpty(pageId)) {
+			return PageNavigationResponse.builder().pageId(pageId).build();
+		}
+
+		String redirectUrl = input.getContext().getCommandMessage().getCommand()
+				.getFirstParameterValue(Constants.KEY_NAV_ARG_REDIRECT_URL.code);
+		if (!StringUtils.isEmpty(redirectUrl)) {
+			return PageNavigationResponse.builder().type(Type.EXTERNAL).redirectUrl(redirectUrl).build();
+		}
+		
+		return null;
+	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/nav/PageNavigationResponse.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/nav/PageNavigationResponse.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.cmd.exec.internal.nav;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Builder
+@Data
+public class PageNavigationResponse {
+	
+	@Getter
+	public static enum Type {
+		INTERNAL,
+		EXTERNAL;
+	}
+	
+	@Builder.Default
+	private Type type = Type.INTERNAL;
+	private String pageId;
+	private String redirectUrl;
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
@@ -74,6 +74,7 @@ public enum Constants {
 	KEY_FUNCTION("fn"),
 	KEY_FUNCTION_NAME("name"),
 	
+	KEY_NAV_ARG_REDIRECT_URL("redirectUrl"),
 	KEY_NAV_ARG_PAGE_ID("pageId"),
 	
 	KEY_FN_INITSTATE_ARG_TARGET_PATH("target"),

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNavTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNavTest.java
@@ -1,0 +1,77 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.cmd.exec.internal.nav.PageNavigationResponse;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
+import com.antheminc.oss.nimbus.support.Holder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class DefaultActionExecutorNavTest extends AbstractFrameworkIngerationPersistableTests {
+
+	@Before
+	public void init() {
+		createOrGetDomainRoot_RefId();
+	}
+	
+	@Test(expected = InvalidConfigException.class)
+	public void testUnknownNavigation() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT)
+				.addRefId(domainRoot_refId)
+				.addAction(Action._nav).getMock();
+		this.controller.handleGet(request, null);
+	}
+	
+	@Test
+	public void testPageIdNavigation() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT)
+				.addRefId(domainRoot_refId)
+				.addAction(Action._nav)
+				.addParam(Constants.KEY_NAV_ARG_PAGE_ID.code, "page_green")
+				.getMock();
+		Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handleGet(request, null);
+		PageNavigationResponse actual = (PageNavigationResponse) response.getState().getSingleResult();
+		System.out.println(actual);
+		Assert.assertEquals(PageNavigationResponse.Type.INTERNAL, actual.getType());
+		Assert.assertEquals("page_green", actual.getPageId());
+	}
+	
+	@Test
+	public void testExternalRedirect() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT)
+				.addRefId(domainRoot_refId)
+				.addAction(Action._nav)
+				.addParam(Constants.KEY_NAV_ARG_REDIRECT_URL.code, "https://mywebsite.com")
+				.getMock();
+		Holder<MultiOutput> response = (Holder<MultiOutput>) this.controller.handleGet(request, null);
+		PageNavigationResponse actual = (PageNavigationResponse) response.getState().getSingleResult();
+		Assert.assertEquals(PageNavigationResponse.Type.EXTERNAL, actual.getType());
+		Assert.assertEquals("https://mywebsite.com", actual.getRedirectUrl());
+	}
+}

--- a/nimbus-ui/nimbusui/src/app/services/page.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/page.service.ts
@@ -39,6 +39,7 @@ import { ViewComponent } from '../shared/param-annotations.enum';
 import { TableBasedData } from './../shared/param-state';
 import { NmMessageService } from './toastmessage.service';
 import { Observable } from 'rxjs/Observable';
+import { PageNavigationResponse } from './../shared/page-navigation-response';
 
 /**
  * \@author Dinakar.Meda
@@ -375,9 +376,17 @@ export class PageService {
                         this.logger.debug('Navigation using browser back location');
                         this.location.back();
                 } else if (navOutput) {
-                        let flow = this.getFlowNameFromOutput(navOutput.inputCommandUri);
-                        let pageParam = this.findMatchingPageConfigById(navOutput.value, flow);
-                        this.navigateToPage(pageParam, flow);
+                        let navResponse = new PageNavigationResponse(navOutput.value);
+                        switch (navResponse.type) {
+                                case PageNavigationResponse.Type.EXTERNAL:
+                                        window.open(navResponse.redirectUrl, "_blank");
+                                        break;
+                                default:
+                                        let flow = this.getFlowNameFromOutput(navOutput.inputCommandUri);
+                                        let pageParam = this.findMatchingPageConfigById(navResponse.pageId, flow);
+                                        this.navigateToPage(pageParam, flow);
+                                        break;
+                        }
                 }
         }
 

--- a/nimbus-ui/nimbusui/src/app/shared/page-navigation-response.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/page-navigation-response.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2016-2019 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Converter } from './object.conversion';
+
+ 'use strict';
+
+/**
+ * \@author Tony Lopez
+ * \@whatItDoes 
+ * 
+ * \@howToUse 
+ * 
+ */
+enum Type {
+    INTERNAL = "INTERNAL",
+    EXTERNAL = "EXTERNAL"
+}
+
+/**
+ * \@author Tony Lopez
+ * \@whatItDoes 
+ * 
+ * \@howToUse 
+ * 
+ */
+export class PageNavigationResponse {
+
+    static readonly Type = Type;
+
+    type: Type = Type.INTERNAL;
+    pageId: string;
+    redirectUrl: string;
+
+    constructor(inJson: string) {
+        Converter.convert(inJson, this);
+    }
+}


### PR DESCRIPTION
# Description
Fixes #465 

Added configuration and UI support for navigating to external web pages using `@Config` and the default  `_nav` action executor.  See the following config:

```java
@Label("Nav Externally")
@Link
@Config(url = "/_nav?redirectUrl=https://mywebsite.com")
private String navExternally;

```


# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* `DefaultActionExecutorNav` Changes
  * Modified to accept query param `redirectUrl` as a URL string
  * Refactored the resulting object returned and received from `String` to `PageNavigationResponse`
* The UI framework now responds more intelligently to the `PageNavigationResponse` response received from the server

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] New feature

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* `DefaultActionExecutorNavTest`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

This change does not replace the existing `@Link(value = Type.EXTERNAL, target = "_blank", url = "url")` typed configuration. Rather it offers a new flavor for folks who are needing to also execute configs prior to navigating externally.