### PR TITLE
combobox req icon missing on load

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/combobox.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/combobox.component.ts
@@ -88,5 +88,6 @@ export class ComboBox extends BaseControl<String> {
       }
       this.cb.selectedOptionUpdated = true;
     }
+    super.ngOnInit();
   }
 }


### PR DESCRIPTION
# Description
ComboBox is missing a required icon because the class has a new ngOnInit() method added recently


# Overview of Changes
called the super.ngOnInit()

# Type of Change
- [ ] Bug fix

