### PR TITLE
External Model Repository fix for _get

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorGet.java
@@ -96,7 +96,7 @@ public class DefaultActionExecutorGet extends AbstractCommandExecutor<Object> {
 		
 		// db - entity
 		if(Repo.Database.exists(repo) ) {
-			if (refId != null) { // root (view or core) is persistent
+			if (refId != null || Repo.Database.rep_ws.equals(repo.value())) { // root (view or core) is persistent
 				entity = getRepositoryFactory().get(rootDomainConfig.getRepo())
 						._get(refId, rootDomainConfig.getReferredClass(), resolvedRepAlias, eCtx.getCommandMessage().getCommand().getAbsoluteUri());
 			} else {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/ModelRepositoryTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/ModelRepositoryTest.java
@@ -140,12 +140,12 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t3_testGet_Ext() {
-		final String requestUri = "piedpiper/encryption_3.9/p/ext_client:7/_get";
+		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_get";
 		Command cmd = CommandUtils.prepareCommand(requestUri);
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
-		this.mockServer.expect(requestTo(new StringContains(requestUri)))
+		this.mockServer.expect(requestTo("http://localhost:9095"))
 			.andRespond(withSuccess("{\"client\": {\"code\":\"example23\"}}", MediaType.APPLICATION_JSON));
 
 		MultiOutput multiOp = this.commandGateway.execute(cmdMsg);
@@ -160,25 +160,25 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 		assertEquals("example23", param.findParamByPath("/client/code").getState());
 	}
 	
-	// TODO - Set client object in db.
-	@Ignore
 	@Test
-	public void t4_testGet() {
-		final String requestUri = "piedpiper/encryption_3.9/p/client:7/_get";
+	public void testExternalGetWithRefId() {
+		final String requestUri = "piedpiper/encryption_3.9/p/ext_client:42/_get";
 		Command cmd = CommandUtils.prepareCommand(requestUri);
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
-		this.mockServer.expect(requestTo(new StringContains(requestUri)))
+		this.mockServer.expect(requestTo("http://localhost:9095"))
 			.andRespond(withSuccess("{\"client\": {\"code\":\"example23\"}}", MediaType.APPLICATION_JSON));
-		
+
 		MultiOutput multiOp = this.commandGateway.execute(cmdMsg);
 		
-		Param<?> param = (Param<?>) multiOp.getSingleResult();
+		Param<?> param = (Param<?>)multiOp.getSingleResult();
 		
-		assertNotNull("Param (Client) cannot be null", param.findParamByPath("/"));
-		assertNotNull("Param (client.code) cannot ne null", param.findParamByPath("/code"));
-		assertNotNull("ParamState (Client.code) cannot be null", param.findParamByPath("/code").getState());
+		assertNotNull("Param (ExtClient) cannot be null", param.findParamByPath("/"));
+		assertNotNull("Param (ExtClient.client.code) cannot ne null", param.findParamByPath("/client/code"));
+		assertNotNull("ParamState (ExtClient.Client.code) cannot be null", param.findParamByPath("/client/code").getState());
 		
+
+		assertEquals("example23", param.findParamByPath("/client/code").getState());
 	}
 }


### PR DESCRIPTION
# Description
<!-- Include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed an issue where `_get` on an external webservice domain was not working properly.

# Overview of Changes
<!-- Please include a bulleted list of changes here -->

* Added a provision to allow `_get` requests without a `refId` for entities where `@Repo(Database.rep_ws)` is present.
  * Added a warning when `refId` is sent, as it doesn't really make sense.
* Modified the external `_get` retrieval URL.
  * Previously a request to an external domain entity `"ext_client"` like `"/a/b/p/ext_client/foo/_get"` configured to point to: `"http://coolwebservice.com/api"` would invoke a webservice call via the url: `"http://coolwebservice.com/api/a/b/p/ext_client/foo/_get"`. Now, the same call invokes via `"http://coolwebservice.com/api"`

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

* `ModelRepositoryTest`

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
