### PR TITLE
Exception message enhancements

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebActionControllerAdvice.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebActionControllerAdvice.java
@@ -106,7 +106,7 @@ public class WebActionControllerAdvice implements ResponseBodyAdvice<Object> {
 			} else {
 				Optional<Class<?>> hierarchyclass = exceptions.keySet()
 						.stream()
-						.filter(c -> c.isAssignableFrom(pEx.getClass()))
+						.filter(c -> null != c && c.isAssignableFrom(pEx.getClass()))
 						.findFirst();
 			
 				if (hierarchyclass.isPresent()) 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
@@ -108,6 +109,10 @@ public class DefaultActionExecutorGet extends AbstractCommandExecutor<Object> {
 			entity = instantiateEntity(eCtx, rootDomainConfig);
 		}
 
+		if (null == entity) {
+			throw new FrameworkRuntimeException("Entity not found for " + eCtx);
+		}
+		
 		if(rootDomainConfig.isMapped()) 
 			return handleMapped(rootDomainConfig, eCtx, entity, Action._get);
 		

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/FunctionExecutor.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/FunctionExecutor.java
@@ -15,6 +15,12 @@
  */
 package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.Behavior;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
@@ -32,44 +38,65 @@ import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
  *
  */
 @EnableLoggingInterceptor
-public class FunctionExecutor<T,R> extends AbstractCommandExecutor<R> {
+public class FunctionExecutor<T, R> extends AbstractCommandExecutor<R> {
 
 	public FunctionExecutor(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
 	}
-	
-	@Override
-	@SuppressWarnings("unchecked")
-	protected Output<R> executeInternal(Input input) {
-		R response =  (R)executeFunctionHanlder(input, FunctionHandler.class);
-		return Output.instantiate(input, input.getContext(), response);		
-	}
-	
-	protected <H extends FunctionHandler<T, R>> R executeFunctionHanlder(Input input, Class<H> handlerClass) {
-		ExecutionContext eCtx = input.getContext();
-		Param<T> actionParameter = findParamByCommandOrThrowEx(eCtx);
-		H processHandler = getHandler(input.getContext().getCommandMessage(), handlerClass);
-		return processHandler.execute(eCtx, actionParameter);
-	}	
-	
-	protected <F extends FunctionHandler<?, ?>> F getHandler(CommandMessage commandMessage, Class<F> handlerClass){
-		String functionName = constructFunctionHandlerKey(commandMessage);
-		return getHandler(functionName, handlerClass);
-	}	
-	
-	protected <F extends FunctionHandler<?, ?>> F getHandler(String functionName, Class<F> handlerClass){
-		return findMatchingBean(handlerClass, functionName);
-	}		
-	
-	private String constructFunctionHandlerKey(CommandMessage cmdMsg){
+
+	private String constructFunctionHandlerKey(CommandMessage cmdMsg) {
 		StringBuilder key = new StringBuilder();
 		String functionName = cmdMsg.getCommand().getFirstParameterValue(Constants.KEY_FUNCTION.code);
 		String absoluteUri = cmdMsg.getCommand().getAbsoluteAlias();
 		absoluteUri = absoluteUri.replaceAll(Constants.SEPARATOR_URI.code, "\\.");
 		key.append(absoluteUri).append(".").append(cmdMsg.getCommand().getAction().toString())
-		   .append(Behavior.$execute.name())
-		   .append(Constants.REQUEST_PARAMETER_MARKER.code).append(Constants.KEY_FUNCTION.code).append("=").append(functionName);
+				.append(Behavior.$execute.name()).append(Constants.REQUEST_PARAMETER_MARKER.code)
+				.append(Constants.KEY_FUNCTION.code).append("=").append(functionName);
 		return key.toString();
-	}	
-	
+	}
+
+	private Supplier<InvalidConfigException> handleUnknownFunctionHandler(Input input) {
+		CommandMessage commandMessage = input.getContext().getCommandMessage();
+		String functionName = commandMessage.getCommand().getFirstParameterValue(Constants.KEY_FUNCTION.code);
+		StringBuilder errorMessage = new StringBuilder(
+				"Unable to locate a function handler to execute from the command message: ");
+		errorMessage.append(input.getContext().getCommandMessage()).append("\".\n");
+		if (StringUtils.isEmpty(functionName)) {
+			errorMessage.append("No value was provided for the query parameter \"").append(Constants.KEY_FUNCTION.code)
+					.append("\".");
+		} else {
+			errorMessage.append("No function handler exists for \"").append(functionName)
+					.append("\". Please ensure that:").append("\n (1) -> ")
+					.append("The value for the query parameter \"").append(Constants.KEY_FUNCTION.code).append("\" (\"")
+					.append(functionName).append("\") is spelled correctly.").append("\n (2) -> ")
+					.append("The bean for ").append("\"").append(constructFunctionHandlerKey(commandMessage))
+					.append("\"").append(" exists.");
+		}
+		return () -> new InvalidConfigException(errorMessage.toString());
+	}
+
+	protected <H extends FunctionHandler<T, R>> R executeFunctionHandler(Input input, Class<H> handlerClass) {
+		ExecutionContext eCtx = input.getContext();
+		Param<T> actionParameter = findParamByCommandOrThrowEx(eCtx);
+		H processHandler = Optional.ofNullable(getHandler(input.getContext().getCommandMessage(), handlerClass))
+				.orElseThrow(this.handleUnknownFunctionHandler(input));
+		return processHandler.execute(eCtx, actionParameter);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected Output<R> executeInternal(Input input) {
+		R response = (R) executeFunctionHandler(input, FunctionHandler.class);
+		return Output.instantiate(input, input.getContext(), response);
+	}
+
+	protected <F extends FunctionHandler<?, ?>> F getHandler(CommandMessage commandMessage, Class<F> handlerClass) {
+		String functionName = constructFunctionHandlerKey(commandMessage);
+		return getHandler(functionName, handlerClass);
+	}
+
+	protected <F extends FunctionHandler<?, ?>> F getHandler(String functionName, Class<F> handlerClass) {
+		return findMatchingBean(handlerClass, functionName);
+	}
+
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/config/builder/DomainConfigBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/config/builder/DomainConfigBuilder.java
@@ -74,7 +74,10 @@ public class DomainConfigBuilder {
 	
 	public ModelConfig<?> getRootDomainOrThrowEx(String rootAlias) {
 		return Optional.ofNullable(getRootDomain(rootAlias))
-				.orElseThrow(()->new InvalidConfigException("Domain model config not found for root-alias: "+rootAlias));
+				.orElseThrow(() -> new InvalidConfigException("Domain model config not found for root-alias \""
+						+ rootAlias + "\".\n -> (1) Has the Java class for the domain entity been declared with @"
+						+ Domain.class.getSimpleName() + "(value = \"" + rootAlias + "\")?"
+						+ "\n -> (2) Has the package that includes the domain entity been defined in ${domain.model.basePackages}?"));
 	}
 
 


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

Adds more user-friendly exception message information for commonly experienced exceptions

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Exception message improvements
  * Command DSL Reference to an undefined function handler
    * See `FunctionExecutor.handleUnknownFunctionHandler`
  * Command DSL invocation of `_get` call on an entity that does not exist now gives `"Entity not found for /object:42"` instead of `"Both view and core can not be null"`
    * See `DefaultActionExecutorGet.createNewQuad`
  * Command DSL execution of an unknown domain alias offers suggestions for common errors. 
* Ran sort members/formatter on classes that were touched
* Added a `null` check for when `application.exceptions` in `application.yml` is empty, to prevent a `NullPointerException` in the global exception handler.

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Other

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

N/A

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
