### PR TITLE
NIMBUS-62: Tenant URL Extraction & Mongo Record Level Document Support

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultMongoConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultMongoConfig.java
@@ -26,11 +26,13 @@ import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.config.builder.DomainConfigBuilder;
+import com.antheminc.oss.nimbus.domain.model.state.repo.db.ModelRepositoryOptions.TenancyStrategy;
 import com.antheminc.oss.nimbus.domain.model.state.repo.db.MongoDBModelRepositoryOptions;
 import com.antheminc.oss.nimbus.domain.model.state.repo.db.MongoSearchByExampleOperation;
 import com.antheminc.oss.nimbus.domain.model.state.repo.db.MongoSearchByQueryOperation;
 import com.antheminc.oss.nimbus.domain.model.state.repo.db.mongo.DefaultMongoModelRepository;
 import com.antheminc.oss.nimbus.support.mongo.MongoConvertersBuilder;
+import com.antheminc.oss.nimbus.support.pojo.JavaBeanHandler;
 
 /**
  * @author Soham Chakravrati
@@ -51,10 +53,11 @@ public class DefaultMongoConfig {
 	}
 	
 	@Bean
-	public MongoDBModelRepositoryOptions defaultMongoDBModelRepositoryOptions(MongoOperations mongoOps, DomainConfigBuilder domainConfigBuilder) {
+	public MongoDBModelRepositoryOptions defaultMongoDBModelRepositoryOptions(MongoOperations mongoOps, DomainConfigBuilder domainConfigBuilder, JavaBeanHandler beanHandler) {
 		return MongoDBModelRepositoryOptions.builder()
-			.addSearchOperation(new MongoSearchByExampleOperation(mongoOps, domainConfigBuilder))
+			.addSearchOperation(new MongoSearchByExampleOperation(mongoOps, domainConfigBuilder, beanHandler))
 			.addSearchOperation(new MongoSearchByQueryOperation(mongoOps, domainConfigBuilder))
+			.tenancyStrategy(TenancyStrategy.RECORD)
 			.build();
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultMultitenancyConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultMultitenancyConfig.java
@@ -17,11 +17,14 @@ package com.antheminc.oss.nimbus.app.extension.config;
 
 import java.util.Optional;
 
+import org.apache.commons.collections.MapUtils;
 import org.springframework.context.annotation.Bean;
 
 import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.model.state.multitenancy.DefaultTenantRepository;
 import com.antheminc.oss.nimbus.domain.model.state.multitenancy.MultitenancyProperties;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.TenantFilter;
 import com.antheminc.oss.nimbus.domain.model.state.multitenancy.TenantRepository;
 
 /**
@@ -41,5 +44,10 @@ public class DefaultMultitenancyConfig {
 		.orElseThrow(() -> new InvalidConfigException(
 				"Unable to determine tenant information. Is \"${nimbus.multitenancy.tenants}\" set?"));
 		return new DefaultTenantRepository(multitenancyProperties);
+	}
+	
+	@Bean
+	public TenantFilter tenantFilter(BeanResolverStrategy beanResolver) {
+		return new TenantFilter(beanResolver);
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultMultitenancyConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/DefaultMultitenancyConfig.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.app.extension.config;
+
+import java.util.Optional;
+
+import org.springframework.context.annotation.Bean;
+
+import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.DefaultTenantRepository;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.MultitenancyProperties;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.TenantRepository;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class DefaultMultitenancyConfig {
+
+	@Bean
+	public MultitenancyProperties multitenancyProperties() {
+		return new MultitenancyProperties();
+	}
+	
+	@Bean
+	public TenantRepository tenantRepository(MultitenancyProperties multitenancyProperties) {
+		Optional.ofNullable(multitenancyProperties.getTenants())
+		.orElseThrow(() -> new InvalidConfigException(
+				"Unable to determine tenant information. Is \"${nimbus.multitenancy.tenants}\" set?"));
+		return new DefaultTenantRepository(multitenancyProperties);
+	}
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebActionController.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebActionController.java
@@ -37,27 +37,29 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContextLoader;
-import com.antheminc.oss.nimbus.domain.cmd.exec.FileImportGateway;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
 import com.antheminc.oss.nimbus.support.Holder;
 import com.antheminc.oss.nimbus.support.LoggingLevelService;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * STEPS to follow with examples. <br>
  * 
  * <p>EXAMPLES:</p>
- * Ex 1:  /anthem/icr/member/_search - POST operation which contains criteria <br>
- * Ex 2:  /anthem/icr/member/{id} - GET operation which has member id as path variable <br>
- * Ex 3:  /anthem/acmp/member/{id}/_info - GET operation which contains member id as path variable, but also contains an action 'info' to return less data <br>
- * Ex 4:  /anthem/acmp/um/case/{cid}/member/address/{aid} - GET operation to return one address from the collection <br>
- * Ex 5:  /anthem/acmp/um/case/{cid}/member/address		- POST operation to create new address <br>
- * Ex 6:  /anthem/icr/um/case/{cid}/member/address/{aid}?version=n - PUT operation to update a given address. This would be a complete model update <br>
- * Ex 7:  /anthem/icr/um/case/{cid}/member/address/{aid}?version=n - PATCH operation to update a given address. This would be a partial model update <br>
- * Ex 8:  /anthem/icr/member/_search$validate - POST operation which contains criteria which will be validated and response provided per field <br>
- * Ex 9:  /anthem/hrs/member/_search$config	 - GET operation that returns static meta data created for 'member/_search' process <br>
- * Ex 10: /anthem/hrs/um/case/{cid}/member/address$validate - POST operation that contains address field populated which will be validated at each field level <br>
- * Ex 11: /anthem/hrs/address$validate - POST operation
+ * Ex 1:  /hooli/1/thebox/p/member/_search - POST operation which contains criteria <br>
+ * Ex 2:  /hooli/1/thebox/p/member/{id} - GET operation which has member id as path variable <br>
+ * Ex 3:  /hooli/1/thebox/p/member/{id}/_info - GET operation which contains member id as path variable, but also contains an action 'info' to return less data <br>
+ * Ex 4:  /hooli/1/thebox/p/case/{cid}/member/address/{aid} - GET operation to return one address from the collection <br>
+ * Ex 5:  /hooli/1/thebox/p/case/{cid}/member/address		- POST operation to create new address <br>
+ * Ex 6:  /hooli/1/thebox/p/case/{cid}/member/address/{aid}?version=n - PUT operation to update a given address. This would be a complete model update <br>
+ * Ex 7:  /hooli/1/thebox/p/case/{cid}/member/address/{aid}?version=n - PATCH operation to update a given address. This would be a partial model update <br>
+ * Ex 8:  /hooli/1/thebox/p/member/_search$validate - POST operation which contains criteria which will be validated and response provided per field <br>
+ * Ex 9:  /hooli/1/thebox/p/member/_search$config	 - GET operation that returns static meta data created for 'member/_search' process <br>
+ * Ex 10: /hooli/1/thebox/p/case/{cid}/member/address$validate - POST operation that contains address field populated which will be validated at each field level <br>
+ * Ex 11: /hooli/1/thebox/p//address$validate - POST operation
  * <br>
  * <br>
  * <p>STEPS:</p>
@@ -93,7 +95,7 @@ import com.antheminc.oss.nimbus.support.LoggingLevelService;
  *
  */
 @RestController
-//@EnableResourceServer
+@Getter @Setter
 public class WebActionController {
 	
 	public static final String URI_PATTERN_P = "/{clientCode}/**/p";

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebCommandBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebCommandBuilder.java
@@ -27,10 +27,14 @@ import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
 import com.antheminc.oss.nimbus.support.JustLogit;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @author Soham Chakravarti
  *
  */
+@Getter @Setter
 public class WebCommandBuilder {
 
 	private JustLogit logit = new JustLogit(this.getClass());
@@ -57,13 +61,11 @@ public class WebCommandBuilder {
 		}
 		
 		
-		Command cmd = handleInternal(constructedUri, request.getParameterMap());
-		return cmd;
+		return handleInternal(constructedUri, request.getParameterMap());
 	}
 	
 	public Command handleInternal(String uri, Map<String, String[]> rParams) {
-		Command cmd = CommandBuilder.withUri(uri).addParams(rParams).getCommand();
-		return cmd;
+		return CommandBuilder.withUri(uri).addParams(rParams).getCommand();
 	} 
 	
 	private String constructRequestUri(HttpServletRequest request) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebCommandDispatcher.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/channel/web/WebCommandDispatcher.java
@@ -20,10 +20,10 @@ package com.antheminc.oss.nimbus.channel.web;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.antheminc.oss.nimbus.channel.CommandDispatcher;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
-import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
@@ -35,16 +35,13 @@ import lombok.Getter;
  */
 @Getter
 @EnableLoggingInterceptor
-public class WebCommandDispatcher {
+public class WebCommandDispatcher extends CommandDispatcher {
 
 	private final WebCommandBuilder builder;
-
-	private final CommandExecutorGateway gateway;
-
+	
 	public WebCommandDispatcher(BeanResolverStrategy beanResolver) {
+		super(beanResolver);
 		this.builder = beanResolver.get(WebCommandBuilder.class);
-		this.gateway = beanResolver.get(CommandExecutorGateway.class);
-		
 	}
 	
 	public Object handle(HttpServletRequest httpReq, ModelEvent<String> event) {
@@ -55,9 +52,5 @@ public class WebCommandDispatcher {
 	public Object handle(HttpServletRequest httpReq, String json) {
 		Command cmd = getBuilder().build(httpReq);
 		return handle(cmd, json);
-	}
-
-	public MultiOutput handle(Command cmd, String payload) {
-		return getGateway().execute(cmd, payload);
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/converter/tabular/TabularDataFileImporter.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/converter/tabular/TabularDataFileImporter.java
@@ -99,7 +99,7 @@ public class TabularDataFileImporter implements Importer {
 		if (WriteStrategy.COMMAND_DSL == writeStrategy) {
 			onRowProcess = new CommandHandlingBeanWriter(getOm(), getCommandGateway(), command);
 		} else if (WriteStrategy.MODEL_REPOSITORY == writeStrategy) {
-			onRowProcess = new ModelRepositoryBeanWriter<Object>(getDomainConfigBuilder(), getModelRepositoryFactory());
+			onRowProcess = new ModelRepositoryBeanWriter<>(getDomainConfigBuilder(), getModelRepositoryFactory(), command);
 		} else {
 			throw new UnsupportedOperationException("Write strategy for" + writeStrategy + " is not supported.");
 		}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/converter/writer/ModelRepositoryBeanWriter.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/converter/writer/ModelRepositoryBeanWriter.java
@@ -17,6 +17,7 @@ package com.antheminc.oss.nimbus.converter.writer;
 
 import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.converter.RowProcessable.RowProcessingHandler;
+import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.config.builder.DomainConfigBuilder;
 import com.antheminc.oss.nimbus.domain.model.config.ModelConfig;
 import com.antheminc.oss.nimbus.domain.model.state.repo.ModelRepository;
@@ -36,6 +37,7 @@ public class ModelRepositoryBeanWriter<T> implements RowProcessingHandler<T> {
 
 	private final DomainConfigBuilder domainConfigBuilder;
 	private final ModelRepositoryFactory modelRepositoryFactory;
+	private final Command command;
 	
 	@SuppressWarnings("unchecked")
 	@Override
@@ -45,7 +47,7 @@ public class ModelRepositoryBeanWriter<T> implements RowProcessingHandler<T> {
 			throw new FrameworkRuntimeException("Unable to find model config for " + bean);
 		}
 		ModelRepository modelRepository = getModelRepositoryFactory().get(modelConfig.getRepo());
-		T newState = modelRepository._new(null, modelConfig, bean);
+		T newState = modelRepository._new(command, modelConfig, bean);
 		modelRepository._save(modelConfig.getAlias(), newState);
 	}
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilder.java
@@ -92,7 +92,8 @@ public class CommandBuilder {
 		tmpCmd.getRootDomainElement().setAlias(replaceDomainRootAlias);
 		
 		String newAbsoluteUri = tmpCmd.buildUri(Type.DomainAlias);
-		return withUri(newAbsoluteUri);
+		CommandBuilder cb = withUri(newAbsoluteUri);
+		return cb;
 	}
 	
 	public CommandBuilder stripRequestParams() {
@@ -175,7 +176,7 @@ public class CommandBuilder {
 			startingIndex = 1;
 		}
 		
-		Type type = Type.ClientOrgAlias;
+		Type type = Type.TENANT_ID;
 		
 		for(int i=startingIndex; i<uriSplit.length; i++) {
 			String val = uriSplit[i];

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandElement.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/CommandElement.java
@@ -39,7 +39,7 @@ abstract public class CommandElement implements Serializable {
 	public enum Type {
 		
 		ClientAlias("ClientAlias", false),
-		ClientOrgAlias("ClientOrgAlias", false),
+		TENANT_ID("TenantId", false),
 		AppAlias("AppAlias", false),
 		PlatformMarker("PlatformMarker", false),
 		DomainAlias("DomainAlias", true),

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/ExecutionContext.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/ExecutionContext.java
@@ -57,7 +57,7 @@ public class ExecutionContext implements Serializable {
 	}
 	
 	public String getId() {
-		return getCommandMessage().getCommand().getRootDomainUri();
+		return getCommandMessage().getCommand().getAbsoluteAliasUntilRootDomain(true);
 	}
 	
 	public boolean equalsId(Command cmd) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProvider.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProvider.java
@@ -15,28 +15,23 @@
  */
 package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
-import java.beans.PropertyDescriptor;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutor;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
 import com.antheminc.oss.nimbus.domain.model.state.HierarchyMatch;
-import com.antheminc.oss.nimbus.entity.AbstractEntity;
 import com.antheminc.oss.nimbus.entity.StaticCodeValue;
 
 import lombok.Getter;
@@ -51,7 +46,6 @@ public class ParamCodeValueProvider implements HierarchyMatch, CommandExecutor<L
 	
 	private static final String DEFAULT_KEY_ATTRIBUTE = "id";
 	private static final String KEY_VALUE_SEPERATOR = "&";
-	public static final String STATIC_CODE_VALUE = "staticCodeValue";
 	
 	DefaultActionExecutorSearch searchExecutor;
 	
@@ -76,7 +70,7 @@ public class ParamCodeValueProvider implements HierarchyMatch, CommandExecutor<L
 	public Output<List<ParamValue>> execute(Input input) {
 		CommandMessage cmdMsg = input.getContext().getCommandMessage();
 		final List<ParamValue> codeValues;
-		if(StringUtils.equalsIgnoreCase(cmdMsg.getCommand().getElementSafely(Type.DomainAlias).getAlias(), STATIC_CODE_VALUE)) {
+		if(StringUtils.equalsIgnoreCase(cmdMsg.getCommand().getElementSafely(Type.DomainAlias).getAlias(), Constants.STATIC_CODE_VALUE.code)) {
 			codeValues = getStaticCodeValue(input);
 		}
 		else{

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
@@ -21,6 +21,7 @@ package com.antheminc.oss.nimbus.domain.defn;
  */
 public enum Constants {
 	
+	FIELD_NAME_TENANT_ID("_tenantId"),
 	FIELD_NAME_VERSION("version"),
 	
 	MARKER_URI_PLATFORM("p"),

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
@@ -20,6 +20,8 @@ package com.antheminc.oss.nimbus.domain.defn;
  *
  */
 public enum Constants {
+
+	ACTIVE_TENANT_COOKIE("NIMBUS_ACTIVE_TENANT_PREFIX"),
 	
 	FIELD_NAME_TENANT_ID("_tenantId"),
 	FIELD_NAME_VERSION("version"),

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
@@ -20,7 +20,9 @@ package com.antheminc.oss.nimbus.domain.defn;
  *
  */
 public enum Constants {
-
+	
+	FIELD_NAME_VERSION("version"),
+	
 	MARKER_URI_PLATFORM("p"),
 	MARKER_URI_BEHAVIOR("b"),
 	MARKER_COLLECTION_ELEM_INDEX("{index}"),
@@ -59,6 +61,7 @@ public enum Constants {
 	
 	SEPARATOR_AND("And"),
 	SEPARATOR_MAPSTO(".m"),
+	STATIC_CODE_VALUE("staticCodeValue"),
 	
 	PREFIX_FLOW("flow_"),
 	PREFIX_DEFAULT("default."),

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/StaticCodeValueBasedCodeToLabelConverter.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/StaticCodeValueBasedCodeToLabelConverter.java
@@ -52,7 +52,7 @@ public class StaticCodeValueBasedCodeToLabelConverter implements ParamConverter<
 	@Override
 	public String serialize(String input) {
 		//TODO - need to make this generic
-		Command cmd = CommandBuilder.withUri("Anthem/icr/p/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramValues.any().code.eq('"+input+"')").getCommand();
+		Command cmd = CommandBuilder.withUri("hooli/1/thebox/p/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramValues.any().code.eq('"+input+"')").getCommand();
 		cmd.setAction(Action._search);
 		
 		CommandMessage cmdMsg = new CommandMessage();

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/messagequeue/MessageQueueEvent.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/messagequeue/MessageQueueEvent.java
@@ -18,15 +18,16 @@ package com.antheminc.oss.nimbus.domain.model.state.messagequeue;
 import com.antheminc.oss.nimbus.domain.model.state.internal.AbstractEvent;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author Tony Lopez
  *
  */
-@Data
+@Getter @Setter
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class MessageQueueEvent extends AbstractEvent<String, String> {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/DefaultTenantRepository.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/DefaultTenantRepository.java
@@ -1,0 +1,102 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.BeanUtils;
+import org.springframework.util.AntPathMatcher;
+
+import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.MultitenancyProperties.TenantDetail;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * <p>A default {@link TenantRepository} implementation that reads tenant
+ * information from application properties.
+ * 
+ * @author Tony Lopez
+ * @since 2.0
+ *
+ */
+@Getter
+@Setter
+public class DefaultTenantRepository implements TenantRepository {
+
+	private final MultitenancyProperties multitenancyProperties;
+	private final AntPathMatcher pathMatcher;
+
+	public DefaultTenantRepository(MultitenancyProperties multitenancyProperties) {
+		this.multitenancyProperties = multitenancyProperties;
+		this.pathMatcher = new AntPathMatcher();
+	}
+
+	@Override
+	public Tenant findById(Long id) {
+		if (null == id || MapUtils.isEmpty(this.multitenancyProperties.getTenants())) {
+			return null;
+		}
+		return this.toTenant(id, this.multitenancyProperties.getTenants().get(id));
+	}
+	
+	@Override
+	public Set<Tenant> findByIds(Set<Long> ids) {
+		if (CollectionUtils.isEmpty(ids) || MapUtils.isEmpty(this.multitenancyProperties.getTenants())) {
+			return new HashSet<>();
+		}
+		Set<Tenant> tenants = new HashSet<>();
+		ids.stream().map(this::findById).forEach(tenants::add);
+		return tenants;
+	}
+	
+	@Override
+	public Tenant findOneMatchingPrefix(String value) {
+		List<Tenant> matchingTenants = new ArrayList<>();
+		for (Entry<Long, TenantDetail> entry : this.multitenancyProperties.getTenants().entrySet()) {
+			final String pathToMatch = entry.getValue().getPrefix();
+			if (StringUtils.isEmpty(pathToMatch)) {
+				throw new InvalidConfigException(
+						"Tenant prefix must be defined but was not. Tenant details: " + entry.getValue());
+			}
+			if (this.pathMatcher.match(pathToMatch, value)) {
+				matchingTenants.add(this.toTenant(entry.getKey(), entry.getValue()));
+			}
+		}
+
+		if (CollectionUtils.isEmpty(matchingTenants)) {
+			return null;
+		}
+
+		// TODO find best match
+		return matchingTenants.get(0);
+	}
+
+	private Tenant toTenant(Long id, TenantDetail tenantDetail) {
+		Tenant tenant = new Tenant();
+		BeanUtils.copyProperties(tenantDetail, tenant);
+		tenant.setId(id);
+		return tenant;
+	}
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/MultitenancyProperties.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/MultitenancyProperties.java
@@ -13,20 +13,35 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.antheminc.oss.nimbus.test.domain.support;
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
 
-import com.antheminc.oss.nimbus.domain.defn.Constants;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
+ * <p>Holds configured properties related to multitenancy.
+ * 
  * @author Tony Lopez
+ * @since 2.0
  *
  */
-public abstract class AbstractFrameworkTest {
+@Getter
+@Setter
+@ToString
+@ConfigurationProperties("nimbus.multitenancy")
+public class MultitenancyProperties {
 
-	protected static final String CLIENT_ID = "hooli";
-	protected static final Long TENANT_ID = 1L;
-	protected static final String APP_ID = "thebox";
-	protected static final String CMD_PREFIX = "/" + CLIENT_ID + "/" + TENANT_ID + "/" + APP_ID;
-	protected static final String PLATFORM_ROOT = CMD_PREFIX + "/"
-			+ Constants.MARKER_URI_PLATFORM.code;
+	@Getter
+	@Setter
+	public static class TenantDetail {
+		private String description;
+		private String prefix;
+	}
+
+	private Map<Long, TenantDetail> tenants;
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/Tenant.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/Tenant.java
@@ -13,20 +13,31 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.antheminc.oss.nimbus.test.domain.support;
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
 
-import com.antheminc.oss.nimbus.domain.defn.Constants;
+import java.io.Serializable;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
+ * <p>A model object containing tenant information.
+ * 
  * @author Tony Lopez
+ * @since 2.0
  *
  */
-public abstract class AbstractFrameworkTest {
+@Getter
+@Setter
+@ToString(of = { "id", "prefix" })
+public class Tenant implements Serializable {
 
-	protected static final String CLIENT_ID = "hooli";
-	protected static final Long TENANT_ID = 1L;
-	protected static final String APP_ID = "thebox";
-	protected static final String CMD_PREFIX = "/" + CLIENT_ID + "/" + TENANT_ID + "/" + APP_ID;
-	protected static final String PLATFORM_ROOT = CMD_PREFIX + "/"
-			+ Constants.MARKER_URI_PLATFORM.code;
+	private static final long serialVersionUID = 1L;
+
+	private Long id;
+
+	private String description;
+	
+	private String prefix;
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/TenantFilter.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/TenantFilter.java
@@ -1,0 +1,118 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
+import com.antheminc.oss.nimbus.channel.web.WebCommandBuilder;
+import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
+import com.antheminc.oss.nimbus.domain.session.SessionProvider;
+import com.antheminc.oss.nimbus.entity.client.user.ClientUser;
+
+/**
+ * 
+ * @author Sandeep Mantha
+ *
+ */
+public class TenantFilter extends OncePerRequestFilter {
+
+	public static final String URI_PATTERN_P = "/**/p/**";
+
+	private final SessionProvider sessionProvider;
+
+	private TenantRepository tenantRepository;
+
+	private WebCommandBuilder builder;
+
+	private final AntPathMatcher pathMatcher;
+
+	public TenantFilter(BeanResolverStrategy beanResolver) {
+		this.sessionProvider = beanResolver.get(SessionProvider.class);
+		this.tenantRepository = beanResolver.get(TenantRepository.class);
+		this.builder = beanResolver.get(WebCommandBuilder.class);
+		this.pathMatcher = new AntPathMatcher();
+	}
+
+	protected boolean canAccessTenant(ClientUser user, Long tenantId) {
+		return user.getTenantIds().stream().anyMatch(tenantId::equals);
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		ClientUser user = sessionProvider.getLoggedInUser();
+		if (user == null) {
+			throw new FrameworkRuntimeException(
+					"Tenant/user information is missing. Please contact a system administrator.");
+		}
+		if (!isAuthorized(request, user)) {
+			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+			throw new FrameworkRuntimeException(
+					"Request is not authorized as the tenant information is not valid. Please contact a system administrator.");
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	protected boolean isAuthorized(HttpServletRequest request, ClientUser user) {
+		Cookie[] cookies = request.getCookies();
+		Stream<Cookie> stream = Objects.nonNull(cookies) ? Arrays.stream(cookies) : Stream.empty();
+		String cookieValue = stream.filter(cookie -> Constants.ACTIVE_TENANT_COOKIE.code.equals(cookie.getName()))
+				.findFirst().orElse(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, null)).getValue();
+
+		// the cookie value should always be present.
+		if (StringUtils.isBlank(cookieValue)) {
+			return false;
+		}
+
+		// check if the user has access to the tenant passed in the cookie
+		Tenant tenant = this.tenantRepository.findOneMatchingPrefix(cookieValue);
+		if (tenant == null) {
+			return false;
+		}
+
+		// check if the cookie value has been tampered with
+		final Command cmd = this.builder.build(request);
+		final String tenantPrefixInSession = this.sessionProvider.getAttribute(Constants.ACTIVE_TENANT_COOKIE.code);
+		if (!StringUtils.equals(cookieValue, tenantPrefixInSession)
+				|| !StringUtils.equals(cmd.getPrefix(), tenantPrefixInSession)) {
+			return false;
+		}
+
+		return canAccessTenant(user, cmd.getTenantId());
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return !this.pathMatcher.match(URI_PATTERN_P, request.getRequestURI());
+	}
+
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/TenantRepository.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/TenantRepository.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
+
+import java.util.Set;
+
+/**
+ * <p>A repository for providing tenant objects.
+ * 
+ * @author Tony Lopez
+ * @since 2.0
+ *
+ */
+public interface TenantRepository {
+
+	/**
+	 * <p>Find a {@link Tenant} by it's unique id.
+	 * @param id the of the {@link Tenant} to find
+	 * @return the {@link Tenant} object
+	 */
+	Tenant findById(Long id);
+	
+	/**
+	 * <p>Find a list of {@link Tenant} by all unique ids.
+	 * @param ids the set of id's for {@link Tenant} objects to find
+	 * @return the {@link Tenant} object
+	 */
+	Set<Tenant> findByIds(Set<Long> ids);
+	
+	/**
+	 * <p>Find a {@link Tenant} object where the provided {@code value} matches
+	 * the tenant object's prefix.
+	 * @param value the value to match against all known {@link Tenant} object's
+	 *            prefix.
+	 * @return the {@link Tenant} object
+	 */
+	Tenant findOneMatchingPrefix(String value);
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/DBSearchOperation.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/DBSearchOperation.java
@@ -23,5 +23,5 @@ public interface DBSearchOperation {
 	
 	boolean shouldAllow(SearchCriteria<?> criteria);
 	
-	<T> Object search(Class<T> referredClass, String alias, SearchCriteria<?> criteria);
+	<T> Object search(Class<T> referredClass, String alias, SearchCriteria<?> criteria, ModelRepositoryOptions options);
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ModelRepositoryOptions.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ModelRepositoryOptions.java
@@ -16,6 +16,9 @@
 package com.antheminc.oss.nimbus.domain.model.state.repo.db;
 
 /**
+ * <p>A simple encapsulation for common options across {@link ModelRepository}
+ * implementations.
+ * 
  * @author Tony Lopez
  *
  */

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ModelRepositoryOptions.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ModelRepositoryOptions.java
@@ -39,6 +39,12 @@ public interface ModelRepositoryOptions {
 		 * <p> Default strategy that implies no tenancy strategy should be used.
 		 */
 		NONE,
+
+		/**
+		 * <p> Record level based strategy that mandates tenant information is
+		 * stored and read as part of the domain entity.
+		 */
+		RECORD;
 	}
 
 	/**

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ModelRepositoryOptions.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ModelRepositoryOptions.java
@@ -15,6 +15,8 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.repo.db;
 
+import com.antheminc.oss.nimbus.domain.model.state.repo.ModelRepository;
+
 /**
  * <p>A simple encapsulation for common options across {@link ModelRepository}
  * implementations.
@@ -24,4 +26,25 @@ package com.antheminc.oss.nimbus.domain.model.state.repo.db;
  */
 public interface ModelRepositoryOptions {
 
+	/**
+	 * <p> A strategy definition used to determine the read/write control in
+	 * relation to tenancy.
+	 * 
+	 * @author Tony Lopez
+	 *
+	 */
+	public enum TenancyStrategy {
+
+		/**
+		 * <p> Default strategy that implies no tenancy strategy should be used.
+		 */
+		NONE,
+	}
+
+	/**
+	 * <p> Get the strategy that should be used to determine how data should be
+	 * handled in regards to tenancy.
+	 * @return the {@link TenancyStrategy} object
+	 */
+	TenancyStrategy getTenancyStrategy();
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoDBModelRepositoryOptions.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoDBModelRepositoryOptions.java
@@ -25,7 +25,7 @@ import lombok.Getter;
  *
  */
 @Getter
-public class MongoDBModelRepositoryOptions {
+public class MongoDBModelRepositoryOptions implements ModelRepositoryOptions {
 
 	public static class Builder {
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoDBModelRepositoryOptions.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoDBModelRepositoryOptions.java
@@ -30,6 +30,7 @@ public class MongoDBModelRepositoryOptions implements ModelRepositoryOptions {
 	public static class Builder {
 
 		private final List<MongoDBSearchOperation> searchOperations = new ArrayList<>();
+		private TenancyStrategy tenancyStrategy = TenancyStrategy.NONE;
 
 		public Builder() {
 
@@ -41,6 +42,11 @@ public class MongoDBModelRepositoryOptions implements ModelRepositoryOptions {
 
 		public Builder addSearchOperation(MongoDBSearchOperation searchOperation) {
 			this.searchOperations.add(searchOperation);
+			return this;
+		}
+		
+		public Builder tenancyStrategy(TenancyStrategy tenancyStrategy) {
+			this.tenancyStrategy = tenancyStrategy;
 			return this;
 		}
 
@@ -58,8 +64,10 @@ public class MongoDBModelRepositoryOptions implements ModelRepositoryOptions {
 	}
 
 	private final List<MongoDBSearchOperation> searchOperations;
+	private final TenancyStrategy tenancyStrategy;
 
 	public MongoDBModelRepositoryOptions(Builder builder) {
 		this.searchOperations = builder.searchOperations;
+		this.tenancyStrategy = builder.tenancyStrategy;
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByExampleOperation.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByExampleOperation.java
@@ -53,8 +53,8 @@ public class MongoSearchByExampleOperation extends MongoDBSearchOperation {
 	}
 
 	@Override
-	public <T> Object search(Class<T> referredClass, String alias, SearchCriteria<?> criteria) {
-		Query query = buildQuery(referredClass, alias, criteria.getWhere());
+	public <T> Object search(Class<T> referredClass, String alias, SearchCriteria<?> criteria, ModelRepositoryOptions options) {
+		Query query = buildQuery(referredClass, alias, criteria.getWhere(), options);
 		
 		if(StringUtils.equalsIgnoreCase(criteria.getAggregateCriteria(),Constants.SEARCH_REQ_AGGREGATE_COUNT.code)){
 			return getMongoOps().count(query, referredClass, alias);
@@ -72,7 +72,7 @@ public class MongoSearchByExampleOperation extends MongoDBSearchOperation {
 		
 	}
 
-	private <T> Query buildQuery(Class<?> referredClass, String alias, T criteria) {
+	private <T> Query buildQuery(Class<?> referredClass, String alias, T criteria, ModelRepositoryOptions options) {
 		if(criteria == null) 
 			return new Query();
 		

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByQueryOperation.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/MongoSearchByQueryOperation.java
@@ -127,16 +127,16 @@ public class MongoSearchByQueryOperation extends MongoDBSearchOperation {
 	}
 	
 	@Override
-	public <T> Object search(Class<T> referredClass, String alias, SearchCriteria<?> criteria) {
+	public <T> Object search(Class<T> referredClass, String alias, SearchCriteria<?> criteria, ModelRepositoryOptions options) {
 		String where = (String) criteria.getWhere();
 		if(StringUtils.isNotBlank(where) && AGGREGATION_QUERY_REGEX_PATTERN.matcher(where).matches()) {
-			return searchByAggregation(referredClass, alias, criteria);
+			return searchByAggregation(referredClass, alias, criteria, options);
 		}
-		return searchByQuery(referredClass, alias, criteria);
+		return searchByQuery(referredClass, alias, criteria, options);
 	}
 	
 	
-	private <T> Object searchByQuery(Class<?> referredClass, String alias, SearchCriteria<T> criteria) {
+	private <T> Object searchByQuery(Class<?> referredClass, String alias, SearchCriteria<T> criteria, ModelRepositoryOptions options) {
 		Class<?> outputClass = findOutputClass(criteria, referredClass);
 		
 		AbstractMongodbQuery query = new QueryBuilder(getMongoOps(), outputClass, alias)
@@ -185,7 +185,7 @@ public class MongoSearchByQueryOperation extends MongoDBSearchOperation {
 		return paths.toArray(new PathBuilder[paths.size()]);
 	}
 	
-	private  <T> Object searchByAggregation(Class<?> referredClass, String alias, SearchCriteria<T> criteria) {
+	private  <T> Object searchByAggregation(Class<?> referredClass, String alias, SearchCriteria<T> criteria, ModelRepositoryOptions options) {
 		List<?> output = new ArrayList();
 		String cr = (String)criteria.getWhere();
 		Document query = Document.parse(cr);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/mongo/DefaultMongoModelRepository.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/mongo/DefaultMongoModelRepository.java
@@ -183,6 +183,6 @@ public class DefaultMongoModelRepository implements ModelRepository {
 		if (!searchOperation.isPresent()) {
 			throw new FrameworkRuntimeException("Unable to determine search operation for search criteria: " + sc);
 		}
-		return searchOperation.get().search(referredClass, alias, sc);
+		return searchOperation.get().search(referredClass, alias, sc, this.options);
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/AbstractEntity.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/AbstractEntity.java
@@ -81,6 +81,9 @@ public abstract class AbstractEntity<ID extends Serializable> implements Seriali
     //@Version
 	@Setter private long version;
 	
+	@Ignore
+	@Setter
+	private Long _tenantId;
 	
 	@JsonIgnore
 	public <T extends AbstractEntityBehavior<M, ID>, M extends AbstractEntity<ID>> T newBehaviorInstance(Class<T> clazz) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/client/ClientEntity.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/client/ClientEntity.java
@@ -57,7 +57,6 @@ public class ClientEntity extends AbstractEntity.IdLong {
 	
 	
 	@NotNull
-	//@Model.Param.Values(url="Anthem/icr/p/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/orgType')")
     private Type type;
 	
 	private String code;
@@ -67,7 +66,6 @@ public class ClientEntity extends AbstractEntity.IdLong {
 	
 	
 	@NotNull
-	//@Model.Param.Values(url="Anthem/icr/p/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/orgStatus')")
 	private Status status;
 	
 	private String description;

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/client/user/ClientUser.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/entity/client/user/ClientUser.java
@@ -16,6 +16,7 @@
 package com.antheminc.oss.nimbus.entity.client.user;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.annotation.ReadOnlyProperty;
 
@@ -25,7 +26,6 @@ import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
 import com.antheminc.oss.nimbus.entity.client.Client;
-import com.antheminc.oss.nimbus.entity.client.ClientEntity;
 import com.antheminc.oss.nimbus.entity.client.access.ClientAccessEntity;
 import com.antheminc.oss.nimbus.entity.client.access.ClientUserRole;
 import com.antheminc.oss.nimbus.entity.user.AbstractUser;
@@ -52,6 +52,7 @@ public class ClientUser extends AbstractUser<ClientUserRole> {
 	@Ignore 
 	private Client client;
 
+	private Set<Long> tenantIds;
 	private List<UserRole> roles;
 	private List<UserStatus> userStatuses;
 	

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/CommandUtils.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/CommandUtils.java
@@ -15,14 +15,11 @@
  */
 package com.antheminc.oss.nimbus.support;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.antheminc.oss.nimbus.domain.cmd.Behavior;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
-import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.google.common.base.Enums;
 
 /**
@@ -67,14 +64,6 @@ public final class CommandUtils {
 			return defaultValue;
 		}
 		return (T) Enums.getIfPresent(defaultValue.getClass(), sRequestParamValue.toUpperCase()).or(defaultValue);
-	}
-
-	public static Command prepareCommand(String uri, Behavior... behaviors) {
-		final Command command = CommandBuilder.withUri(uri).getCommand();
-		if (behaviors != null) {
-			Arrays.asList(behaviors).forEach((b) -> command.templateBehaviors().add(b));
-		}
-		return command;
 	}
 
 	private CommandUtils() {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/fi/util/SupplierUtils.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/support/fi/util/SupplierUtils.java
@@ -15,6 +15,7 @@
  */
 package com.antheminc.oss.nimbus.support.fi.util;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.antheminc.oss.nimbus.FrameworkRuntimeException;
@@ -25,6 +26,40 @@ import com.antheminc.oss.nimbus.support.fi.ThrowingSupplier;
  *
  */
 public class SupplierUtils {
+
+	public static final String REQUIRE_ERROR_MSG = "Field must not be null.";
+
+	/**
+	 * <p> Get the value given from the provided supplier or throw a
+	 * {@link FrameworkRuntimeException}.
+	 * @param s the supplier to retrieve
+	 * @return the supplier value
+	 */
+	public static <T> T acquire(Supplier<T> s) {
+		return acquire(s, REQUIRE_ERROR_MSG);
+	}
+
+	/**
+	 * <p> Get the value given from the provided supplier or throw a
+	 * {@link RuntimeException}.
+	 * @param s the supplier to retrieve
+	 * @param errorMsg the error message to use in the thrown exception
+	 * @return the supplier value
+	 */
+	public static <T> T acquire(Supplier<T> s, RuntimeException e) {
+		return Optional.ofNullable(s.get()).orElseThrow(() -> e);
+	}
+
+	/**
+	 * <p> Get the value given from the provided supplier or throw a
+	 * {@link FrameworkRuntimeException}.
+	 * @param s the supplier to retrieve
+	 * @param errorMsg the error message to use in the thrown exception
+	 * @return the supplier value
+	 */
+	public static <T> T acquire(Supplier<T> s, String errorMsg) {
+		return acquire(s, new FrameworkRuntimeException(errorMsg));
+	}
 
 	/**
 	 * <p>Convenience method for handling suppliers that wraps any thrown
@@ -65,5 +100,8 @@ public class SupplierUtils {
 				throw e;
 			}
 		};
+	}
+
+	private SupplierUtils() {
 	}
 }

--- a/nimbus-core/src/main/resources/META-INF/spring.factories
+++ b/nimbus-core/src/main/resources/META-INF/spring.factories
@@ -9,4 +9,5 @@ com.antheminc.oss.nimbus.app.extension.config.DefaultCoreBuilderConfig,\
 com.antheminc.oss.nimbus.app.extension.config.ActivitiProcessAsBeanRegistrar,\
 com.antheminc.oss.nimbus.app.extension.config.DefaultFrameworkExtensionsConfig,\
 com.antheminc.oss.nimbus.app.extension.config.properties.ActiveMQConfigurationProperties,\
-com.antheminc.oss.nimbus.app.extension.config.DefaultActiveMQConfig
+com.antheminc.oss.nimbus.app.extension.config.DefaultActiveMQConfig,\
+com.antheminc.oss.nimbus.app.extension.config.DefaultMultitenancyConfig

--- a/nimbus-core/src/test/java/com/antheminc/oss/nimbus/AbstractFrameworkTest.java
+++ b/nimbus-core/src/test/java/com/antheminc/oss/nimbus/AbstractFrameworkTest.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus;
+
+import com.antheminc.oss.nimbus.domain.defn.Constants;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public abstract class AbstractFrameworkTest {
+
+	protected static final String CLIENT_ID = "hooli";
+	protected static final Long TENANT_ID = 1L;
+	protected static final String APP_ID = "thebox";
+	protected static final String CMD_PREFIX = "/" + CLIENT_ID + "/" + TENANT_ID + "/" + APP_ID;
+	protected static final String PLATFORM_ROOT = CMD_PREFIX + "/"
+			+ Constants.MARKER_URI_PLATFORM.code;
+}

--- a/nimbus-core/src/test/java/com/antheminc/oss/nimbus/AbstractPersistableUnitTests.java
+++ b/nimbus-core/src/test/java/com/antheminc/oss/nimbus/AbstractPersistableUnitTests.java
@@ -37,7 +37,7 @@ import cz.jirutka.spring.embedmongo.EmbeddedMongoFactoryBean;
  * @author Soham Chakravarti
  *
  */
-public abstract class AbstractPersistableUnitTests {
+public abstract class AbstractPersistableUnitTests extends AbstractFrameworkTest {
 	
     private static final String MONGO_DB_URL = "localhost";
     private static final String MONGO_DB_NAME = "embeded_db";

--- a/nimbus-core/src/test/java/com/antheminc/oss/nimbus/channel/web/WebCommandDispatcherTest.java
+++ b/nimbus-core/src/test/java/com/antheminc/oss/nimbus/channel/web/WebCommandDispatcherTest.java
@@ -18,12 +18,10 @@ package com.antheminc.oss.nimbus.channel.web;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import com.antheminc.oss.nimbus.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.cmd.Behavior;
@@ -39,23 +37,24 @@ import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
  * @author Tony Lopez
  *
  */
-@RunWith(MockitoJUnitRunner.class)
-public class WebCommandDispatcherTest {
+public class WebCommandDispatcherTest extends AbstractFrameworkTest {
 	
 	private WebCommandDispatcher testee;
+
+	private BeanResolverStrategy beanResolver;
 	
-	@Mock
 	private WebCommandBuilder builder;
 
-	@Mock
 	private CommandExecutorGateway gateway;
 	
 	@Before
 	public void init() {
-		final BeanResolverStrategy beanResolver = Mockito.mock(BeanResolverStrategy.class);
+		this.beanResolver = Mockito.mock(BeanResolverStrategy.class);
+		this.gateway = Mockito.mock(CommandExecutorGateway.class);
+		this.builder = Mockito.mock(WebCommandBuilder.class);
 		Mockito.when(beanResolver.get(WebCommandBuilder.class)).thenReturn(this.builder);
 		Mockito.when(beanResolver.get(CommandExecutorGateway.class)).thenReturn(this.gateway);
-		this.testee = new WebCommandDispatcher(beanResolver);
+		this.testee = new WebCommandDispatcher(this.beanResolver);
 		Mockito.verify(beanResolver, Mockito.times(1)).get(WebCommandBuilder.class);
 		Mockito.verify(beanResolver, Mockito.times(1)).get(CommandExecutorGateway.class);
 	}
@@ -72,7 +71,7 @@ public class WebCommandDispatcherTest {
 		final ModelEvent<String> event = new ModelEvent<>();
 		event.setPayload("{}");
 		
-		final String commandUri = "/Acme/abc/def/p/home/_new&execute";
+		final String commandUri = PLATFORM_ROOT + "/home/_new&execute";
 		final Command expectedCommand = CommandBuilder.withUri(commandUri).getCommand();
 		final MultiOutput expected = new MultiOutput(commandUri, new ExecutionContext(expectedCommand), Action._new, Behavior.$execute);
 		
@@ -90,7 +89,7 @@ public class WebCommandDispatcherTest {
 		final MockHttpServletRequest request = new MockHttpServletRequest();
 		final String payload = "{}";
 		
-		final String commandUri = "/Acme/abc/def/p/home/_new&execute";
+		final String commandUri = PLATFORM_ROOT + "/home/_new&execute";
 		final Command expectedCommand = CommandBuilder.withUri(commandUri).getCommand();
 		final MultiOutput expected = new MultiOutput(commandUri, new ExecutionContext(expectedCommand), Action._new, Behavior.$execute);
 		
@@ -106,7 +105,7 @@ public class WebCommandDispatcherTest {
 	@Test
 	public void testHandleViaJsonAndProvidedCommand() {
 		final String payload = "{}";
-		final String commandUri = "/Acme/abc/def/p/home/_new&execute";
+		final String commandUri = PLATFORM_ROOT + "/home/_new&execute";
 		final Command command = CommandBuilder.withUri(commandUri).getCommand();
 		final MultiOutput expected = new MultiOutput(commandUri, new ExecutionContext(command), Action._new, Behavior.$execute);
 		

--- a/nimbus-core/src/test/java/com/antheminc/oss/nimbus/domain/bpm/activiti/CommandExecutorTaskDelegateUnitTest.java
+++ b/nimbus-core/src/test/java/com/antheminc/oss/nimbus/domain/bpm/activiti/CommandExecutorTaskDelegateUnitTest.java
@@ -15,15 +15,13 @@
  */
 package com.antheminc.oss.nimbus.domain.bpm.activiti;
 
-import java.util.ArrayList;
-
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.Expression;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.antheminc.oss.nimbus.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.bpm.ProcessEngineContext;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
@@ -32,7 +30,6 @@ import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
-import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandPathVariableResolver;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
@@ -44,7 +41,7 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
  * @author Tony Lopez
  *
  */
-public class CommandExecutorTaskDelegateUnitTest {
+public class CommandExecutorTaskDelegateUnitTest extends AbstractFrameworkTest {
 
 	private CommandExecutorTaskDelegate testee;
 	private BeanResolverStrategy beanResolver;
@@ -59,8 +56,8 @@ public class CommandExecutorTaskDelegateUnitTest {
 		this.commandGateway = Mockito.mock(CommandExecutorGateway.class);
 		this.pathVariableResolver = Mockito.mock(CommandPathVariableResolver.class);
 		this.activitiExpressionManager = Mockito.mock(ActivitiExpressionManager.class);
-		this.expression = Mockito.mock(Expression.class);
-		
+		this.expression = Mockito.mock(Expression.class); 
+				
 		Mockito.when(this.beanResolver.find(CommandExecutorGateway.class)).thenReturn(this.commandGateway);
 		Mockito.when(this.beanResolver.find(CommandPathVariableResolver.class)).thenReturn(this.pathVariableResolver);
 		Mockito.when(this.beanResolver.find(ActivitiExpressionManager.class)).thenReturn(this.activitiExpressionManager);
@@ -71,9 +68,9 @@ public class CommandExecutorTaskDelegateUnitTest {
 	
 	@Test
 	public void testExecuteSingleOutput() {
-		String expressionText = "/app/org/client/p/<!/.m/entity!>_view/p1";
+		String expressionText = PLATFORM_ROOT + "/<!/.m/entity!>_view/p1";
 		String[] commandUrls = expressionText.split("\\r?\\n");
-		String resolvedCommandUrl0 = "/app/org/client/p/sample_view/p1";
+		String resolvedCommandUrl0 = PLATFORM_ROOT + "/sample_view/p1";
 		MultiOutput expectedOutput0 = new MultiOutput(resolvedCommandUrl0, getMockExecutionContext(), Action._get, Behavior.$execute);
 		
 		ProcessEngineContext context = Mockito.mock(ProcessEngineContext.class);

--- a/nimbus-core/src/test/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilderTest.java
+++ b/nimbus-core/src/test/java/com/antheminc/oss/nimbus/domain/cmd/CommandBuilderTest.java
@@ -22,8 +22,11 @@ import static org.junit.Assert.assertSame;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import com.antheminc.oss.nimbus.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
 
@@ -34,21 +37,14 @@ import com.antheminc.oss.nimbus.domain.defn.Constants;
  * @author Soham Chakravarti
  * @author Rakesh Patel
  */
-public class CommandBuilderTest {
-
+public class CommandBuilderTest extends AbstractFrameworkTest {
+	
+	@Rule
+	public ExpectedException expectedEx = ExpectedException.none();
+	
 	@Test
-	public void t0_multiple() {
-		String uri = "/Anthem/fep/p/dashboard/landingPage/tileCreateCase/sectionCreateCase/umCaseLists.m/_process?fn=_set&url=/Anthem/fep/p/umcase/_search?fn=example";
-		Command cmd = CommandBuilder.withUri(uri).getCommand();
-		assertNotNull(cmd);
-		
-		assertSame(Action._process, cmd.getAction());
-		assertNotNull(cmd.getBehaviors());
-	}
-
-	@Test
-	public void t0_multiple_withClient() {
-		String uri = "/Anthem/fep/p/dashboard/landingPage/tileCreateCase/sectionCreateCase/umCaseLists.m/_process?fn=_set&url=/Anthem/fep/p/umcase/_search?fn=example";
+	public void testMultiple() {
+		String uri = PLATFORM_ROOT + "/dashboard/landingPage/tileCreateCase/sectionCreateCase/umCaseLists.m/_process?fn=_set&url=" + PLATFORM_ROOT + "/umcase/_search?fn=example";
 		Command cmd = CommandBuilder.withUri(uri).getCommand();
 		assertNotNull(cmd);
 		
@@ -57,15 +53,15 @@ public class CommandBuilderTest {
 	}
 	
 	@Test
-	public void t0_multiple_split() {
-		String uri = "/Anthem/fep/p/dashboard/landingPage/tileCreateCase/sectionCreateCase/umCaseLists.m/_process?fn=_set&url=/Anthem/fep/p/umcase/_search?fn=example";
+	public void testMultipleSplit() {
+		String uri = PLATFORM_ROOT + "/dashboard/landingPage/tileCreateCase/sectionCreateCase/umCaseLists.m/_process?fn=_set&url=" + PLATFORM_ROOT + "/umcase/_search?fn=example";
 		Command cmd = CommandBuilder.withUri(uri).getCommand();
 		assertNotNull(cmd);
 		
 		assertSame(Action._process, cmd.getAction());
 		
 		String url = cmd.getRequestParams().get("url")[0];
-		assertEquals("/Anthem/fep/p/umcase/_search?fn=example", url);
+		assertEquals(PLATFORM_ROOT + "/umcase/_search?fn=example", url);
 		
 		Command subCmd = CommandBuilder.withUri(url).getCommand();
 		assertNotNull(subCmd);
@@ -74,26 +70,26 @@ public class CommandBuilderTest {
 	
 	
 	@Test
-	public void t0_noParams() {
-		String uri = "/client_xyz/app_abc/p/domainRoot_alias/_new";
+	public void testNoParams() {
+		String uri = PLATFORM_ROOT + "/domainRoot_alias/_new";
 		Command cmd = CommandBuilder.withUri(uri).getCommand();
 		assertNotNull(cmd);
 		
-		assertEquals("client_xyz", cmd.getRootClientAlias());
-		assertEquals("app_abc", cmd.getAppAlias());
+		assertEquals(CLIENT_ID, cmd.getRootClientAlias());
+		assertEquals(APP_ID, cmd.getAppAlias());
 		assertEquals("domainRoot_alias", cmd.getRootDomainAlias());
 		
 		assertSame(Action._new, cmd.getAction());
 	}
 	
 	@Test
-	public void t1_withParams() {
-		String uri = "/client_xyz/app_abc/p/domainRoot_alias/_new?b=$executeAnd$save&criteria=customer.name.eq(\"John\")";
+	public void testWithParams() {
+		String uri = PLATFORM_ROOT + "/domainRoot_alias/_new?b=$executeAnd$save&criteria=customer.name.eq(\"John\")";
 		Command cmd = CommandBuilder.withUri(uri).getCommand();
 		assertNotNull(cmd);
 		
-		assertEquals("client_xyz", cmd.getRootClientAlias());
-		assertEquals("app_abc", cmd.getAppAlias());
+		assertEquals(CLIENT_ID, cmd.getRootClientAlias());
+		assertEquals(APP_ID, cmd.getAppAlias());
 		assertEquals("domainRoot_alias", cmd.getRootDomainAlias());
 		
 		assertSame(Action._new, cmd.getAction());
@@ -105,41 +101,30 @@ public class CommandBuilderTest {
 	}
 
 	@Test
-	public void t2_nestedDomainNoParams() {
-		String uri = "/client_xyz/app_abc/p/domainRoot_alias/param_alias/_new";
+	public void testNestedDomainNoParams() {
+		String uri = PLATFORM_ROOT + "/domainRoot_alias/param_alias/_new";
 		Command cmd = CommandBuilder.withUri(uri).getCommand();
 		assertNotNull(cmd);
 		
-		assertEquals("client_xyz", cmd.getRootClientAlias());
-		assertEquals("app_abc", cmd.getAppAlias());
+		assertEquals(CLIENT_ID, cmd.getRootClientAlias());
+		assertEquals(APP_ID, cmd.getAppAlias());
 		assertEquals("domainRoot_alias", cmd.getRootDomainAlias());
-		
-		System.out.println("cmd.getAbsoluteAlias(): "+cmd.getAbsoluteAlias());
-		System.out.println("cmd.getAbsoluteAliasTillRootDomain(): "+cmd.getAbsoluteAliasTillRootDomain());
-		System.out.println("cmd.getAbsoluteDomainAlias(): "+cmd.getAbsoluteDomainAlias());
-		System.out.println("cmd.getAbsoluteDomainUri(): "+cmd.getAbsoluteDomainUri());
-		System.out.println("cmd.getAbsoluteUri(): "+cmd.getAbsoluteUri());
-		System.out.println("cmd.getAbsoluteUri(Type): "+cmd.getAbsoluteUri(Type.DomainAlias));
-		System.out.println("cmd.getAlias(Type): "+cmd.getAlias(Type.DomainAlias));
-		System.out.println("cmd.getAliasUri(Type): "+cmd.getAliasUri(Type.DomainAlias));
-		System.out.println("cmd.getRootDomainAlias(): "+cmd.getRootDomainAlias());
-		System.out.println("cmd.getRootDomainUri(): "+cmd.getRootDomainUri());
 		
 		assertSame(Action._new, cmd.getAction());
 		assertNotNull(cmd.getBehaviors());
 	}
 	
 	@Test
-	public void t2_simple_with_lazyParams() {
-		String uri = "/client_xyz/app_abc/p/domainRoot_alias/_new";
+	public void testSimpleWithLazyParams() {
+		String uri = PLATFORM_ROOT + "/domainRoot_alias/_new";
 		Map<String, String[]> rParams = new HashMap<>();
 		rParams.put(Constants.MARKER_URI_BEHAVIOR.code, new String[]{"$executeAnd$save"});
 		
 		Command cmd = CommandBuilder.withUri(uri).addParams(rParams).getCommand();
 		assertNotNull(cmd);
 		
-		assertEquals("client_xyz", cmd.getRootClientAlias());
-		assertEquals("app_abc", cmd.getAppAlias());
+		assertEquals(CLIENT_ID, cmd.getRootClientAlias());
+		assertEquals(APP_ID, cmd.getAppAlias());
 		assertEquals("domainRoot_alias", cmd.getRootDomainAlias());
 		
 		assertSame(Action._new, cmd.getAction());
@@ -150,8 +135,8 @@ public class CommandBuilderTest {
 	
 	
 	@Test
-	public void t3_linked_commandElements_are_generated() {
-		String uri = "/xyz/admin/p/flow_patientenrollment/_loadTask:582363676028/_process";
+	public void testLinkedCommandElementsAreGenerated() {
+		String uri = PLATFORM_ROOT + "/flow_patientenrollment/_loadTask:582363676028/_process";
 		//?b=
 		
 		Map<String, String[]> rParams = new HashMap<>();
@@ -163,8 +148,6 @@ public class CommandBuilderTest {
 		assertNotNull(cmd.getElement(Type.ProcessAlias));
 		
 		assertNotNull(cmd.getRefId(Type.ProcessAlias));
-		
-		System.out.println(cmd.getRefId(Type.ProcessAlias));
 	}
 
 }

--- a/nimbus-core/src/test/java/com/antheminc/oss/nimbus/domain/cmd/CommandTest.java
+++ b/nimbus-core/src/test/java/com/antheminc/oss/nimbus/domain/cmd/CommandTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runners.MethodSorters;
 
+import com.antheminc.oss.nimbus.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
 
@@ -34,83 +35,79 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
  *
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class CommandTest {
-
+public class CommandTest extends AbstractFrameworkTest {
+	
 	@Rule
 	public ExpectedException expectedEx = ExpectedException.none();
 	
 	@Test
-	public void t0_relativeUri_complete() {
-		Command in = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+	public void testRelativeUriComplete() {
+		Command in = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
 		
-		String configUri = "/anthem/fep/icr/p/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/requestType')";
+		String configUri = PLATFORM_ROOT + "/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/requestType')";
 		String out = in.getRelativeUri(configUri);
 		assertEquals(configUri, out);
 	}
 	
 	@Test
-	public void t0_relativeUri_domainRoot_provided_1() {
-		Command in = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+	public void testRelativeUriDomainRootProvided1() {
+		Command in = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
 		
 		String configUri = "/p/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/requestType')";
 		String out = in.getRelativeUri(configUri);
-		System.out.println(out);
-		assertEquals("/anthem/fep/icr"+configUri, out);
+		assertEquals(CMD_PREFIX + configUri, out);
 	}
 	
 	@Test
-	public void t0_relativeUri_domainRoot_provided_2() {
-		Command in = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+	public void testRelativeUriDomainRootProvided2() {
+		Command in = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
 		
 		String configUri = "/p/staticCodeValue:200/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/requestType')";
 		String out = in.getRelativeUri(configUri);
-		System.out.println(out);
-		assertEquals("/anthem/fep/icr"+configUri, out);
+		assertEquals(CMD_PREFIX + configUri, out);
 	}
 	
 	@Test
-	public void t0_relativeUri_domainRoot_relative_1() {
-		Command in = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+	public void testRelativeUriDomainRootRelative1() {
+		Command in = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
 		
 		String configUri = "/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/requestType')";
 		String out = in.getRelativeUri(configUri);
-		System.out.println(out);
-		assertEquals("/anthem/fep/icr/p/umcase_view"+configUri, out);
+		assertEquals(PLATFORM_ROOT + "/umcase_view"+configUri, out);
 	}
 	
 	@Test
-	public void t0_relativeUri_domainRoot_relative_2() {
-		Command in = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+	public void testRelativeUriDomainRootRelative2() {
+		Command in = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
 		
 		String configUri = "/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/requestType')";
 		String out = in.getRelativeUri(configUri);
-		System.out.println(out);
-		assertEquals("/anthem/fep/icr/p/umcase_view:100"+configUri, out);
+		assertEquals(PLATFORM_ROOT + "/umcase_view:100"+configUri, out);
 	}
 	
 	@Test
 	public void testToUri() {
-		Command cmd = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
-		assertEquals("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?b=$execute", cmd.toUri());
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+		assertEquals(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?b=$execute", cmd.toUri());
 	}
 	
 	@Test
 	public void testToUriMultipleBehaviors() {
-		Command cmd = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
 		cmd.getBehaviors().add(Behavior.$nav);
-		assertEquals("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?b=$executeAnd$nav", cmd.toUri());
+		assertEquals(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?b=$executeAnd$nav", cmd.toUri());
 	}
 	
 	@Test
 	public void testToUriWithEvent() {
-		Command cmd = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get").getCommand();
 		cmd.setEvent("someEvent");
-		assertEquals("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get/someEvent?b=$execute", cmd.toUri());
+		assertEquals(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get/someEvent?b=$execute", cmd.toUri());
 	}
 	
 	@Test
 	public void testToUriWithQueryParams() {
-		Command cmd = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?b=$state&abc=cba&abc=xyz&pqr=mnc").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?b=$state&abc=cba&abc=xyz&pqr=mnc").getCommand();
 		String uriWithQueryParams = cmd.toUri();
 		Command cmd2 = CommandBuilder.withUri(uriWithQueryParams).getCommand();
 		assertThat(cmd.getRequestParams().size()).isEqualTo(cmd2.getRequestParams().size());
@@ -118,7 +115,7 @@ public class CommandTest {
 	
 	@Test
 	public void testToUriWithDefaultBehaviorAndQueryParams() {
-		Command cmd = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?abc=cba&abc=xyz&pqr=mnc").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/tileCreateCaseInfo/sectionUMCaseInfo/formUMCaseInfo/_get?abc=cba&abc=xyz&pqr=mnc").getCommand();
 		String uriWithQueryParams = cmd.toUri();
 		Command cmd2 = CommandBuilder.withUri(uriWithQueryParams).getCommand();
 		assertThat(cmd.getRequestParams().size()).isLessThan(cmd2.getRequestParams().size());
@@ -126,18 +123,18 @@ public class CommandTest {
 	
 	@Test
 	public void testBuildRemoteUri() {
-		String uri = "/client_xyz/app_abc/p/domainRoot_alias/nestedDomain/abc/_new?b=$executeAnd$save&criteria=customer.name.eq(\"John\")";
+		String uri = PLATFORM_ROOT + "/domainRoot_alias/nestedDomain/abc/_new?b=$executeAnd$save&criteria=customer.name.eq(\"John\")";
 		Command cmd = CommandBuilder.withUri(uri).getCommand();
 		assertNotNull(cmd);
 		
 		String buildUri = cmd.toRemoteUri(Type.ParamName, Action._new, Behavior.$execute);
 		
-		assertThat(buildUri).isEqualTo("/client_xyz/app_abc/p/domainRoot_alias/nestedDomain/abc/_new?b=$execute");
+		assertThat(buildUri).isEqualTo(PLATFORM_ROOT + "/domainRoot_alias/nestedDomain/abc/_new?b=$execute");
 	}
 	
 	@Test
 	public void testConstructor() {
-		Command cmd = CommandBuilder.withUri("/anthem/fep/icr/p/umcase_view:100/pageCreateCaseInfo/_get").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/pageCreateCaseInfo/_get").getCommand();
 		Command cloned = new Command(cmd);
 		assertNotEquals(cmd, cloned);
 		assertEquals(cmd.getAbsoluteUri(), cloned.getAbsoluteUri());
@@ -149,35 +146,43 @@ public class CommandTest {
 	}
 	
 	@Test
-	public void testInvalidCommandMissingAction() throws Exception {
+	public void testInvalidCommandMissingAction() {
 		expectedEx.expect(InvalidConfigException.class);
-		expectedEx.expectMessage("Command with URI: /anthem/p/umcase_view:100 cannot have null Action.");
-		Command cmd = CommandBuilder.withUri("/anthem/p/umcase_view:100").getCommand();
+		expectedEx.expectMessage("Command with URI: /hooli/1/thebox/p/umcase_view:100 cannot have null Action.");
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100").getCommand();
 		cmd.validate();
 	}
 	
 	@Test
-	public void testInvalidCommandMissingBehavior() throws Exception {
+	public void testInvalidCommandMissingBehavior() {
 		expectedEx.expect(InvalidConfigException.class);
-		expectedEx.expectMessage("Command with URI: /anthem/org/fep/p/umcase_view:100/_get cannot have null Behavior.");
-		Command cmd = CommandBuilder.withUri("/anthem/org/fep/p/umcase_view:100/_get").getCommand();
+		expectedEx.expectMessage("Command with URI: /hooli/1/thebox/p/umcase_view:100/_get cannot have null Behavior.");
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/umcase_view:100/_get").getCommand();
 		cmd.setBehaviors(null);
 		cmd.validate();
 	}
 	
 	@Test
-	public void testInvalidCommandMissingAppAlias() throws Exception {
+	public void testInvalidCommandMissingTenantId() {
 		expectedEx.expect(InvalidConfigException.class);
-		expectedEx.expectMessage("Command with URI: /anthem/p/umcase_view:100/_get cannot have null AppAlias.");
-		Command cmd = CommandBuilder.withUri("/anthem/p/umcase_view:100/_get").getCommand();
+		expectedEx.expectMessage("Command with URI: /hooli/p/umcase_view:100/_get cannot have null TenantId.");
+		Command cmd = CommandBuilder.withUri("/hooli/p/umcase_view:100/_get").getCommand();
 		cmd.validate();
 	}
 	
 	@Test
-	public void testInvalidCommandMissingDomainAlias() throws Exception {
+	public void testInvalidCommandMissingAppAlias() {
 		expectedEx.expect(InvalidConfigException.class);
-		expectedEx.expectMessage("Command with URI: /anthem/org/fep/p/_get cannot have null DomainAlias.");
-		Command cmd = CommandBuilder.withUri("/anthem/org/fep/p/_get").getCommand();
+		expectedEx.expectMessage("Command with URI: /hooli/1/thebox/p/_get cannot have null AppAlias.");
+		Command cmd = CommandBuilder.withUri("/hooli/1/p/umcase_view:100/_get").getCommand();
+		cmd.validate();
+	}
+	
+	@Test
+	public void testInvalidCommandMissingDomainAlias() {
+		expectedEx.expect(InvalidConfigException.class);
+		expectedEx.expectMessage("Command with URI: /hooli/1/thebox/p/_get cannot have null DomainAlias.");
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/_get").getCommand();
 		cmd.validate();
 	}
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/AbstractFrameworkIntegrationTests.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/AbstractFrameworkIntegrationTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.channel.web.WebActionController;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessageConverter;
 import com.antheminc.oss.nimbus.entity.client.Client;
@@ -38,51 +39,98 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Soham Chakravarti
+ * @author Tony Lopez
  *
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes=FrameworkIntegrationTestScenariosApplication.class)
+@SpringBootTest(classes = FrameworkIntegrationTestScenariosApplication.class)
 @ActiveProfiles("test")
-public abstract class AbstractFrameworkIntegrationTests {
-	
-	protected static final String CLIENT_ID = "hooli";
-	
-	protected static final String PLATFORM_ROOT = "/"+CLIENT_ID+"/thebox/p";
-	
-	@Autowired protected WebActionController controller;
-	
-	@Autowired protected MongoOperations mongo;
-	
-	@Autowired protected MongoTemplate mt;
-	
-	@Autowired protected CommandMessageConverter converter;
-	
-	@Autowired protected ObjectMapper om;
-	
+public abstract class AbstractFrameworkIntegrationTests extends AbstractFrameworkTest {
+
+	@Autowired
+	protected WebActionController controller;
+
+	@Autowired
+	protected MongoOperations mongo;
+
+	@Autowired
+	protected MongoTemplate mt;
+
+	@Autowired
+	protected CommandMessageConverter converter;
+
+	@Autowired
+	protected ObjectMapper om;
+
 	protected JacksonTester<Object> json;
 
-	
-	
 	@Before
 	public void before() {
 		this.tearDown();
 
 		JacksonTester.initFields(this, om);
-		
+
 		Client newClient = new Client();
 		Long id = new Random().nextLong();
 		newClient.setId(id);
 		newClient.setName(CLIENT_ID);
 		mongo.insert(newClient, "cliententity");
-		
+
 		assertNotNull(mongo.findById(id, Client.class, "cliententity"));
 	}
-	
+
 	/**
-	 * Drop the test db "integrationtest" 
+	 * Drop the test db "integrationtest"
 	 */
 	@After
 	public void tearDown() {
 		mt.getDb().drop();
+	}
+
+	protected String asString(Object o) {
+		try {
+			return this.om.writeValueAsString(o);
+		} catch (Exception e) {
+			throw new FrameworkRuntimeException("Failed to convert object to string.", e);
+		}
+	}
+
+	/**
+	 * <p> Determine whether or not the entity exists within the system. Test
+	 * classes may override this to assume different behavior.
+	 * @param refId the id of the stored object
+	 * @param entityClass the type of the object
+	 * @param alias the domain alias of the object
+	 * @return {@code} true if a domain entity exists, {@code false} otherwise
+	 * @see #find(Long, Class, String)
+	 */
+	protected boolean exists(Long refId, Class<?> entityClass, String alias) {
+		return null != find(refId, entityClass, alias);
+	}
+
+	/**
+	 * <p> Find the entity within the system. Default implementation uses
+	 * MongoDB for retrieval. Test classes may override this to assume different
+	 * behavior.
+	 * @param refId the id of the stored object
+	 * @param entityClass the type of the object
+	 * @param alias the domain alias of the object
+	 * @return {@code} true if a domain entity exists, {@code false} otherwise
+	 */
+	protected <T> T find(Long refId, Class<T> entityClass, String alias) {
+		return this.mongo.findById(refId, entityClass, alias);
+	}
+
+	/**
+	 * <p> Inserts an entity into the system. Default implementation uses
+	 * MongoDB to perform insertion. Test classes may override this to assume
+	 * different behavior.
+	 * @param alias the domain alias of the object
+	 * @param o the object to insert
+	 * @return the inserted object
+	 */
+	protected <T> T insert(String alias, T o) {
+		this.mongo.insert(o, alias);
+		return o;
 	}
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/AbstractFrameworkTest.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/support/AbstractFrameworkTest.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.domain.support;
+
+import com.antheminc.oss.nimbus.domain.defn.Constants;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public abstract class AbstractFrameworkTest {
+
+	protected static final String CLIENT_ID = "hooli";
+	protected static final String ORG_ID = "org";
+	protected static final String APP_ID = "thebox";
+	protected static final String CMD_PREFIX = "/" + CLIENT_ID + "/" + ORG_ID + "/" + APP_ID;
+	protected static final String PLATFORM_ROOT = CMD_PREFIX + "/"
+			+ Constants.MARKER_URI_PLATFORM.code;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/multidb/core/SampleMultiDbDefaultEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/multidb/core/SampleMultiDbDefaultEntity.java
@@ -22,6 +22,7 @@ import com.antheminc.oss.nimbus.domain.defn.Domain;
 import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.Tenant;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -41,6 +42,7 @@ public class SampleMultiDbDefaultEntity {
 		private final String _class = this.getClass().getName(); 
 		@Id
 		private Long id;
+		private Long _tenantId;
 		private String field1;
 		private String field2;
 		

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/multidb/core/SampleMultiDbDomainPrimary.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/multidb/core/SampleMultiDbDomainPrimary.java
@@ -22,6 +22,7 @@ import com.antheminc.oss.nimbus.domain.defn.Domain;
 import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.Tenant;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -40,6 +41,7 @@ public class SampleMultiDbDomainPrimary {
 	private final String _class = this.getClass().getName(); 
 	@Id
 	private Long id;
+	private Long _tenantId;
 	private String primaryField1;
 	private String primaryField2;
 	

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/multidb/core/SampleMultiDbDomainSecondary.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/multidb/core/SampleMultiDbDomainSecondary.java
@@ -40,6 +40,7 @@ public class SampleMultiDbDomainSecondary {
 	private String _class = this.getClass().getName(); 
 	@Id
 	private Long id;
+	private Long _tenantId;
 	private String secondaryField1;
 	private String secondaryField2;
 	

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
@@ -109,11 +109,11 @@ public class VPSampleViewPageGreen {
 		private SampleForm view_nc_form;
 		
 		@ComboBox
-		@Values(url = "a/b/p/sampletask/_search?fn=lookup&projection.mapsTo=code:id,label:taskName")
+		@Values(url = "/p/sampletask/_search?fn=lookup&projection.mapsTo=code:id,label:taskName")
 		private List<String> unsortedDynamicValues;
 		
 		@ComboBox
-		@Values(url = "a/b/p/sampletask/_search?fn=lookup&orderby=sampletask.taskName.asc()&projection.mapsTo=code:id,label:taskName")
+		@Values(url = "/p/sampletask/_search?fn=lookup&orderby=sampletask.taskName.asc()&projection.mapsTo=code:id,label:taskName")
 		private List<String> sortedDynamicValues;
 		
 		@TextBox(postEventOnChange = true)

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/AbstractFrameworkIngerationPersistableTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/AbstractFrameworkIngerationPersistableTests.java
@@ -17,11 +17,14 @@ package com.antheminc.oss.nimbus.domain;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.util.HashSet;
+
 import org.junit.After;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.session.SessionProvider;
 import com.antheminc.oss.nimbus.entity.client.user.ClientUser;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
@@ -141,6 +144,10 @@ public abstract class AbstractFrameworkIngerationPersistableTests extends Abstra
 	
 	public void createClientUser() {
 		ClientUser clientUser = new ClientUser();
+    	clientUser.setTenantIds(new HashSet<>());
+    	clientUser.getTenantIds().add(1L);
+    	clientUser.getTenantIds().add(2L);
     	sessionProvider.setLoggedInUser(clientUser);
+    	sessionProvider.setAttribute(Constants.ACTIVE_TENANT_COOKIE.code, CMD_PREFIX);
 	}
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/AbstractFrameworkIngerationPersistableTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/AbstractFrameworkIngerationPersistableTests.java
@@ -17,10 +17,16 @@ package com.antheminc.oss.nimbus.domain;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.util.HashSet;
+
 import org.junit.After;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
+import com.antheminc.oss.nimbus.domain.session.SessionProvider;
+import com.antheminc.oss.nimbus.entity.client.user.ClientUser;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
@@ -88,6 +94,9 @@ public abstract class AbstractFrameworkIngerationPersistableTests extends Abstra
 	
 	protected static Long sampleEntity_refId;
 	
+	@Autowired
+	private SessionProvider sessionProvider;
+	
 	public synchronized Long createOrGetDomainRoot_RefId() {
 		if(domainRoot_refId!=null) 
 			return domainRoot_refId;
@@ -131,5 +140,10 @@ public abstract class AbstractFrameworkIngerationPersistableTests extends Abstra
 		super.tearDown();
 		
 		domainRoot_refId = null;
+	}
+	
+	public void createClientUser() {
+		ClientUser clientUser = new ClientUser();
+    	sessionProvider.setLoggedInUser(clientUser);
 	}
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/AbstractFrameworkIngerationPersistableTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/AbstractFrameworkIngerationPersistableTests.java
@@ -17,14 +17,11 @@ package com.antheminc.oss.nimbus.domain;
 
 import static org.junit.Assert.assertNotNull;
 
-import java.util.HashSet;
-
 import org.junit.After;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import com.antheminc.oss.nimbus.domain.cmd.Action;
-import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.session.SessionProvider;
 import com.antheminc.oss.nimbus.entity.client.user.ClientUser;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/AccessConditionalStateEventHandlerHttpTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/AccessConditionalStateEventHandlerHttpTest.java
@@ -93,10 +93,12 @@ public class AccessConditionalStateEventHandlerHttpTest extends AbstractFramewor
 		
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1");
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test2");
 		mongo.save(scea, "sample_core_access");
 		mongo.save(scea2, "sample_core_access");
@@ -260,6 +262,7 @@ public class AccessConditionalStateEventHandlerHttpTest extends AbstractFramewor
 	private String createClientUserWithRoles(String loginId, String... roles) {
 		ClientUser cu = new ClientUser();
 		cu.setId(new Random().nextLong());
+		cu.set_tenantId(TENANT_ID);
 		cu.setLoginId(loginId);
 		
 		List<UserRole> userRoles = new ArrayList<>();
@@ -267,6 +270,7 @@ public class AccessConditionalStateEventHandlerHttpTest extends AbstractFramewor
 			
 			ClientUserRole userRole = new ClientUserRole();
 			userRole.setId(new Random().nextLong());
+			userRole.set_tenantId(TENANT_ID);
 			userRole.setCode(r);
 			userRole.setEffectiveDate(LocalDate.now());
 			
@@ -274,6 +278,7 @@ public class AccessConditionalStateEventHandlerHttpTest extends AbstractFramewor
 			
 			ClientAccessEntity accessEntity = new ClientAccessEntity();
 			accessEntity.setId(new Random().nextLong());
+			accessEntity.set_tenantId(TENANT_ID);
 			accessEntity.setCode("member_management");
 			
 			mongo.save(accessEntity, "authorities");

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/AccessConditionalStateEventHandlerHttpTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/AccessConditionalStateEventHandlerHttpTest.java
@@ -239,7 +239,7 @@ public class AccessConditionalStateEventHandlerHttpTest extends AbstractFramewor
 			
 		}
 		
-		final MockHttpServletRequest fetchAuthorities = MockHttpRequestBuilder.withUri("/hooli/thebox/p/authorities")
+		final MockHttpServletRequest fetchAuthorities = MockHttpRequestBuilder.withUri(PLATFORM_ROOT + "/authorities")
 				.addAction(Action._search)
 				.addParam("fn", "query")
 				.addParam("where", "authorities.code.in("+sb2.toString()+")")

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorConfigTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorConfigTest.java
@@ -65,17 +65,17 @@ public class DefaultActionExecutorConfigTest extends AbstractFrameworkIngeration
 	@WithMockUser(username="user", password="pwd")
 	public void t00_json() throws Exception {
 
-		
+		createClientUser();
 		mvc.perform(post(createRequest(VIEW_PARAM_ROOT, Action._config).getRequestURI())
 				.with(csrf())
-					.content("{}")
-					.contentType(APPLICATION_JSON_UTF8))
-	               	.andExpect(status().isOk())
-	               	.andExpect(jsonPath("$.result.0.result.outputs[0].value", IsNull.notNullValue()))
-	               	.andReturn()
-	               	.getResponse()
-	               	.getContentAsString()
-	               ;
+				.content("{}")
+				.contentType(APPLICATION_JSON_UTF8))
+               	.andExpect(status().isOk())
+               	.andExpect(jsonPath("$.result.0.result.outputs[0].value", IsNull.notNullValue()))
+               	.andReturn()
+               	.getResponse()
+               	.getContentAsString()
+               ;
 	}
 	
 	@Test

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorConfigTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorConfigTest.java
@@ -23,6 +23,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import javax.servlet.http.Cookie;
+
 import org.hamcrest.core.IsNull;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -36,6 +38,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.config.builder.DomainConfigBuilder;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.config.ParamConfig;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
@@ -68,6 +71,7 @@ public class DefaultActionExecutorConfigTest extends AbstractFrameworkIngeration
 		createClientUser();
 		mvc.perform(post(createRequest(VIEW_PARAM_ROOT, Action._config).getRequestURI())
 				.with(csrf())
+				.cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, CMD_PREFIX))
 				.content("{}")
 				.contentType(APPLICATION_JSON_UTF8))
                	.andExpect(status().isOk())

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNewTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNewTest.java
@@ -68,10 +68,11 @@ public class DefaultActionExecutorNewTest extends AbstractFrameworkIngerationPer
 	
 	@Autowired
 	private MockMvc mvc;
-
+	
 	@WithMockUser(username="user", password="pwd")
 	@Test
 	public void t00_json() throws Exception {
+		createClientUser();
 		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
 
 		mvc.perform(post(req.getRequestURI()).content("{}")
@@ -289,16 +290,19 @@ public class DefaultActionExecutorNewTest extends AbstractFrameworkIngerationPer
 	@WithMockUser(username="user", password="pwd")
 	@Test
 	public void testSuccessiveNewCalls() throws Exception {
+		createClientUser();
 		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
 
-		mvc.perform(post(req.getRequestURI()).with(csrf()).content("{}").contentType(APPLICATION_JSON_UTF8))
+		mvc.perform(post(req.getRequestURI())
+				.with(csrf()).content("{}").contentType(APPLICATION_JSON_UTF8))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.result.0.result.outputs[0].value", IsNull.notNullValue())).andReturn()
 				.getResponse().getContentAsString();
 
 		Assert.assertEquals(1, mongo.getCollection("sample_core").count());
 
-		mvc.perform(post(req.getRequestURI()).with(csrf()).content("{}").contentType(APPLICATION_JSON_UTF8))
+		mvc.perform(post(req.getRequestURI())
+				.with(csrf()).content("{}").contentType(APPLICATION_JSON_UTF8))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.result.0.result.outputs[0].value", IsNull.notNullValue())).andReturn()
 				.getResponse().getContentAsString();

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNewTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorNewTest.java
@@ -27,6 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
+import javax.servlet.http.Cookie;
+
 import org.hamcrest.core.IsNull;
 import org.junit.Assert;
 import org.junit.FixMethodOrder;
@@ -77,6 +79,7 @@ public class DefaultActionExecutorNewTest extends AbstractFrameworkIngerationPer
 
 		mvc.perform(post(req.getRequestURI()).content("{}")
 				.with(csrf())
+				.cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, CMD_PREFIX))
 				.contentType(APPLICATION_JSON_UTF8))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.result.0.result.outputs[0].value", IsNull.notNullValue())).andReturn()
@@ -293,7 +296,7 @@ public class DefaultActionExecutorNewTest extends AbstractFrameworkIngerationPer
 		createClientUser();
 		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
 
-		mvc.perform(post(req.getRequestURI())
+		mvc.perform(post(req.getRequestURI()).cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, CMD_PREFIX))
 				.with(csrf()).content("{}").contentType(APPLICATION_JSON_UTF8))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.result.0.result.outputs[0].value", IsNull.notNullValue())).andReturn()
@@ -301,7 +304,7 @@ public class DefaultActionExecutorNewTest extends AbstractFrameworkIngerationPer
 
 		Assert.assertEquals(1, mongo.getCollection("sample_core").count());
 
-		mvc.perform(post(req.getRequestURI())
+		mvc.perform(post(req.getRequestURI()).cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, CMD_PREFIX))
 				.with(csrf()).content("{}").contentType(APPLICATION_JSON_UTF8))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.result.0.result.outputs[0].value", IsNull.notNullValue())).andReturn()

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearchHttpTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearchHttpTest.java
@@ -72,6 +72,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1_string1");
 		scea.setAttr_String2("test2_string2");
 		scea.setAttr_LocalDate1(LocalDate.now());
@@ -82,6 +83,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test2_string1");
 		scea2.setAttr_String2("test2_string2");
 		scea2.setAttr_LocalDate1(LocalDate.now());
@@ -131,6 +133,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1_string1");
 		scea.setAttr_String2("test2_string2");
 		scea.setAttr_LocalDate1(LocalDate.now());
@@ -141,6 +144,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test2_string1");
 		scea2.setAttr_String2("test2_string2");
 		scea2.setAttr_LocalDate1(LocalDate.now());
@@ -193,6 +197,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1_string1");
 		scea.setAttr_String2("test2_string2");
 		scea.setAttr_LocalDate1(LocalDate.now());
@@ -203,6 +208,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test2_string1");
 		scea2.setAttr_String2("test2_string2");
 		scea2.setAttr_LocalDate1(LocalDate.now().plusDays(1));
@@ -258,6 +264,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1_string1");
 		scea.setAttr_String2("test2_string2");
 		scea.setAttr_LocalDate1(LocalDate.now());
@@ -268,6 +275,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test2_string1");
 		scea2.setAttr_String2("test2_string2");
 		scea2.setAttr_LocalDate1(LocalDate.now());
@@ -320,6 +328,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1_string1");
 		scea.setAttr_String2("test2_string2");
 		scea.setAttr_LocalDate1(LocalDate.now());
@@ -330,6 +339,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test2_string1");
 		scea2.setAttr_String2("test2_string2");
 		scea2.setAttr_LocalDate1(LocalDate.now().plusDays(2));
@@ -383,6 +393,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1_string1");
 		scea.setAttr_String2("test2_string2");
 		scea.setAttr_LocalDate1(LocalDate.now());
@@ -393,6 +404,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test2_string1");
 		scea2.setAttr_String2("test2_string2");
 		scea2.setAttr_LocalDate1(LocalDate.now().plusDays(2));
@@ -443,9 +455,11 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 	public void testLookupSort() {
 		SampleTask task1 = new SampleTask();
 		task1.setId(1L);
+		task1.set_tenantId(TENANT_ID);
 		task1.setTaskName("Play");
 		SampleTask task2 = new SampleTask();
 		task2.setId(2L);
+		task2.set_tenantId(TENANT_ID);
 		task2.setTaskName("Groom");
 		mongo.insert(task1, "sampletask");
 		mongo.insert(task2, "sampletask");
@@ -572,6 +586,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 	private String createClientUserWithRoles(String loginId, String... roles) {
 		ClientUser cu = new ClientUser();
 		cu.setId(new Random().nextLong());
+		cu.set_tenantId(TENANT_ID);
 		cu.setLoginId(loginId);
 		
 		List<UserRole> userRoles = new ArrayList<>();
@@ -579,6 +594,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 			
 			ClientUserRole userRole = new ClientUserRole();
 			userRole.setId(new Random().nextLong());
+			userRole.set_tenantId(TENANT_ID);
 			userRole.setCode(r);
 			userRole.setEffectiveDate(LocalDate.now());
 			
@@ -586,6 +602,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 			
 			ClientAccessEntity accessEntity = new ClientAccessEntity();
 			accessEntity.setId(new Random().nextLong());
+			accessEntity.set_tenantId(TENANT_ID);
 			accessEntity.setCode("member_management");
 			
 			mongo.save(accessEntity, "authorities");

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearchHttpTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearchHttpTest.java
@@ -554,7 +554,7 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 			i++;
 		}
 		
-		final MockHttpServletRequest fetchAuthorities = MockHttpRequestBuilder.withUri("/hooli/thebox/p/authorities")
+		final MockHttpServletRequest fetchAuthorities = MockHttpRequestBuilder.withUri(PLATFORM_ROOT + "/authorities")
 				.addAction(Action._search)
 				.addParam("fn", "query")
 				.addParam("where", "authorities.code.in("+sb2.toString()+")")

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/HierarchyMatchBasedBeanFinderTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/HierarchyMatchBasedBeanFinderTest.java
@@ -24,9 +24,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.antheminc.oss.nimbus.domain.cmd.Behavior;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.exec.internal.process.SetFunctionHandler;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
-import com.antheminc.oss.nimbus.support.CommandUtils;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -36,7 +36,7 @@ public class HierarchyMatchBasedBeanFinderTest extends AbstractFrameworkIntegrat
 
 	@Test
 	public void test() {
-		final Command command = CommandUtils.prepareCommand("/Acme/admin/p/testmappedmodel/_process?fn=_set", Behavior.$execute);
+		final Command command = CommandBuilder.withUri("/Acme/admin/p/testmappedmodel/_process?fn=_set&b=$execute").getCommand();
 		assertNotNull(hierarchyMatchBasedBeanFinder.findMatchingBean(SetFunctionHandler.class, this.constructFunctionHandlerKey(command)));
 	}
 	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/HierarchyMatchBasedBeanFinderTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/HierarchyMatchBasedBeanFinderTest.java
@@ -36,7 +36,7 @@ public class HierarchyMatchBasedBeanFinderTest extends AbstractFrameworkIntegrat
 
 	@Test
 	public void test() {
-		final Command command = CommandBuilder.withUri("/Acme/admin/p/testmappedmodel/_process?fn=_set&b=$execute").getCommand();
+		final Command command = CommandBuilder.withUri(PLATFORM_ROOT + "/testmappedmodel/_process?fn=_set&b=$execute").getCommand();
 		assertNotNull(hierarchyMatchBasedBeanFinder.findMatchingBean(SetFunctionHandler.class, this.constructFunctionHandlerKey(command)));
 	}
 	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProviderUnitTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProviderUnitTest.java
@@ -34,6 +34,7 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
 import com.antheminc.oss.nimbus.entity.StaticCodeValue;
 
@@ -72,7 +73,7 @@ public class ParamCodeValueProviderUnitTest {
 		Output<List<StaticCodeValue>> searchResultsOutput = Output.instantiate(input, eCtx);
 		searchResultsOutput.setValue(searchResults);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.STATIC_CODE_VALUE.code);
 		Mockito.when(this.searchExecutor.execute(input)).thenReturn(searchResultsOutput);
 		
 		Assert.assertNull(this.testee.execute(input).getValue());
@@ -100,7 +101,7 @@ public class ParamCodeValueProviderUnitTest {
 		Output<List<StaticCodeValue>> searchResultsOutput = Output.instantiate(input, eCtx);
 		searchResultsOutput.setValue(searchResults);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.STATIC_CODE_VALUE.code);
 		Mockito.when(this.searchExecutor.execute(input)).thenReturn(searchResultsOutput);
 		
 		Assert.assertEquals(expected, this.testee.execute(input).getValue());
@@ -129,7 +130,7 @@ public class ParamCodeValueProviderUnitTest {
 		Output<List<StaticCodeValue>> searchResultsOutput = Output.instantiate(input, eCtx);
 		searchResultsOutput.setValue(searchResults);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.STATIC_CODE_VALUE.code);
 		Mockito.when(this.searchExecutor.execute(input)).thenReturn(searchResultsOutput);
 		
 		this.testee.execute(input).getValue();
@@ -160,7 +161,7 @@ public class ParamCodeValueProviderUnitTest {
 		values.put(codeKey, expected);
 		this.testee.setValues(values);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.STATIC_CODE_VALUE.code);
 		Mockito.when(commandMessage.getRawPayload()).thenReturn(rawPayload);
 		
 		Assert.assertEquals(expected, this.testee.execute(input).getValue());

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/config/builder/AnnotationConfigHandlerPropertyResolverTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/config/builder/AnnotationConfigHandlerPropertyResolverTest.java
@@ -128,7 +128,7 @@ public class AnnotationConfigHandlerPropertyResolverTest extends AbstractFramewo
 	
 	@Test
 	public void t04_config() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_expr/_new").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/sample_expr/_new").getCommand();
 		
 		QuadModel<?, ?> q = quadBuilder.build(cmd);
 		assertNotNull(q);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/AbstractStateEventHandlerTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/AbstractStateEventHandlerTests.java
@@ -35,6 +35,7 @@ import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContextLoader;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.ExecutionModel;
 import com.antheminc.oss.nimbus.domain.model.state.internal.BaseStateEventListener;
+import com.antheminc.oss.nimbus.domain.model.state.multitenancy.TenantRepository;
 import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
 import com.antheminc.oss.nimbus.test.FrameworkIntegrationTestScenariosApplication;
 
@@ -50,6 +51,9 @@ public abstract class AbstractStateEventHandlerTests extends AbstractFrameworkIn
 	//@Autowired QuadModelBuilder quadModelBuilder;
 	@Autowired 
 	protected ExecutionContextLoader executionContextLoader;
+	
+	@Autowired
+	protected TenantRepository tenantRepository;
 	
 	protected Command _cmd;
 	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/ActivateParamBaseTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/ActivateParamBaseTest.java
@@ -30,14 +30,15 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.ExecutionModel;
 import com.antheminc.oss.nimbus.domain.model.state.builder.QuadModelBuilder;
 import com.antheminc.oss.nimbus.domain.model.state.internal.BaseStateEventListener;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 
 /**
  * @author Soham Chakravarti
  *
  */
-public abstract class ActivateParamBaseTest {
-
+public abstract class ActivateParamBaseTest extends AbstractFrameworkTest {
+	
 	@Autowired QuadModelBuilder quadModelBuilder;
 	
 	protected Command _cmd;
@@ -48,9 +49,8 @@ public abstract class ActivateParamBaseTest {
 	
 	protected BaseStateEventListener _stateEventListener;
 	
-	protected static Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_core/_new").getCommand();
-		return cmd;
+	protected Command createCommand() {
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_core/_new").getCommand();
 	}
 	
 	protected abstract String getSourceParamPath();

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/AbstractStateBuilderCollectionScenariosTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/AbstractStateBuilderCollectionScenariosTest.java
@@ -25,6 +25,7 @@ import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
 import com.antheminc.oss.nimbus.test.FrameworkIntegrationTestScenariosApplication;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.view.VRSampleViewRootEntity;
 
@@ -35,13 +36,12 @@ import com.antheminc.oss.nimbus.test.scenarios.s0.view.VRSampleViewRootEntity;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes=FrameworkIntegrationTestScenariosApplication.class)
 @ActiveProfiles("test")
-public abstract class AbstractStateBuilderCollectionScenariosTest {
-
+public abstract class AbstractStateBuilderCollectionScenariosTest extends AbstractFrameworkTest {
+	
 	@Autowired QuadModelBuilder quadModelBuilder;
-
-	protected static Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+	
+	protected Command createCommand() {
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	protected QuadModel<VRSampleViewRootEntity, SampleCoreEntity> buildQuad() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
@@ -47,6 +47,7 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
 import com.antheminc.oss.nimbus.domain.model.state.extension.StaticCodeValueBasedCodeToLabelConverter;
 import com.antheminc.oss.nimbus.domain.model.state.internal.AbstractListPaginatedParam.PageWrapper.PageRequestAndRespone;
@@ -76,7 +77,6 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	protected static final String CLIENT_USER_ALIAS = "clientuser";
 	protected static final String CLIENT_USER_GROUP_ALIAS = "clientusergroup";
 	protected static final String QUEUE_ALIAS = "queue";
-	protected static final String STATIC_CODE_VALUE_ALIAS = "staticCodeValue";
 	
 	private static final String[] COLLECTIONS = {QUEUE_ALIAS, CLIENT_USER_ALIAS, CLIENT_USER_GROUP_ALIAS,SAMPLE_CORE_ENTITY_ACCESS_ALIAS};
 	
@@ -92,13 +92,13 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	
 	@Test
 	public void t1_testSearchByLookupStaticCodeValue() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.STATIC_CODE_VALUE.code);
 		
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue("code1", "label1", "desc1"));
 		final StaticCodeValue expected = new StaticCodeValue("/status0", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/status0')");
 		
@@ -122,14 +122,14 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	 */
 	@Test
 	public void t0_testSearchByLookupStaticCodeValue_inMemorySorted() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.STATIC_CODE_VALUE.code);
 		
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue(Long.valueOf(1), "label1", "desc1"));
 		expectedValues.add(new ParamValue(Long.valueOf(2), "label2", "desc2"));
 		final StaticCodeValue expected = new StaticCodeValue("/status1", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/status1')&orderby=code.desc()");
 		
@@ -155,21 +155,21 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	 */
 	@Test
 	public void testSearchByLookupStaticCodeValue_dbsorted() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.STATIC_CODE_VALUE.code);
 		
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue(Long.valueOf(1), "slabel1", "sdesc1"));
 		expectedValues.add(new ParamValue(Long.valueOf(2), "slabel2", "sdesc2"));
 		final StaticCodeValue expected = new StaticCodeValue("/status1", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		final List<ParamValue> expectedValues2 = new ArrayList<>();
 		expectedValues2.add(new ParamValue(Long.valueOf(1), "clabel1", "cdesc1"));
 		expectedValues2.add(new ParamValue(Long.valueOf(2), "clabel2", "cdesc2"));
 		final StaticCodeValue expected2 = new StaticCodeValue("/category", expectedValues);
 		expected2.setId(new Random().nextLong());
-		this.mongoOps.insert(expected2, "staticCodeValue");
+		this.mongoOps.insert(expected2, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&orderby=staticCodeValue.paramCode.desc()");
 		
@@ -199,12 +199,12 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	
 	@Test
 	public void t11_testSearchByLookupStaticCodeValueElemMatch() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.STATIC_CODE_VALUE.code);
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue("ACL", "Anticardiolpin Antibodies", null));
 		final StaticCodeValue expected = new StaticCodeValue("anything", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		assertEquals("Anticardiolpin Antibodies", this.labelConverter.serialize("ACL"));
 	}
@@ -277,12 +277,12 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 
 	@Test
 	public void t5_testSearchByQueryWithProjection() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.STATIC_CODE_VALUE.code);
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue("code1", "label1", "desc1"));
 		final StaticCodeValue expected = new StaticCodeValue("/status", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&where=staticCodeValue.paramCode.eq('/status')&projection.alias=vstaticCodeValue");
 		
@@ -445,13 +445,13 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	
 	@Test
 	public void t6_testSearchByQueryWithCountAggregation() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.STATIC_CODE_VALUE.code);
 		StaticCodeValue scv = new StaticCodeValue("/status", null);
 		scv.setId(new Random().nextLong());
 		StaticCodeValue scv2 = new StaticCodeValue("/status", null);
 		scv2.setId(new Random().nextLong());
-		this.mongoOps.insert(scv, "staticCodeValue");
-		this.mongoOps.insert(scv2, "staticCodeValue");
+		this.mongoOps.insert(scv, Constants.STATIC_CODE_VALUE.code);
+		this.mongoOps.insert(scv2, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&where=staticCodeValue.paramCode.eq('/status')&aggregate=count");
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
@@ -98,6 +98,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		expectedValues.add(new ParamValue("code1", "label1", "desc1"));
 		final StaticCodeValue expected = new StaticCodeValue("/status0", expectedValues);
 		expected.setId(new Random().nextLong());
+		expected.set_tenantId(TENANT_ID);
 		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/status0')");
@@ -129,6 +130,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		expectedValues.add(new ParamValue(Long.valueOf(2), "label2", "desc2"));
 		final StaticCodeValue expected = new StaticCodeValue("/status1", expectedValues);
 		expected.setId(new Random().nextLong());
+		expected.set_tenantId(TENANT_ID);
 		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/status1')&orderby=code.desc()");
@@ -162,6 +164,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		expectedValues.add(new ParamValue(Long.valueOf(2), "slabel2", "sdesc2"));
 		final StaticCodeValue expected = new StaticCodeValue("/status1", expectedValues);
 		expected.setId(new Random().nextLong());
+		expected.set_tenantId(TENANT_ID);
 		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		final List<ParamValue> expectedValues2 = new ArrayList<>();
@@ -169,6 +172,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		expectedValues2.add(new ParamValue(Long.valueOf(2), "clabel2", "cdesc2"));
 		final StaticCodeValue expected2 = new StaticCodeValue("/category", expectedValues);
 		expected2.setId(new Random().nextLong());
+		expected2.set_tenantId(TENANT_ID);
 		this.mongoOps.insert(expected2, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&orderby=staticCodeValue.paramCode.desc()");
@@ -204,6 +208,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		expectedValues.add(new ParamValue("ACL", "Anticardiolpin Antibodies", null));
 		final StaticCodeValue expected = new StaticCodeValue("anything", expectedValues);
 		expected.setId(new Random().nextLong());
+		expected.set_tenantId(TENANT_ID);
 		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		assertEquals("Anticardiolpin Antibodies", this.labelConverter.serialize("ACL"));
@@ -282,6 +287,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		expectedValues.add(new ParamValue("code1", "label1", "desc1"));
 		final StaticCodeValue expected = new StaticCodeValue("/status", expectedValues);
 		expected.setId(new Random().nextLong());
+		expected.set_tenantId(TENANT_ID);
 		this.mongoOps.insert(expected, Constants.STATIC_CODE_VALUE.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&where=staticCodeValue.paramCode.eq('/status')&projection.alias=vstaticCodeValue");
@@ -301,6 +307,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		SampleDomain entity1 = new SampleDomain();
 		SampleNestedDomain nestedEntity1 = new SampleNestedDomain();
 		entity1.setId(2L);
+		entity1.set_tenantId(TENANT_ID);
 		entity1.setAttr_String("searchString");
 		nestedEntity1.setNested_attr_String("nestedAttribute1");
 		entity1.setAttr_NestedEntity(nestedEntity1);
@@ -308,6 +315,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		SampleDomain entity2 = new SampleDomain();
 		SampleNestedDomain nestedEntity2 = new SampleNestedDomain();
 		entity2.setId(3L);
+		entity2.set_tenantId(TENANT_ID);
 		entity2.setAttr_String("searchString1");
 		nestedEntity2.setNested_attr_String("nestedAttribute2");
 		entity2.setAttr_NestedEntity(nestedEntity2);
@@ -367,6 +375,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		SampleDomain entity1 = new SampleDomain();
 		SampleNestedDomain nestedEntity1 = new SampleNestedDomain();
 		entity1.setId(2L);
+		entity1.set_tenantId(TENANT_ID);
 		entity1.setAttr_String("searchString");
 		nestedEntity1.setNested_attr_String("nestedAttribute1");
 		entity1.setAttr_NestedEntity(nestedEntity1);
@@ -374,6 +383,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		SampleDomain entity2 = new SampleDomain();
 		SampleNestedDomain nestedEntity2 = new SampleNestedDomain();
 		entity2.setId(3L);
+		entity2.set_tenantId(TENANT_ID);
 		entity2.setAttr_String("searchString1");
 		nestedEntity2.setNested_attr_String("nestedAttribute2");
 		entity2.setAttr_NestedEntity(nestedEntity2);
@@ -411,6 +421,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		SampleDomain entity1 = new SampleDomain();
 		SampleNestedDomain nestedEntity1 = new SampleNestedDomain();
 		entity1.setId(2L);
+		entity1.set_tenantId(TENANT_ID);
 		entity1.setAttr_String("searchString");
 		nestedEntity1.setNested_attr_String("nestedAttribute1");
 		entity1.setAttr_NestedEntity(nestedEntity1);
@@ -418,6 +429,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		SampleDomain entity2 = new SampleDomain();
 		SampleNestedDomain nestedEntity2 = new SampleNestedDomain();
 		entity2.setId(3L);
+		entity2.set_tenantId(TENANT_ID);
 		entity2.setAttr_String("searchString1");
 		nestedEntity2.setNested_attr_String("nestedAttribute2");
 		entity2.setAttr_NestedEntity(nestedEntity2);
@@ -448,8 +460,10 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		this.mongoOps.dropCollection(Constants.STATIC_CODE_VALUE.code);
 		StaticCodeValue scv = new StaticCodeValue("/status", null);
 		scv.setId(new Random().nextLong());
+		scv.set_tenantId(TENANT_ID);
 		StaticCodeValue scv2 = new StaticCodeValue("/status", null);
 		scv2.setId(new Random().nextLong());
+		scv2.set_tenantId(TENANT_ID);
 		this.mongoOps.insert(scv, Constants.STATIC_CODE_VALUE.code);
 		this.mongoOps.insert(scv2, Constants.STATIC_CODE_VALUE.code);
 		
@@ -730,6 +744,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	public void t20_tt() {
 		SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 		scea.setId(1L);
+		scea.set_tenantId(TENANT_ID);
 		scea.setAttr_String("test1_string1");
 		scea.setAttr_String2("test2_string2");
 		scea.setAttr_LocalDate1(LocalDate.now());
@@ -739,6 +754,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		SampleCoreEntityAccess scea2 = new SampleCoreEntityAccess();
 		scea2.setId(2L);
+		scea2.set_tenantId(TENANT_ID);
 		scea2.setAttr_String("test1_string1");
 		scea2.setAttr_String2("test2_string2");
 		scea2.setAttr_LocalDate1(LocalDate.now().plusYears(1));
@@ -818,6 +834,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		for(int i=0; i < attr_String.length; i++) {
 			SampleCoreEntityAccess scea = new SampleCoreEntityAccess();
 			scea.setId(new Random().nextLong());
+			scea.set_tenantId(TENANT_ID);
 			scea.setAttr_String(attr_String[i]);
 			if(attr_String2 != null && attr_String2.length > 0 && i <= attr_String2.length) {
 				scea.setAttr_String2(attr_String2[i]);
@@ -866,12 +883,14 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		Client c = new Client();
 		c.setId(new Random().nextLong());
+		c.set_tenantId(TENANT_ID);
 		c.setName("client");
 		c.setCode("c");
 		mongoOps.insert(c, "client");
 		
 		Client c1 = new Client();
 		c1.setId(new Random().nextLong());
+		c1.set_tenantId(TENANT_ID);
 		c1.setName("client1");
 		c1.setCode("c1");
 		mongoOps.insert(c1, "client");
@@ -883,20 +902,24 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		ClientUser clientUser = new ClientUser();
 		clientUser.setId(new Random().nextLong());
+		clientUser.set_tenantId(TENANT_ID);
 		clientUser.setDisplayName("U1");
 		clientUser.setLoginId("casemanager");
 		
 		
 		ClientUser clientUser2 = new ClientUser();
+		clientUser2.set_tenantId(TENANT_ID);
 		clientUser2.setId(new Random().nextLong());
 		clientUser2.setDisplayName("U2");
 		
 		ClientUser clientUser3 = new ClientUser();
 		clientUser3.setId(new Random().nextLong());
+		clientUser3.set_tenantId(TENANT_ID);
 		clientUser3.setDisplayName("U3");
 		
 		ClientUser clientUser4 = new ClientUser();
 		clientUser4.setId(new Random().nextLong());
+		clientUser4.set_tenantId(TENANT_ID);
 		clientUser4.setDisplayName("U4");
 		
 		mongoOps.save(clientUser, "clientuser");
@@ -910,20 +933,24 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		ClientUserGroup userGroup = new ClientUserGroup();
 		userGroup.setId(new Random().nextLong());
+		userGroup.set_tenantId(TENANT_ID);
 		userGroup.setName("UG1");
 		
 		List<GroupUser> groupUsers = new ArrayList<>();
 		GroupUser groupUser = new GroupUser();
 		groupUser.setUserId("casemanager");
+		groupUser.set_tenantId(TENANT_ID);
 		groupUsers.add(groupUser);
 		
 		GroupUser groupUser22 = new GroupUser();
 		groupUser22.setUserId("U3");
+		groupUser22.set_tenantId(TENANT_ID);
 		groupUser22.setAdmin(true);
 		groupUsers.add(groupUser22);
 		
 		GroupUser groupUser33 = new GroupUser();
 		groupUser33.setUserId("U4");
+		groupUser33.set_tenantId(TENANT_ID);
 		groupUser33.setAdmin(true);
 		groupUsers.add(groupUser33);
 		
@@ -961,6 +988,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		Queue queue = new Queue();
 		queue.setId(new Random().nextLong());
+		queue.set_tenantId(TENANT_ID);
 		queue.setName("Q1");
 		
 		ClientUser cu = mongoOps.findOne(new Query(Criteria.where("displayName").is("U1")), ClientUser.class, "clientuser");
@@ -969,6 +997,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		Queue queue2 = new Queue();
 		queue2.setId(new Random().nextLong());
+		queue2.set_tenantId(TENANT_ID);
 		queue2.setName("Q2");
 		
 		ClientUserGroup cug = mongoOps.findOne(new Query(Criteria.where("name").is("UG1")), ClientUserGroup.class, "clientusergroup");
@@ -977,6 +1006,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		Queue queue3 = new Queue();
 		queue3.setId(new Random().nextLong());
+		queue3.set_tenantId(TENANT_ID);
 		queue3.setName("Q3");
 		
 		ClientUserGroup cug2 = mongoOps.findOne(new Query(Criteria.where("name").is("UG1")), ClientUserGroup.class, "clientusergroup");
@@ -985,6 +1015,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		Queue queue4 = new Queue();
 		queue4.setId(new Random().nextLong());
+		queue4.set_tenantId(TENANT_ID);
 		queue4.setName("Q4");
 		
 		ClientUserGroup cug3 = mongoOps.findOne(new Query(Criteria.where("name").is("UG2")), ClientUserGroup.class, "clientusergroup");
@@ -993,6 +1024,7 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 		
 		Queue queue5 = new Queue();
 		queue5.setId(new Random().nextLong());
+		queue5.set_tenantId(TENANT_ID);
 		queue5.setName("Q5");
 		
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DetachedQuadModelCollectionsTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DetachedQuadModelCollectionsTest.java
@@ -44,9 +44,8 @@ public class DetachedQuadModelCollectionsTest extends AbstractFrameworkIntegrati
 	@Autowired QuadModelBuilder quadModelBuilder;
 	@Autowired SessionProvider sessionProvider;
 	
-	private static Command getCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/compressopm/thebox/p/v_simpledashboard/_new").getCommand();
-		return cmd;
+	private Command getCommand() {
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/v_simpledashboard/_new").getCommand();
 	}
 	
 	@Before

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/QuadModelCollectionsTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/QuadModelCollectionsTest.java
@@ -58,6 +58,7 @@ import com.antheminc.oss.nimbus.domain.model.state.internal.DefaultParamState;
 import com.antheminc.oss.nimbus.domain.model.state.internal.ExecutionEntity;
 import com.antheminc.oss.nimbus.domain.session.SessionProvider;
 import com.antheminc.oss.nimbus.test.FrameworkIntegrationTestScenariosApplication;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.test.scenarios.s3.core.ServiceLine;
 import com.antheminc.oss.nimbus.test.scenarios.s3.core.ServiceLine.AuditInfo;
 import com.antheminc.oss.nimbus.test.scenarios.s3.core.SimpleCase;
@@ -72,18 +73,18 @@ import com.antheminc.oss.nimbus.test.scenarios.s3.view.VRSimpleCaseFlow;
 @SpringBootTest(classes=FrameworkIntegrationTestScenariosApplication.class)
 @ActiveProfiles("test")
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class QuadModelCollectionsTest {
+public class QuadModelCollectionsTest extends AbstractFrameworkTest {
 	
 	@Autowired QuadModelBuilder quadModelBuilder;
 	@Autowired SessionProvider sessionProvider;
 	
 	public static Command create_view_main() {
 
-		Command c = new Command("/hooli/comm/thebox/p/view_simplecase/_new");
+		Command c = new Command(PLATFORM_ROOT + "/view_simplecase/_new");
 
-		c.createRoot(Type.ClientAlias, "hooli")
-			.createNext(Type.ClientOrgAlias, "compression")
-			.createNext(Type.AppAlias, "icr")
+		c.createRoot(Type.ClientAlias, CLIENT_ID)
+			.createNext(Type.ClientOrgAlias, ORG_ID)
+			.createNext(Type.AppAlias, APP_ID)
 			.createNext(Type.PlatformMarker, "p")
 			.createNext(Type.DomainAlias, "view_simplecase")
 			;//.createNext(Type.Action, Action._new.name());

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/QuadModelCollectionsTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/QuadModelCollectionsTest.java
@@ -83,7 +83,7 @@ public class QuadModelCollectionsTest extends AbstractFrameworkTest {
 		Command c = new Command(PLATFORM_ROOT + "/view_simplecase/_new");
 
 		c.createRoot(Type.ClientAlias, CLIENT_ID)
-			.createNext(Type.ClientOrgAlias, ORG_ID)
+			.createNext(Type.TENANT_ID, String.valueOf(TENANT_ID))
 			.createNext(Type.AppAlias, APP_ID)
 			.createNext(Type.PlatformMarker, "p")
 			.createNext(Type.DomainAlias, "view_simplecase")

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/StateBuilderCollections_V2C_Attached_Transient_Test.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/StateBuilderCollections_V2C_Attached_Transient_Test.java
@@ -41,6 +41,7 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.MappedTransientPa
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
 import com.antheminc.oss.nimbus.test.FrameworkIntegrationTestScenariosApplication;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.view.VPSampleViewPageBlue.Section_ConvertedNestedEntity;
@@ -56,17 +57,16 @@ import com.antheminc.oss.nimbus.test.scenarios.s0.view.VRSampleViewRootEntity;
 @SpringBootTest(classes=FrameworkIntegrationTestScenariosApplication.class)
 @ActiveProfiles("test")
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class StateBuilderCollections_V2C_Attached_Transient_Test {
+public class StateBuilderCollections_V2C_Attached_Transient_Test extends AbstractFrameworkTest {
 
 	private static final String CORE_PARAM_PATH = "/sample_core/attr_list_2_NestedEntity";
-
 	private static final String VIEW_PARAM_MAPPED_PATH = "/sample_view/page_blue/tile/vm_attached_convertedList";
 	private static final String VIEW_PARAM_TRANSIENT_PATH = "/sample_view/page_red/tile/vt_attached_convertedNestedEntity";
 
 	@Autowired QuadModelBuilder quadModelBuilder;
-
-	protected static Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
+	
+	protected Command createCommand() {
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 		return cmd;
 	}
 	

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/collections/DefaultListParamStateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/collections/DefaultListParamStateTest.java
@@ -49,7 +49,7 @@ public class DefaultListParamStateTest extends AbstractFrameworkIngerationPersis
 	
 	@Test
 	public void t1_add_validateSize() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 		
 		QuadModel<?, ?> q = quadBuilder.build(cmd);
 		assertNotNull(q);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/AccessConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/AccessConditionalStateEventHandlerTest.java
@@ -67,8 +67,7 @@ public class AccessConditionalStateEventHandlerTest extends AbstractStateEventHa
 	
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_core_access/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_core_access/_new").getCommand();
 	}
 	
 	@Override

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalNoConversionTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalNoConversionTest.java
@@ -50,8 +50,7 @@ public class ActivateConditionalNoConversionTest extends AbstractStateEventHandl
 	
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view:"+REF_ID+"/_get").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view:"+REF_ID+"/_get").getCommand();
 	}
 	
 	private SampleCoreEntity createOrGetCore() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateParamActivateDeactivateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateParamActivateDeactivateTest.java
@@ -47,8 +47,7 @@ public class ActivateParamActivateDeactivateTest extends AbstractStateEventHandl
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	protected String getSourceParamPath() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateParamRuleTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateParamRuleTest.java
@@ -46,8 +46,7 @@ public class ActivateParamRuleTest  extends AbstractStateEventHandlerTests {
 	private static final String CORE_PARAM_PATH_q2Level1_nested_attr_String = CORE_PARAM_PATH_q2Level1 + "/nested_attr_String";
 
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri(CORE_PARAM_ROOT + "/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(CORE_PARAM_ROOT + "/_new").getCommand();
 	}
 	
 	protected String getSourceParamPath() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/AuditStateChangeHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/AuditStateChangeHandlerTest.java
@@ -63,8 +63,7 @@ public class AuditStateChangeHandlerTest extends AbstractStateEventHandlerTests 
 	
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	private Param<String> getCore_audit_string() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ConfigConditionalStateChangeHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ConfigConditionalStateChangeHandlerTest.java
@@ -51,8 +51,7 @@ public class ConfigConditionalStateChangeHandlerTest extends AbstractStateEventH
 	
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	@Override

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/EnableConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/EnableConditionalStateEventHandlerTest.java
@@ -38,8 +38,7 @@ public class EnableConditionalStateEventHandlerTest extends AbstractStateEventHa
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	@Test

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ExpressionConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ExpressionConditionalStateEventHandlerTest.java
@@ -80,7 +80,7 @@ public class ExpressionConditionalStateEventHandlerTest extends AbstractFramewor
 	
 	@Test
 	public void t01_onLoad() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_expr/_new").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/sample_expr/_new").getCommand();
 		
 		QuadModel<?, ?> q = quadBuilder.build(cmd);
 		assertNotNull(q);
@@ -97,7 +97,7 @@ public class ExpressionConditionalStateEventHandlerTest extends AbstractFramewor
 	
 	@Test
 	public void t02_onChange() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_expr/_new").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/sample_expr/_new").getCommand();
 		
 		QuadModel<?, ?> q = quadBuilder.build(cmd);
 		assertNotNull(q);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelConditionalStateEventHandlerTest.java
@@ -15,8 +15,6 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
-import java.util.Locale;
-
 import org.junit.Assert;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -26,7 +24,6 @@ import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.model.state.AbstractStateEventHandlerTests;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
-import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.LabelState;
 
 /**
  * @author Tony Lopez
@@ -169,7 +166,6 @@ public class LabelConditionalStateEventHandlerTest extends AbstractStateEventHan
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelStateOnLoadEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelStateOnLoadEventHandlerTest.java
@@ -77,6 +77,7 @@ public class LabelStateOnLoadEventHandlerTest extends AbstractFrameworkIntegrati
 	private Object prepareParam(String viewRoot) {
 		Sample_Core_Label_Entity sc_main = new Sample_Core_Label_Entity();
 		sc_main.setId(CORE_REF_ID_1);
+		sc_main.set_tenantId(TENANT_ID);
 		sc_main.setAttr1("Green");
 		mongo.insert(sc_main, "sample_core_label");
 		
@@ -247,6 +248,7 @@ public class LabelStateOnLoadEventHandlerTest extends AbstractFrameworkIntegrati
 	public void t06_label_nested_coll_multiple_withstate() {
 		Sample_Core_Label_Entity sc_main = new Sample_Core_Label_Entity();
 		sc_main.setId(new Long(2));
+		sc_main.set_tenantId(TENANT_ID);
 		Nested_Attr nested_1 = new Nested_Attr();
 		nested_1.setAttr_nested_1("nested attr1");
 		Nested_Attr_Level2 attr_level2 = new Nested_Attr_Level2();
@@ -298,6 +300,7 @@ public class LabelStateOnLoadEventHandlerTest extends AbstractFrameworkIntegrati
 	public void t07_label_state_nested_attr() {
 		Sample_Core_Label_Entity sc_main = new Sample_Core_Label_Entity();
 		sc_main.setId(new Long(3));
+		sc_main.set_tenantId(TENANT_ID);
 		Nested_Attr nested_1 = new Nested_Attr();
 		nested_1.setAttr_nested_1("nested attr1");
 		sc_main.setAttr_nested(nested_1);
@@ -414,6 +417,7 @@ public class LabelStateOnLoadEventHandlerTest extends AbstractFrameworkIntegrati
 		
 		Sample_Core_Label_Entity sc_main = new Sample_Core_Label_Entity();
 		sc_main.setId(new Long(5));
+		sc_main.set_tenantId(TENANT_ID);
 		sc_main.setAttr2("test");
 		
 		mongo.insert(sc_main, "sample_core_label");

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelStateOnLoadEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/LabelStateOnLoadEventHandlerTest.java
@@ -43,7 +43,6 @@ import com.antheminc.oss.nimbus.domain.defn.MapsTo.Type;
 import com.antheminc.oss.nimbus.domain.defn.Model;
 import com.antheminc.oss.nimbus.domain.defn.extension.Content.Label;
 import com.antheminc.oss.nimbus.domain.model.config.ParamConfig;
-import com.antheminc.oss.nimbus.domain.model.state.EntityState.ListParam;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.LabelState;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalEventHandlerTest.java
@@ -27,7 +27,6 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.model.state.AbstractStateEventHandlerTests;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.ModelEvent;
-import com.antheminc.oss.nimbus.domain.model.state.internal.DefaultParamState.LeafState;
 import com.antheminc.oss.nimbus.domain.model.state.internal.MappedDefaultParamState.MappedLeafState;
 import com.antheminc.oss.nimbus.support.Holder;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
@@ -41,9 +40,7 @@ public class MessageConditionalEventHandlerTest extends AbstractStateEventHandle
 
 	@Override
 	protected Command createCommand() {
-
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	@Test
@@ -114,7 +111,7 @@ public class MessageConditionalEventHandlerTest extends AbstractStateEventHandle
 	public <T, M> void t02_testOnStateLoadMessageWithSpelMessage_4() throws IOException {
 		
 		JacksonTester.initFields(this, om);
-		MockHttpServletRequest req = MockHttpRequestBuilder.withUri("Anthem/fep/p/sample_view/")
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(PLATFORM_ROOT + "/sample_view/")
 				.addAction(Action._new)
 				.getMock();
 

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
@@ -23,6 +23,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import javax.servlet.http.Cookie;
+
 import org.apache.commons.lang.StringUtils;
 import org.hamcrest.core.IsNull;
 import org.junit.FixMethodOrder;
@@ -36,6 +38,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.Message;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
@@ -88,6 +91,7 @@ public class MessageEventHandlerTest extends AbstractFrameworkIngerationPersista
 		createClientUser();
 		// to simulate the _get call with JsonSerializer
 		mvc.perform(get(createRequest(uri, Action._get).getRequestURI())
+				.cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, CMD_PREFIX))
 				.contentType(APPLICATION_JSON_UTF8))
                	.andExpect(status().isOk())
                	.andExpect(jsonPath("$.result.0.result.outputs[0].value.type.model.params[4].type.model.params[0].type.model.params[0].type.model.params[0].type.model.params[0].message[0].text", IsNull.notNullValue()))
@@ -106,6 +110,7 @@ public class MessageEventHandlerTest extends AbstractFrameworkIngerationPersista
 		MockHttpServletRequest home_newReq = createRequest(VIEW_PARAM_ROOT, Action._new);
 		createClientUser();
 		mvc.perform(get(home_newReq.getRequestURI())
+				.cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, CMD_PREFIX))
 				.contentType(APPLICATION_JSON_UTF8))
                	.andExpect(status().isOk())
                	.andExpect(jsonPath("$.result.0.result.outputs[0].value.type.model.params[4].type.model.params[0].type.model.params[0].type.model.params[0].type.model.params[9].message[0].text", IsNull.notNullValue()))

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageEventHandlerTest.java
@@ -85,7 +85,7 @@ public class MessageEventHandlerTest extends AbstractFrameworkIngerationPersista
 		Message msg = testWarningTextBox_p.getMessages().stream()
 			.filter(m -> StringUtils.equalsIgnoreCase("This is a Test Warning Message", m.getText())).findFirst().get();		
 		assertEquals("This is a Test Warning Message",msg.getText());
-		
+		createClientUser();
 		// to simulate the _get call with JsonSerializer
 		mvc.perform(get(createRequest(uri, Action._get).getRequestURI())
 				.contentType(APPLICATION_JSON_UTF8))
@@ -104,6 +104,7 @@ public class MessageEventHandlerTest extends AbstractFrameworkIngerationPersista
 	@WithMockUser(username="user", password="pwd")
 	public void t02_messageState_json_onload() throws Exception{
 		MockHttpServletRequest home_newReq = createRequest(VIEW_PARAM_ROOT, Action._new);
+		createClientUser();
 		mvc.perform(get(home_newReq.getRequestURI())
 				.contentType(APPLICATION_JSON_UTF8))
                	.andExpect(status().isOk())

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ModalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ModalStateEventHandlerTest.java
@@ -46,8 +46,7 @@ public class ModalStateEventHandlerTest extends AbstractStateEventHandlerTests {
 	
 	@Override
 	protected Command createCommand() {
-		final Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view:"+REF_ID+"/_get").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view:"+REF_ID+"/_get").getCommand();
 	}
 
 	private SampleCoreEntity createOrGetCore() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ModalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ModalStateEventHandlerTest.java
@@ -57,6 +57,7 @@ public class ModalStateEventHandlerTest extends AbstractStateEventHandlerTests {
 		AtomicInteger counter = new AtomicInteger(0);
 		final SampleCoreEntity core = new SampleCoreEntity();
 		core.setId(Long.valueOf(counter.getAndIncrement()));
+		core.set_tenantId(TENANT_ID);
 		mongo.insert(core, "sample_core");
 		REF_ID = core.getId();
 		assertNotNull(REF_ID);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ParamContextStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ParamContextStateEventHandlerTest.java
@@ -44,8 +44,7 @@ public class ParamContextStateEventHandlerTest extends AbstractStateEventHandler
 	
 	@Override
 	protected Command createCommand() {
-		final Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view:"+REF_ID+"/_get").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view:"+REF_ID+"/_get").getCommand();
 	}
 
 	private SampleCoreEntity createOrGetCore() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/RuleStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/RuleStateEventHandlerTest.java
@@ -57,6 +57,7 @@ public class RuleStateEventHandlerTest extends AbstractStateEventHandlerTests {
 		
 		final SampleCoreEntity core = new SampleCoreEntity();
 		core.setId(new Random().nextLong());
+		core.set_tenantId(TENANT_ID);
 		mongo.insert(core, ENTITY_CORE);
 		REF_ID = core.getId();
 		assertNotNull(REF_ID);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/RuleStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/RuleStateEventHandlerTest.java
@@ -46,8 +46,7 @@ public class RuleStateEventHandlerTest extends AbstractStateEventHandlerTests {
 	
 	@Override
 	protected Command createCommand() {
-		final Command cmd = CommandBuilder.withUri("/hooli/thebox/p/" + ENTITY_VIEW + ":"+REF_ID+"/_get").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/" + ENTITY_VIEW + ":"+REF_ID+"/_get").getCommand();
 	}
 
 	private SampleCoreEntity createOrGetCore() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ScriptEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ScriptEventHandlerTest.java
@@ -32,8 +32,7 @@ public class ScriptEventHandlerTest extends AbstractStateEventHandlerTests {
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	@Test

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandlerTest.java
@@ -123,7 +123,6 @@ public class StyleConditionalStateEventHandlerTest extends AbstractStateEventHan
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValidateConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValidateConditionalStateEventHandlerTest.java
@@ -33,8 +33,7 @@ public class ValidateConditionalStateEventHandlerTest extends AbstractStateEvent
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 	
 	@Test

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
@@ -48,8 +48,7 @@ public class ValuesConditionalStateEventHandlerIntegTest extends AbstractStateEv
 	
 	@Override
 	protected Command createCommand() {
-		final Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view:"+REF_ID+"/_get").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view:"+REF_ID+"/_get").getCommand();
 	}
 
 	private SampleCoreEntity createOrGetCore() {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerIntegTest.java
@@ -59,6 +59,7 @@ public class ValuesConditionalStateEventHandlerIntegTest extends AbstractStateEv
 		//AtomicInteger counter = new AtomicInteger(0);
 		final SampleCoreEntity core = new SampleCoreEntity();
 		core.setId(new Random().nextLong());
+		core.set_tenantId(TENANT_ID);
 		mongo.insert(core, "sample_core");
 		REF_ID = core.getId();
 		assertNotNull(REF_ID);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/VisibleConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/VisibleConditionalStateEventHandlerTest.java
@@ -35,8 +35,7 @@ public class VisibleConditionalStateEventHandlerTest extends AbstractStateEventH
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 	}
 
 	@Test

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/internal/MappedDefaultParamStateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/internal/MappedDefaultParamStateTest.java
@@ -37,6 +37,7 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
 import com.antheminc.oss.nimbus.domain.model.state.builder.QuadModelBuilder;
 import com.antheminc.oss.nimbus.test.FrameworkIntegrationTestScenariosApplication;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 
 /**
@@ -47,14 +48,14 @@ import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 @SpringBootTest(classes=FrameworkIntegrationTestScenariosApplication.class)
 @ActiveProfiles("test")
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class MappedDefaultParamStateTest {
+public class MappedDefaultParamStateTest extends AbstractFrameworkTest {
 	
 	@Autowired QuadModelBuilder quadModelBuilder;
 	
 	protected QuadModel<?, SampleCoreEntity> _q;
 	
-	protected static Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_view/_new").getCommand();
+	protected Command createCommand() {
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/sample_view/_new").getCommand();
 		return cmd;
 	}
 

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/internal/ParamStateContextMessageUpdateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/internal/ParamStateContextMessageUpdateTest.java
@@ -15,7 +15,6 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.internal;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -48,7 +47,7 @@ public class ParamStateContextMessageUpdateTest extends AbstractStateEventHandle
 
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_expr/_new").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/sample_expr/_new").getCommand();
 		return cmd;
 	}
 

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/DomainEntityMultitenancyTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/DomainEntityMultitenancyTest.java
@@ -1,0 +1,94 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
+
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@TestPropertySource(properties = { 
+		"nimbus.multitenancy.tenants.1.description=ABC",
+		"nimbus.multitenancy.tenants.1.prefix=/foo/1/app",
+		"nimbus.multitenancy.tenants.2.description=DEF",
+		"nimbus.multitenancy.tenants.2.prefix=/foo/2/app",
+})
+public class DomainEntityMultitenancyTest extends AbstractFrameworkIntegrationTests {
+
+	@Autowired
+	private CommandExecutorGateway commandGateway;
+	
+	@Test
+	public void testMongoRecordLevelExampleSearch() {
+		
+		List<SampleCoreEntity> inserted = new ArrayList<>();
+		SampleCoreEntity sc = new SampleCoreEntity();
+		sc.setId(10L);
+		sc.set_tenantId(1L);
+		inserted.add(insert("sample_core", sc));
+		sc = new SampleCoreEntity();
+		sc.setId(11L);
+		sc.set_tenantId(2L);
+		inserted.add(insert("sample_core", sc));
+		
+		SampleCoreEntity expected = new SampleCoreEntity();
+		expected.setId(10L);
+		Command command = CommandBuilder.withUri("/foo/1/app/p/sample_core/_search?fn=example").getCommand();
+		MultiOutput response = this.commandGateway.execute(command, this.asString(expected));
+		List<SampleCoreEntity> actual = (List<SampleCoreEntity>) response.getSingleResult();
+		Assert.assertEquals(1, actual.size());
+		Assert.assertEquals(inserted.get(0).getId(), actual.get(0).getId());
+		Assert.assertEquals(Long.valueOf(1), actual.get(0).get_tenantId());
+	}
+	
+	@Test
+	public void testMongoRecordLevelQuerySearch() {
+		
+		List<SampleCoreEntity> inserted = new ArrayList<>();
+		SampleCoreEntity sc = new SampleCoreEntity();
+		sc.setId(10L);
+		sc.set_tenantId(1L);
+		inserted.add(insert("sample_core", sc));
+		sc = new SampleCoreEntity();
+		sc.setId(11L);
+		sc.set_tenantId(2L);
+		inserted.add(insert("sample_core", sc));
+		
+		SampleCoreEntity expected = new SampleCoreEntity();
+		expected.setId(1L);
+		Command command = CommandBuilder.withUri("/foo/1/app/p/sample_core/_search?fn=query&where=sample_core.id.eq(10)").getCommand();
+		MultiOutput response = this.commandGateway.execute(command, this.asString(expected));
+		List<SampleCoreEntity> actual = (List<SampleCoreEntity>) response.getSingleResult();
+		Assert.assertEquals(1, actual.size());
+		Assert.assertEquals(inserted.get(0).getId(), actual.get(0).getId());
+		Assert.assertEquals(Long.valueOf(1), actual.get(0).get_tenantId());
+	}
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/MultitenantCommandExecutionTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/MultitenantCommandExecutionTests.java
@@ -60,4 +60,122 @@ public class MultitenantCommandExecutionTests extends AbstractFrameworkIntegrati
 		Assert.assertEquals(expected.getId(), actual.getId());
 		Assert.assertEquals(Long.valueOf(2), actual.get_tenantId());
 	}
+
+	/**
+	 * _delete on domain entity
+	 */
+	@Test
+	public void testDelete() {
+		SampleCoreEntity expected = insertSingleSampleCore(1L, 2L);
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._delete).getCommand();
+		MultiOutput response = this.commandGateway.execute(command, null);
+		Assert.assertTrue((Boolean) response.getSingleResult());
+		Assert.assertFalse(exists(1L, SampleCoreEntity.class, "sample_core"));
+	}
+
+	/**
+	 * _delete on domain entity having a different tenant id than what is
+	 * provided in the command url
+	 */
+	@Test
+	public void testDeleteUnallowed() {
+		SampleCoreEntity expected = insertSingleSampleCore(2L, 1L);
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._delete).getCommand();
+		thrown.expect(FrameworkRuntimeException.class);
+		thrown.expectMessage("Entity not found for /foo/2/app/p/sample_core:" + expected.getId());
+		this.commandGateway.execute(command, null);
+	}
+
+	/**
+	 * _get on domain entity
+	 */
+	@Test
+	public void testRead() {
+		SampleCoreEntity expected = insertSingleSampleCore(3L, 2L);
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._get).getCommand();
+		MultiOutput response = this.commandGateway.execute(command, this.asString(expected));
+		SampleCoreEntity actual = ((Param<SampleCoreEntity>) response.getSingleResult()).getState();
+		Assert.assertEquals(expected.getId(), actual.getId());
+		Assert.assertEquals(expected.get_tenantId(), actual.get_tenantId());
+	}
+
+	/**
+	 * _get on domain entity having a different tenant id than what is provided
+	 * in the command url
+	 */
+	@Test
+	public void testReadUnallowed() {
+		SampleCoreEntity expected = insertSingleSampleCore(4L, 1L);
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._get).getCommand();
+		thrown.expect(FrameworkRuntimeException.class);
+		thrown.expectMessage("Entity not found for /foo/2/app/p/sample_core:" + expected.getId());
+		this.commandGateway.execute(command, null);
+	}
+
+	/**
+	 * _replace on domain entity
+	 */
+	@Test
+	public void testReplace() {
+		SampleCoreEntity expected = insertSingleSampleCore(5L, 2L);
+		expected.setAttr_String("foo");
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._replace).getCommand();
+		MultiOutput response = this.commandGateway.execute(command, this.asString(expected));
+		Assert.assertTrue((Boolean) response.getSingleResult());
+		SampleCoreEntity actual = this.find(expected.getId(), SampleCoreEntity.class, "sample_core");
+		Assert.assertEquals(expected.getId(), actual.getId());
+		Assert.assertEquals(expected.get_tenantId(), actual.get_tenantId());
+		Assert.assertEquals(expected.getAttr_String(), actual.getAttr_String());
+	}
+
+	/**
+	 * _replace on domain entity having a different tenant id than what is
+	 * provided in the command url
+	 */
+	@Test
+	public void testReplaceUnallowed() {
+		SampleCoreEntity expected = insertSingleSampleCore(6L, 1L);
+		expected.setAttr_String("foo");
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._replace).getCommand();
+		thrown.expect(FrameworkRuntimeException.class);
+		thrown.expectMessage("Entity not found for /foo/2/app/p/sample_core:" + expected.getId());
+		this.commandGateway.execute(command, this.asString(expected));
+	}
+	
+	/**
+	 * _update on domain entity
+	 */
+	@Test
+	public void testUpdate() {
+		SampleCoreEntity expected = insertSingleSampleCore(7L, 2L);
+		expected.setAttr_String("foo");
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._update).getCommand();
+		MultiOutput response = this.commandGateway.execute(command, this.asString(expected));
+		Assert.assertTrue((Boolean) response.getSingleResult());
+		SampleCoreEntity actual = this.find(expected.getId(), SampleCoreEntity.class, "sample_core");
+		Assert.assertEquals(expected.getId(), actual.getId());
+		Assert.assertEquals(expected.get_tenantId(), actual.get_tenantId());
+		Assert.assertEquals(expected.getAttr_String(), actual.getAttr_String());
+	}
+
+	/**
+	 * _update on domain entity having a different tenant id than what is
+	 * provided in the command url
+	 */
+	@Test
+	public void testUpdateUnallowed() {
+		SampleCoreEntity expected = insertSingleSampleCore(8L, 1L);
+		expected.setAttr_String("foo");
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core:" + expected.getId()).setAction(Action._update).getCommand();
+		thrown.expect(FrameworkRuntimeException.class);
+		thrown.expectMessage("Entity not found for /foo/2/app/p/sample_core:" + expected.getId());
+		this.commandGateway.execute(command, this.asString(expected));
+	}
+
+	private SampleCoreEntity insertSingleSampleCore(Long id, Long tenantId) {
+		SampleCoreEntity expected = new SampleCoreEntity();
+		expected.setId(id);
+		expected.set_tenantId(tenantId);
+		return insert("sample_core", expected);
+	}
 }

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/MultitenantCommandExecutionTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/MultitenantCommandExecutionTests.java
@@ -1,0 +1,63 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@TestPropertySource(properties = { "nimbus.multitenancy.tenants.1.description=ABC",
+		"nimbus.multitenancy.tenants.1.prefix=/foo/1/app", "nimbus.multitenancy.tenants.2.description=DEF",
+		"nimbus.multitenancy.tenants.2.prefix=/foo/2/app", })
+public class MultitenantCommandExecutionTests extends AbstractFrameworkIntegrationTests {
+
+	@Autowired
+	private CommandExecutorGateway commandGateway;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	/**
+	 * _new on domain entity
+	 */
+	@Test
+	public void testCreate() {
+		SampleCoreEntity expected = new SampleCoreEntity();
+		expected.setId(1L);
+		Command command = CommandBuilder.withUri("/foo/2/app/p/sample_core").setAction(Action._new).getCommand();
+		MultiOutput response = this.commandGateway.execute(command, this.asString(expected));
+		SampleCoreEntity actual = ((Param<SampleCoreEntity>) response.getSingleResult()).getState();
+		Assert.assertEquals(expected.getId(), actual.getId());
+		Assert.assertEquals(Long.valueOf(2), actual.get_tenantId());
+	}
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/TenantFilterTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/multitenancy/TenantFilterTest.java
@@ -1,0 +1,125 @@
+
+package com.antheminc.oss.nimbus.domain.model.state.multitenancy;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashSet;
+
+import javax.servlet.http.Cookie;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
+import com.antheminc.oss.nimbus.domain.session.SessionProvider;
+import com.antheminc.oss.nimbus.entity.client.user.ClientUser;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+
+/**
+ * @author Sandeep Mantha
+ */
+@AutoConfigureMockMvc
+@TestPropertySource(properties = { 
+		"nimbus.multitenancy.enabled=true",
+		"nimbus.multitenancy.tenants.1.description=ABC",
+		"nimbus.multitenancy.tenants.1.prefix=/a/1/b",
+		"nimbus.multitenancy.tenants.2.description=DEF",
+		"nimbus.multitenancy.tenants.2.prefix=/a/2/b",
+})
+public class TenantFilterTest extends AbstractFrameworkIntegrationTests {
+
+	@Autowired
+	private SessionProvider sessionProvider;
+
+	protected static final String TENANT_1_PREFIX = "/a/1/b";
+	protected static final String TENANT_2_PREFIX = "/a/2/b";
+
+	protected static final String VIEW_PARAM_ROOT = TENANT_1_PREFIX + "/p/sample_view";
+
+	private MockMvc mvc;
+
+	@Autowired
+	private WebApplicationContext webApplicationContext;
+
+	@Autowired
+	private TenantFilter tenantFilter;
+
+	@Before
+	public void setUp() {
+		mvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).addFilters(this.tenantFilter).build();
+	}
+
+	@Test
+	public void testFilter() throws Exception {
+
+		ClientUser clientUser = new ClientUser();
+		clientUser.setTenantIds(new HashSet<>());
+		clientUser.getTenantIds().add(1L);
+		clientUser.getTenantIds().add(2L);
+		sessionProvider.setLoggedInUser(clientUser);
+		sessionProvider.setAttribute(Constants.ACTIVE_TENANT_COOKIE.code, TENANT_1_PREFIX);
+		MockHttpServletRequest req = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
+		ResultActions res = mvc.perform(post(req.getRequestURI()).content("{}")
+				.cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, TENANT_1_PREFIX)).with(csrf())
+				.contentType(APPLICATION_JSON_UTF8));
+
+		res.andExpect(status().isOk());
+
+		sessionProvider.setAttribute(Constants.ACTIVE_TENANT_COOKIE.code, TENANT_2_PREFIX);
+		MockHttpServletRequest req2 = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
+		try {
+			// cookie is different in the request
+			mvc.perform(post(req2.getRequestURI()).content("{}").with(csrf()).contentType(APPLICATION_JSON_UTF8)
+					.cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, TENANT_1_PREFIX)));
+		} catch (FrameworkRuntimeException e) {
+			assertEquals(e.getExecuteError().getMessage(),
+					"Request is not authorized as the tenant information is not valid. Please contact a system administrator.");
+		}
+
+		sessionProvider.setAttribute(Constants.ACTIVE_TENANT_COOKIE.code, TENANT_2_PREFIX);
+		MockHttpServletRequest req3 = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
+		try {
+			// prefix to /p (tenantprefix) is not valid with the session value
+			mvc.perform(post(req3.getRequestURI()).content("{}").with(csrf()).contentType(APPLICATION_JSON_UTF8)
+					.cookie(new Cookie(Constants.ACTIVE_TENANT_COOKIE.code, TENANT_2_PREFIX)));
+		} catch (FrameworkRuntimeException e) {
+			assertEquals(e.getExecuteError().getMessage(),
+					"Request is not authorized as the tenant information is not valid. Please contact a system administrator.");
+		}
+	}
+	
+	@Ignore
+	@Test(expected = FrameworkRuntimeException.class)
+	public void testMissingUser() {
+		Assert.fail("Implement me!");
+	}
+	
+	@Ignore
+	@Test
+	public void testMissingTenantCookie() {
+		Assert.fail("Implement me!");
+	}
+	
+	@Ignore
+	@Test
+	public void testTenantDoesNotExist() {
+		Assert.fail("Implement me!");
+	}
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/ModelRepositoryTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/ModelRepositoryTest.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
@@ -68,6 +69,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Swetha Vemuri
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestPropertySource(properties = { 
+		"nimbus.multitenancy.tenants.1.description=ABC",
+		"nimbus.multitenancy.tenants.1.prefix=/hooli/1/thebox",
+		"nimbus.multitenancy.tenants.2.description=DEF",
+		"nimbus.multitenancy.tenants.2.prefix=/piedpiper/1/encryption_3.9",
+})
 public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 
 	@Autowired
@@ -102,7 +109,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t1_testSearchByExample_Ext() {
-		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_search?fn=example";
+		final String requestUri = "piedpiper/1/encryption_3.9/p/ext_client/_search?fn=example";
 		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		final String jsonPayload = "{\"client\": {\"code\":\"example\"}}";
 		CommandMessage cmdMsg = new CommandMessage();
@@ -136,8 +143,8 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t2_testSearchByQuery_Ext() {
-		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_search?fn=query&where=ext_client.client.code.eq('7')";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/ext_client/_search?fn=query&where=ext_client.client.code.eq('7')";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -163,7 +170,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Ignore //TODO in DefaultWS
 	public void t2_testSearchByQuery_fetch1_Ext() {
 		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_search?fn=query&where=ext_client.client.code.eq('7')&fetch=1";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -185,8 +192,8 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t3_testGet_Ext() {
-		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_get";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/ext_client/_get";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -207,8 +214,8 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void testExternalGetWithRefId() {
-		final String requestUri = "piedpiper/encryption_3.9/p/ext_client:42/_get";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/ext_client:42/_get";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -229,8 +236,8 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 
 	@Test
 	public void t5_get_remote() throws JsonProcessingException {
-		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo:12/_get";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/remote_repo:12/_get";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -254,8 +261,8 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void t6_testSearchByQuery_remote() throws JsonProcessingException {
-		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_search?fn=query&where=remote_repo.attr1.eq('example1')";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/remote_repo/_search?fn=query&where=remote_repo.attr1.eq('example1')";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 //		Map<String, String[]> requestParams = new HashMap<>();
 //		requestParams.put("fn", new String[]{"query"});
 //		requestParams.put("where", new String[]{"remote_repo.attr1.eq('example1')"});
@@ -284,8 +291,8 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t7_testSearchByQuery_fetch1_remote() {
-		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_search?fn=query&where=remote_repo.attr1.eq('example1')&fetch=1";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/remote_repo/_search?fn=query&where=remote_repo.attr1.eq('example1')&fetch=1";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 //		Map<String, String[]> requestParams = new HashMap<>();
 //		requestParams.put("fn", new String[]{"query"});
 //		requestParams.put("where", new String[]{"remote_repo.attr1.eq('example1')"});
@@ -315,8 +322,8 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t8_testSearchByExample_remote() {
-		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_search?fn=example";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/remote_repo/_search?fn=example";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 //		Map<String, String[]> requestParams = new HashMap<>();
 //		requestParams.put("fn", new String[]{"example"});
 //		cmd.setRequestParams(requestParams);
@@ -344,17 +351,17 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t9_new_remote() throws JsonProcessingException {
-		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_new?b=$executeAnd$state";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/remote_repo/_new?b=$executeAnd$state";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
-		final String remoteRequestUri = "piedpiper/encryption_3.9/p/remote_repo/_new";
+		final String remoteRequestUri = "piedpiper/1/encryption_3.9/p/remote_repo/_new";
 		String jsonresp  = mockSingleGenericExecuteResponse_GetNewSearch();
 		this.mockServerRemoteWs.expect(requestTo(new StringContains(remoteRequestUri)))
 			.andRespond(withSuccess(jsonresp, MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(),requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:1/_update")))
+		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(),requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:1/_update")))
 		.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 	
 		MultiOutput multiOp = this.commandGateway.execute(cmdMsg);
@@ -373,20 +380,20 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t10_delete_root_remote() throws JsonProcessingException {
 		t5_get_remote();
-		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo:12/_delete";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/remote_repo:12/_delete";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
 		
 		String jsonresp  = mockSingleGenericExecuteResponse_GetNewSearch();
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:12/_get")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:12/_get")))
 			.andRespond(withSuccess(jsonresp, MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:12/_update")))
+		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:12/_update")))
 		.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:12/_delete")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:12/_delete")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 		
 		MultiOutput multiOp = this.commandGateway.execute(cmdMsg);
@@ -401,20 +408,20 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t12_delete_nested_remote() throws JsonProcessingException {
-		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo:12/attr2/0/_delete";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		final String requestUri = "piedpiper/1/encryption_3.9/p/remote_repo:12/attr2/0/_delete";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
 		
 		String jsonresp  = mockSingleGenericExecuteResponse_GetNewSearch();
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:12/_get")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:12/_get")))
 			.andRespond(withSuccess(jsonresp, MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:12/_update")))
+		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:12/_update")))
 		.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:12/_update")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:12/_update")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 		
 		MultiOutput multiOp = this.commandGateway.execute(cmdMsg);
@@ -429,17 +436,17 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	
 	@Test
 	public void t13_remote_withExecConfigs_mapped() throws JsonProcessingException {
-		String requestUri = "piedpiper/encryption_3.9/p/vr_remote_repo/_new";
-		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
+		String requestUri = "piedpiper/1/encryption_3.9/p/vr_remote_repo/_new";
+		Command cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
-		final String remoteRequestUri = "piedpiper/encryption_3.9/p/remote_repo/_new";
+		final String remoteRequestUri = "piedpiper/1/encryption_3.9/p/remote_repo/_new";
 		String jsonresp  = mockSingleGenericExecuteResponse_GetNewSearch();
 		this.mockServerRemoteWs.expect(requestTo(new StringContains(remoteRequestUri)))
 			.andRespond(withSuccess(jsonresp, MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(),requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:1/_update")))
+		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(),requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:1/_update")))
 		.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 	
 		MultiOutput multiOp = this.commandGateway.execute(cmdMsg);
@@ -454,33 +461,33 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 		
 		this.mockServerRemoteWs.reset();
 		
-		requestUri = "piedpiper/encryption_3.9/p/vr_remote_repo:1/vr_attr2/_get";
-		cmd = CommandBuilder.withUri(requestUri).getCommand();
+		requestUri = "piedpiper/1/encryption_3.9/p/vr_remote_repo:1/vr_attr2/_get";
+		cmd = CommandBuilder.withUri((requestUri)).getCommand();
 		cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
-		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo:1/_update")))
+		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo:1/_update")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/vr_remote_repo2/_new")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/vr_remote_repo2/_new")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_GetNewSearch2(), MediaType.APPLICATION_JSON));
 
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo2/_new")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo2/_new")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_GetNewSearch2(), MediaType.APPLICATION_JSON));
 	
-		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo2:1/_update")))
+		this.mockServerRemoteWs.expect(ExpectedCount.manyTimes(), requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo2:1/_update")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/vr_remote_repo2:1/_get")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/vr_remote_repo2:1/_get")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_GetNewSearch2(), MediaType.APPLICATION_JSON));
 		
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo2:1/_get")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo2:1/_get")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_GetNewSearch2(), MediaType.APPLICATION_JSON));
 	
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/vr_remote_repo2:1/_delete")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/vr_remote_repo2:1/_delete")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 
-		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/encryption_3.9/p/remote_repo2:1/_delete")))
+		this.mockServerRemoteWs.expect(requestTo(new StringContains("piedpiper/1/encryption_3.9/p/remote_repo2:1/_delete")))
 			.andRespond(withSuccess(mockSingleGenericExecuteResponse_update(), MediaType.APPLICATION_JSON));
 
 		multiOp = this.commandGateway.execute(cmdMsg);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/ModelRepositoryTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/ModelRepositoryTest.java
@@ -43,6 +43,7 @@ import org.springframework.web.client.RestTemplate;
 
 import com.antheminc.oss.nimbus.domain.cmd.Behavior;
 import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
@@ -54,7 +55,6 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.ExecuteOutput.CmdExecuteOutput.H
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecuteOutput.GenericExecute;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.entity.client.ExtClient;
-import com.antheminc.oss.nimbus.support.CommandUtils;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
 import com.antheminc.oss.nimbus.test.scenarios.repo.remote.core.SampleRemoteRepo;
 import com.antheminc.oss.nimbus.test.scenarios.repo.remote.core.SampleRemoteRepo.SampleRepoNested;
@@ -103,7 +103,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t1_testSearchByExample_Ext() {
 		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_search?fn=example";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		final String jsonPayload = "{\"client\": {\"code\":\"example\"}}";
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
@@ -137,7 +137,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t2_testSearchByQuery_Ext() {
 		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_search?fn=query&where=ext_client.client.code.eq('7')";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -163,7 +163,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Ignore //TODO in DefaultWS
 	public void t2_testSearchByQuery_fetch1_Ext() {
 		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_search?fn=query&where=ext_client.client.code.eq('7')&fetch=1";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -186,7 +186,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t3_testGet_Ext() {
 		final String requestUri = "piedpiper/encryption_3.9/p/ext_client/_get";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -208,7 +208,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void testExternalGetWithRefId() {
 		final String requestUri = "piedpiper/encryption_3.9/p/ext_client:42/_get";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -230,7 +230,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t5_get_remote() throws JsonProcessingException {
 		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo:12/_get";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -255,7 +255,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t6_testSearchByQuery_remote() throws JsonProcessingException {
 		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_search?fn=query&where=remote_repo.attr1.eq('example1')";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 //		Map<String, String[]> requestParams = new HashMap<>();
 //		requestParams.put("fn", new String[]{"query"});
 //		requestParams.put("where", new String[]{"remote_repo.attr1.eq('example1')"});
@@ -285,7 +285,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t7_testSearchByQuery_fetch1_remote() {
 		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_search?fn=query&where=remote_repo.attr1.eq('example1')&fetch=1";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 //		Map<String, String[]> requestParams = new HashMap<>();
 //		requestParams.put("fn", new String[]{"query"});
 //		requestParams.put("where", new String[]{"remote_repo.attr1.eq('example1')"});
@@ -316,7 +316,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t8_testSearchByExample_remote() {
 		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_search?fn=example";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 //		Map<String, String[]> requestParams = new HashMap<>();
 //		requestParams.put("fn", new String[]{"example"});
 //		cmd.setRequestParams(requestParams);
@@ -345,7 +345,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t9_new_remote() throws JsonProcessingException {
 		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo/_new?b=$executeAnd$state";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -374,7 +374,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	public void t10_delete_root_remote() throws JsonProcessingException {
 		t5_get_remote();
 		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo:12/_delete";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -402,7 +402,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t12_delete_nested_remote() throws JsonProcessingException {
 		final String requestUri = "piedpiper/encryption_3.9/p/remote_repo:12/attr2/0/_delete";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -430,7 +430,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 	@Test
 	public void t13_remote_withExecConfigs_mapped() throws JsonProcessingException {
 		String requestUri = "piedpiper/encryption_3.9/p/vr_remote_repo/_new";
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		CommandMessage cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		
@@ -455,7 +455,7 @@ public class ModelRepositoryTest extends AbstractFrameworkIntegrationTests {
 		this.mockServerRemoteWs.reset();
 		
 		requestUri = "piedpiper/encryption_3.9/p/vr_remote_repo:1/vr_attr2/_get";
-		cmd = CommandUtils.prepareCommand(requestUri);
+		cmd = CommandBuilder.withUri(requestUri).getCommand();
 		cmdMsg = new CommandMessage();
 		cmdMsg.setCommand(cmd);
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListenerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListenerTest.java
@@ -50,7 +50,7 @@ public class ParamStateAtomicPersistenceEventListenerTest extends AbstractFramew
 
 	@Test
 	public void testDomainRepoAliasMismatchPersistence() throws JsonProcessingException {
-		final String requestUri = "app/org/p/sample_repo_diff_alias/_new";
+		final String requestUri = PLATFORM_ROOT + "/sample_repo_diff_alias/_new";
 		final String expectedCollectionName = "person_of_interest";
 		SampleRepoDifferentAlias expected = new SampleRepoDifferentAlias("Oscar", "Grouch");
 

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListenerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListenerTest.java
@@ -23,9 +23,9 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
-import com.antheminc.oss.nimbus.support.CommandUtils;
 import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkIntegrationTests;
 import com.antheminc.oss.nimbus.test.scenarios.repo.core.SampleRepoDifferentAlias;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -54,7 +54,7 @@ public class ParamStateAtomicPersistenceEventListenerTest extends AbstractFramew
 		final String expectedCollectionName = "person_of_interest";
 		SampleRepoDifferentAlias expected = new SampleRepoDifferentAlias("Oscar", "Grouch");
 
-		Command cmd = CommandUtils.prepareCommand(requestUri);
+		Command cmd = CommandBuilder.withUri(requestUri).getCommand();
 		final String jsonPayload = this.om.writeValueAsString(expected);
 		CommandMessage cmdMsg = new CommandMessage(cmd, jsonPayload);
 		this.commandGateway.execute(cmdMsg);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/chart/SampleChartDataSetTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/chart/SampleChartDataSetTest.java
@@ -104,7 +104,9 @@ public class SampleChartDataSetTest  extends AbstractFrameworkIntegrationTests {
 		mongo.dropCollection("samplechartaggregateview");
 		
 		DataGroup dg1 = new DataGroup();
+		dg1.set_tenantId(TENANT_ID);
 		DataGroup dg2 = new DataGroup();
+		dg2.set_tenantId(TENANT_ID);
 		dg1.setLegend("_search");
 		dg2.setLegend("_new");
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
@@ -325,6 +325,7 @@ public class CrossDomainPathResolverTest extends AbstractStateEventHandlerTests 
 		Long id = new Random().nextLong();
 		SampleCoreEntity sample_core = new SampleCoreEntity();
 		sample_core.setId(id);
+		sample_core.set_tenantId(TENANT_ID);
 		sample_core.setAttr_String("orange");
 		mongo.insert(sample_core, "sample_core");
 		
@@ -350,6 +351,7 @@ public class CrossDomainPathResolverTest extends AbstractStateEventHandlerTests 
 		Long id = new Random().nextLong();
 		SampleCoreEntity sample_core = new SampleCoreEntity();
 		sample_core.setId(id);
+		sample_core.set_tenantId(TENANT_ID);
 		sample_core.setAttr_String("orange");
 		mongo.insert(sample_core, "sample_core");
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/crossdomainresolver/CrossDomainPathResolverTest.java
@@ -51,11 +51,11 @@ import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CrossDomainPathResolverTest extends AbstractStateEventHandlerTests {
 	
-	private final static String ENG_LANG = "English";
-	private final static String FRENCH_LANG = "French";
-	private final static String SAMPLE_VIEW_ROOT = "sample_crossdomain_pathresolver";
+	private static final String ENG_LANG = "English";
+	private static final String FRENCH_LANG = "French";
+	private static final String SAMPLE_VIEW_ROOT = "sample_crossdomain_pathresolver";
 	protected static final String SAMPLE_VIEW_PARAM_ROOT = PLATFORM_ROOT + "/" + SAMPLE_VIEW_ROOT;
-	private final static String SAMPLE_VIEW_MULTI_ROOT = "sample_multi_domain";
+	private static final String SAMPLE_VIEW_MULTI_ROOT = "sample_multi_domain";
 	protected static final String SAMPLE_VIEW_MULTI_PARAM_ROOT = PLATFORM_ROOT + "/" + SAMPLE_VIEW_MULTI_ROOT;
 	
 	@Autowired
@@ -63,8 +63,7 @@ public class CrossDomainPathResolverTest extends AbstractStateEventHandlerTests 
 	
 	@Override
 	protected Command createCommand() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/sample_crossdomain_pathresolver/_new").getCommand();
-		return cmd;
+		return CommandBuilder.withUri(PLATFORM_ROOT + "/sample_crossdomain_pathresolver/_new").getCommand();
 	}
 	
 	private MockHttpServletRequest createRequest(String domainPath, Action a) {

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/multidb/MultipleMongoDBTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/multidb/MultipleMongoDBTest.java
@@ -33,6 +33,7 @@ import com.antheminc.oss.nimbus.domain.cmd.Command;
 import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContextLoader;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
+import com.antheminc.oss.nimbus.test.domain.support.AbstractFrameworkTest;
 import com.antheminc.oss.nimbus.test.scenarios.multidb.core.SampleMultiDbDefaultEntity;
 import com.antheminc.oss.nimbus.test.scenarios.multidb.core.SampleMultiDbDomainPrimary;
 import com.antheminc.oss.nimbus.test.scenarios.multidb.core.SampleMultiDbDomainSecondary;
@@ -44,11 +45,11 @@ import com.antheminc.oss.nimbus.test.scenarios.multidb.core.SampleMultiDbDomainS
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = MultipleMongoDBTestApplication.class)
 @ActiveProfiles("test-multi-db")
-public class MultipleMongoDBTest {
+public class MultipleMongoDBTest extends AbstractFrameworkTest {
 
-	public final static String PRIMARY_ALIAS = "sample_multidb_primary";
-	public final static String SECONDARY_ALIAS = "sample_multidb_secondary";
-	public final static String DEFAULT_ALIAS = "sample_multidb_default";
+	public static final String PRIMARY_ALIAS = "sample_multidb_primary";
+	public static final String SECONDARY_ALIAS = "sample_multidb_secondary";
+	public static final String DEFAULT_ALIAS = "sample_multidb_default";
 
 	protected QuadModel<?, SampleMultiDbDomainPrimary> _qPrimary;
 	protected QuadModel<?, SampleMultiDbDomainSecondary> _qSecondary;
@@ -68,13 +69,13 @@ public class MultipleMongoDBTest {
 	@SuppressWarnings("unchecked")
 	@Before
 	public void init() {
-		Command cmd = CommandBuilder.withUri("/hooli/thebox/p/" + PRIMARY_ALIAS + "/_new").getCommand();
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/" + PRIMARY_ALIAS + "/_new").getCommand();
 		_qPrimary = (QuadModel<?, SampleMultiDbDomainPrimary>) executionContextLoader.load(cmd).getQuadModel();
 
-		cmd = CommandBuilder.withUri("/hooli/thebox/p/" + SECONDARY_ALIAS + "/_new").getCommand();
+		cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/" + SECONDARY_ALIAS + "/_new").getCommand();
 		_qSecondary = (QuadModel<?, SampleMultiDbDomainSecondary>) executionContextLoader.load(cmd).getQuadModel();
 
-		cmd = CommandBuilder.withUri("/hooli/thebox/p/" + DEFAULT_ALIAS + "/_new").getCommand();
+		cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/" + DEFAULT_ALIAS + "/_new").getCommand();
 		_qDefault = (QuadModel<?, SampleMultiDbDefaultEntity>) executionContextLoader.load(cmd).getQuadModel();
 	}
 

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s4/S4_MappedTransientTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s4/S4_MappedTransientTest.java
@@ -230,6 +230,7 @@ public class S4_MappedTransientTest extends AbstractFrameworkIntegrationTests {
 		
 		S4C_CoreMain core = new S4C_CoreMain();
 		core.setId(K_DB_REFID);
+		core.set_tenantId(TENANT_ID);
 		core.setAnotherModeList(Arrays.asList(formEntity));
 		
 		// save: call

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s7/ParamValuesContextPathResolverTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s7/ParamValuesContextPathResolverTest.java
@@ -18,11 +18,8 @@ package com.antheminc.oss.nimbus.test.scenarios.s7;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 
 import org.junit.FixMethodOrder;
 import org.junit.Ignore;

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s7/ParamValuesContextPathResolverTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/s7/ParamValuesContextPathResolverTest.java
@@ -58,6 +58,7 @@ public class ParamValuesContextPathResolverTest extends AbstractFrameworkIntegra
 	public void t00_paramvalues_static_context_resolve() {
 		S7C_CoreMain s7c_main_1 = new S7C_CoreMain();
 		s7c_main_1.setId(CORE_REF_ID_1);
+		s7c_main_1.set_tenantId(TENANT_ID);
 		s7c_main_1.setAttr1_clone("test_0");
 		mongo.insert(s7c_main_1, "s7c_main");
 		
@@ -83,6 +84,7 @@ public class ParamValuesContextPathResolverTest extends AbstractFrameworkIntegra
 	public void t01_paramvalues_dynamic_context_resolve_conditional() {
 		S7C_CoreMain s7c_main_1 = new S7C_CoreMain();
 		s7c_main_1.setId(CORE_REF_ID_2);
+		s7c_main_1.set_tenantId(TENANT_ID);
 		s7c_main_1.setAttr1_clone("test_1");
 		mongo.insert(s7c_main_1, "s7c_main");
 		
@@ -108,6 +110,7 @@ public class ParamValuesContextPathResolverTest extends AbstractFrameworkIntegra
 	public void t02_paramvalues_dynamic_context_resolve_get() {
 		S7C_CoreMain s7c_main_1 = new S7C_CoreMain();
 		s7c_main_1.setId(CORE_REF_ID_3);
+		s7c_main_1.set_tenantId(TENANT_ID);
 		s7c_main_1.setAttr1_clone("test_2");
 		mongo.insert(s7c_main_1, "s7c_main");
 		
@@ -132,6 +135,7 @@ public class ParamValuesContextPathResolverTest extends AbstractFrameworkIntegra
 	public void t03_paramvalues_static_new() {
 		S7C_CoreStatic coreStatic = new S7C_CoreStatic();
 		coreStatic.setId(new Random().nextLong());
+		coreStatic.set_tenantId(TENANT_ID);
 		coreStatic.setStaticAttr("test_01");
 		mongo.insert(coreStatic, "s7c_corestatic");
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/setbyrule/SetByRuleDecisionTableTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/setbyrule/SetByRuleDecisionTableTests.java
@@ -98,7 +98,7 @@ public class SetByRuleDecisionTableTests extends AbstractFrameworkIngerationPers
 		Param<String> attr3 = ExtractResponseOutputUtils.extractOutput(holder);
 		assertEquals("InProgress",attr3.getLeafState());
 		
-		MockHttpServletRequest get_req4 = MockHttpRequestBuilder.withUri("/hooli/thebox/p/"+ASSOCIATED_PARAM_CORE + ":"+ASSOCIATED_PARAM_ID+"/triggeredParameter")
+		MockHttpServletRequest get_req4 = MockHttpRequestBuilder.withUri(PLATFORM_ROOT + "/"+ASSOCIATED_PARAM_CORE + ":"+ASSOCIATED_PARAM_ID+"/triggeredParameter")
 				.addAction(Action._get)
 				.getMock();
 		holder = (Holder<MultiOutput>)controller.handleGet(get_req4, null);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/setbyrule/SetByRuleDecisionTableTests.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/test/scenarios/setbyrule/SetByRuleDecisionTableTests.java
@@ -53,6 +53,7 @@ public class SetByRuleDecisionTableTests extends AbstractFrameworkIngerationPers
 	public void setup() {		
 		final DecisionTableTestCoreModel core = new DecisionTableTestCoreModel();
 		core.setId(new Random().nextLong());
+		core.set_tenantId(TENANT_ID);
 		core.setStateCheckParameter("Complete");
 		mongo.insert(core, ASSOCIATED_PARAM_CORE);
 		ASSOCIATED_PARAM_ID = core.getId();
@@ -67,6 +68,7 @@ public class SetByRuleDecisionTableTests extends AbstractFrameworkIngerationPers
 		
 		final SampleSetByRuleCore core = new SampleSetByRuleCore();
 		core.setId(new Random().nextLong());
+		core.set_tenantId(TENANT_ID);
 		core.setAssociatedParamId(ASSOCIATED_PARAM_ID);
 		mongo.insert(core, ENTITY_CORE_ALIAS);
 		REF_ID = core.getId();

--- a/nimbus-test/src/test/resources/application-test-multi-db.yml
+++ b/nimbus-test/src/test/resources/application-test-multi-db.yml
@@ -29,6 +29,12 @@ nimbus:
       # host: localhost
       # port: 12345
       database: secondary
+      
+  multitenancy: 
+    tenants:
+      1: 
+        description: DEFAULT
+        prefix: /hooli/thebox
 
 ruleBasedRequestHandler:
                      - defaultRuleBasedRequestHandler

--- a/nimbus-test/src/test/resources/application-test.yml
+++ b/nimbus-test/src/test/resources/application-test.yml
@@ -157,3 +157,10 @@ search:
     inMemory:
       sortThreshold: 100
       exceptionIfOverSortThreshold: true   
+      
+nimbus:
+  multitenancy: 
+    tenants:
+      1: 
+        description: DEFAULT
+        prefix: /hooli/1/thebox

--- a/nimbus-ui/nimbusui/src/app/app.module.ts
+++ b/nimbus-ui/nimbusui/src/app/app.module.ts
@@ -191,6 +191,7 @@ import { WindowRefService } from './services/window-ref.service';
 import { CustomErrorHandler } from './shared/custom.error.handler';
 import { GridUtils } from './shared/grid-utils';
 import { StyleGuideCmp } from './styleguide/style-guide.component';
+import { CookieService } from './services/cookie.service';
 
 /**
  * \@author Dinakar.Meda
@@ -395,7 +396,8 @@ export function init_app(appinitservice: AppInitService) {
     MessageService,
     GridUtils,
     DateTimeFormatPipe,
-    PrintService
+    PrintService,
+    CookieService
   ],
   bootstrap: [AppComponent]
 })

--- a/nimbus-ui/nimbusui/src/app/services/app.init.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/app.init.service.ts
@@ -56,7 +56,7 @@ export class AppInitService {
     /*Initially populate the APP_COMMAND_URL with a default value - 
         which may be overwritten with the clientprovided command url in the landing page */
     if (ServiceConstants.APP_COMMAND_URL === undefined) {
-      ServiceConstants.APP_COMMAND_URL = '/client/org/app';
+      ServiceConstants.APP_COMMAND_URL = '/client/1/app';
     }
 
     const docObj = {

--- a/nimbus-ui/nimbusui/src/app/services/app.init.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/app.init.service.ts
@@ -22,6 +22,7 @@ import { Headers, Http, RequestOptions } from '@angular/http';
 import { DOCUMENT } from '@angular/platform-browser';
 import { timeout } from 'rxjs/operators';
 import { ServiceConstants } from './service.constants';
+import { CookieService } from './cookie.service';
 /**
  * \@author Sandeep.Mantha
  * \@whatItDoes
@@ -35,7 +36,7 @@ export class AppInitService {
   options: RequestOptions;
   logOptions: any;
 
-  constructor(@Inject(DOCUMENT) private document: any, private http: Http) {
+  constructor(@Inject(DOCUMENT) private document: any, private http: Http, private cookieService: CookieService) {
     this.headers = new Headers({ 'Content-Type': 'application/json' });
     this.options = new RequestOptions({
       headers: this.headers,
@@ -53,10 +54,9 @@ export class AppInitService {
       .splice(1, 1);
     ServiceConstants.LOCALE_LANGUAGE = 'en-US'; //TODO This locale should be read dynamically. Currently defaulting to en-US
     ServiceConstants.APP_PROTOCOL = this.document.location.protocol;
-    /*Initially populate the APP_COMMAND_URL with a default value - 
-        which may be overwritten with the clientprovided command url in the landing page */
+    ServiceConstants.APP_COMMAND_URL = this.cookieService.getCookieValue(ServiceConstants.TENANT_PREFIX_COOKIE);
     if (ServiceConstants.APP_COMMAND_URL === undefined) {
-      ServiceConstants.APP_COMMAND_URL = '/client/1/app';
+      throw new Error('Command URL tenant prefix was undefined. Please check configurations ensure the tenant settings have been set.');
     }
 
     const docObj = {

--- a/nimbus-ui/nimbusui/src/app/services/cookie.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/cookie.service.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2016-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import { Injectable } from '@angular/core';
+
+/**
+ * \@author Tony Lopez
+ * \@whatItDoes
+ *
+ * \@howToUse
+ *
+ */
+@Injectable()
+export class CookieService {
+
+  getCookieValue(name): string {
+    let value = '; ' + document.cookie;
+    let parts = value.split('; ' + name + '=');
+
+    if (parts.length === 2) {
+      return parts
+        .pop()
+        .split(';')
+        .shift();
+    }
+  }
+}

--- a/nimbus-ui/nimbusui/src/app/services/httpclient.service.ts
+++ b/nimbus-ui/nimbusui/src/app/services/httpclient.service.ts
@@ -25,6 +25,7 @@ import { catchError } from 'rxjs/operators';
 import { ExecuteResponse } from '../shared/app-config.interface';
 import { ServiceConstants } from './service.constants';
 import { SessionStoreService } from './session.store';
+import { CookieService } from './cookie.service';
 
 /**
  * \@author Swetha.Vemuri
@@ -47,7 +48,8 @@ export class CustomHttpClient {
   constructor(
     public http: HttpClient,
     public customHttpClient: HttpClient,
-    private sessionStore: SessionStoreService
+    private sessionStore: SessionStoreService,
+    private cookieService: CookieService
   ) {
     this.http = http;
   }
@@ -87,15 +89,7 @@ export class CustomHttpClient {
   }
 
   getCookie(name) {
-    let value = '; ' + document.cookie;
-    let parts = value.split('; ' + name + '=');
-
-    if (parts.length === 2) {
-      return parts
-        .pop()
-        .split(';')
-        .shift();
-    }
+    return this.cookieService.getCookieValue(name);
   }
 
   errorHandler(error: Response) {

--- a/nimbus-ui/nimbusui/src/app/services/service.constants.ts
+++ b/nimbus-ui/nimbusui/src/app/services/service.constants.ts
@@ -221,7 +221,11 @@ export class ServiceConstants {
   } // this should come from the node server
   public static get LANDING_ROUTE(): string {
     return 'authlanding';
-  } // this should come from the node server and set in app.init.service
+  }
+  public static get TENANT_PREFIX_COOKIE(): string {
+    return 'NIMBUS_ACTIVE_TENANT_PREFIX';
+  }
+  // this should come from the node server and set in app.init.service
 
   // public static get LOG_APPENDER_OPTIONS() : any {
   //     var obj;


### PR DESCRIPTION
# Description

Implements [NIMBUS-62](https://anthemopensource.atlassian.net/browse/NIMBUS-62), [NIMBUS-48](https://anthemopensource.atlassian.net/browse/NIMBUS-48), [NIMBUS-195](https://anthemopensource.atlassian.net/browse/NIMBUS-195)

* Adds multitenancy support
  * See `MultitenancyProperties` for configuration details.
  * Introduced `TenantRepository` for retrieving tenant details.
  * Added `_tenantId` to `AbstractEntity` for storing tenant id information.
* Record level multitenancy support has been added for Mongo
  * On `_new` calls, the id of a `Tenant` identified from the _input command url_ is stored under the domain entity's `_tenantId` field.
  * Data retrieval only returns data that has the tenant id send in the command.
* TenantFilter
  * Introduced `TenantFilter` to assist in authentication for a `ClientUser` permissions for a `Tenant`
* UI Changes
  * `"NIMBUS_ACTIVE_TENANT_PREFIX"` must be set as a session cookie and session attribute (e.g. `"/client/1/app"`)

# Breaking Changes
* If record level tenancy is used (it is by default), existing domain entities must have the `_tenantId` field set to a valid tenant, otherwise the data will not come back from the Mongo layer. Client applications can simply execute a script which update your database entries, correspondingly.
* Authentication: `"NIMBUS_ACTIVE_TENANT_PREFIX"` must be set as a session cookie and session attribute (e.g. `"/client/1/app"`) upon successful login.

# Additional Notes
Sample `application.yml` configuration can be seen here:
```yml
nimbus:
  multitenancy: 
    tenants:
      1:
        description: ABC
        prefix: /foo/1/app
      2:
        description: DEF
        prefix: /foo/2/app
```

# Type of Change

- [ ] New feature