### PR TITLE
NIMBUS-228: combobox/lookup search fh fix

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
@@ -138,7 +138,7 @@ public class DefaultSearchFunctionHandlerLookup<T, R> extends DefaultSearchFunct
 				Object code = this.expressionEvaluator.getValue(cd, model);
 				Object label = this.expressionEvaluator.getValue(lb, model);
 				if(code!= null && label !=null) {
-					paramValues.add(new ParamValue(code.toString(), label.toString()));
+					paramValues.add(new ParamValue(code, label.toString()));
 				}
 			}
 			return sortIfApplicable(paramValues, mConfig, cmd);

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
@@ -116,6 +116,10 @@ public class VPSampleViewPageGreen {
 		@Values(url = "a/b/p/sampletask/_search?fn=lookup&orderby=sampletask.taskName.asc()&projection.mapsTo=code:id,label:taskName")
 		private List<String> sortedDynamicValues;
 		
+		@ComboBox
+		@Values(url = "a/b/p/sampletask/_search?fn=lookup&projection.mapsTo=code:taskName,label:taskName")
+		private String comboboxWithStringId;
+		
 		@TextBox(postEventOnChange = true)
 		@Path
 		@ActivateConditional(when = "state == 'showit'", targetPath = "/../unmappedNested")

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearchHttpTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorSearchHttpTest.java
@@ -440,15 +440,30 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 	}
 	
 	@Test
+	public void testLookupParamValueWithStringCode() {
+		List<SampleTask> expected = this.insertSampleTaskData();
+		Param<List<String>> actual = this.testLookupParamValueType("/page_green/tile/view_sample_form/comboboxWithStringId", "comboboxWithStringId");
+		Assert.assertEquals(2, actual.getValues().size());
+		Assert.assertEquals(expected.get(0).getTaskName(), actual.getValues().get(0).getCode());
+		Assert.assertEquals(expected.get(0).getTaskName(), actual.getValues().get(0).getLabel());
+		Assert.assertEquals(expected.get(1).getTaskName(), actual.getValues().get(1).getCode());
+		Assert.assertEquals(expected.get(1).getTaskName(), actual.getValues().get(1).getLabel());
+	}
+	
+	@Test
+	public void testLookupParamValueWithLongCode() {
+		List<SampleTask> expected = this.insertSampleTaskData();
+		Param<List<String>> actual = this.testLookupParamValueType("/page_green/tile/view_sample_form/unsortedDynamicValues", "unsortedDynamicValues");
+		Assert.assertEquals(2, actual.getValues().size());
+		Assert.assertEquals(expected.get(0).getId(), actual.getValues().get(0).getCode());
+		Assert.assertEquals(expected.get(0).getTaskName(), actual.getValues().get(0).getLabel());
+		Assert.assertEquals(expected.get(1).getId(), actual.getValues().get(1).getCode());
+		Assert.assertEquals(expected.get(1).getTaskName(), actual.getValues().get(1).getLabel());
+	}
+	
+	@Test
 	public void testLookupSort() {
-		SampleTask task1 = new SampleTask();
-		task1.setId(1L);
-		task1.setTaskName("Play");
-		SampleTask task2 = new SampleTask();
-		task2.setId(2L);
-		task2.setTaskName("Groom");
-		mongo.insert(task1, "sampletask");
-		mongo.insert(task2, "sampletask");
+		this.insertSampleTaskData();
 		
 		Long refId = createOrGetDomainRoot_RefId();
 		
@@ -461,9 +476,9 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		final Object unsortedResponse = controller.handlePost(unsortedRequest, null);
 		Param<List<String>> pUnsorted = ParamUtils.extractResponseByParamPath(unsortedResponse, "/unsortedDynamicValues");
 		Assert.assertEquals(2, pUnsorted.getValues().size());
-		Assert.assertEquals("1", pUnsorted.getValues().get(0).getCode());
+		Assert.assertEquals(1L, pUnsorted.getValues().get(0).getCode());
 		Assert.assertEquals("Play", pUnsorted.getValues().get(0).getLabel());
-		Assert.assertEquals("2", pUnsorted.getValues().get(1).getCode());
+		Assert.assertEquals(2L, pUnsorted.getValues().get(1).getCode());
 		Assert.assertEquals("Groom", pUnsorted.getValues().get(1).getLabel());
 		
 		final MockHttpServletRequest sortedRequest = MockHttpRequestBuilder
@@ -475,10 +490,35 @@ public class DefaultActionExecutorSearchHttpTest extends AbstractFrameworkIngera
 		final Object sortedResponse = controller.handlePost(sortedRequest, null);
 		Param<List<String>> pSorted = ParamUtils.extractResponseByParamPath(sortedResponse, "/sortedDynamicValues");
 		Assert.assertEquals(2, pSorted.getValues().size());
-		Assert.assertEquals("2", pSorted.getValues().get(0).getCode());
+		Assert.assertEquals(2L, pSorted.getValues().get(0).getCode());
 		Assert.assertEquals("Groom", pSorted.getValues().get(0).getLabel());
-		Assert.assertEquals("1", pSorted.getValues().get(1).getCode());
+		Assert.assertEquals(1L, pSorted.getValues().get(1).getCode());
 		Assert.assertEquals("Play", pSorted.getValues().get(1).getLabel());
+	}
+	
+	private Param<List<String>> testLookupParamValueType(String pathToCombobox, String fieldName) {
+		Long refId = createOrGetDomainRoot_RefId();
+		
+		final MockHttpServletRequest unsortedRequest = MockHttpRequestBuilder
+				.withUri(VIEW_PARAM_ROOT)
+				.addRefId(refId)
+				.addNested(pathToCombobox)
+				.addAction(Action._get)
+				.getMock();
+		Object response = controller.handlePost(unsortedRequest, null);
+		return ParamUtils.extractResponseByParamPath(response, "/" + fieldName);
+	}
+	
+	private List<SampleTask> insertSampleTaskData() {
+		SampleTask task1 = new SampleTask();
+		task1.setId(1L);
+		task1.setTaskName("Play");
+		SampleTask task2 = new SampleTask();
+		task2.setId(2L);
+		task2.setTaskName("Groom");
+		mongo.insert(task1, "sampletask");
+		mongo.insert(task2, "sampletask");
+		return Arrays.asList(task1, task2);
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/combobox.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/combobox.component.ts
@@ -79,15 +79,4 @@ export class ComboBox extends BaseControl<String> {
   ) {
     super(controlService, cd, cms);
   }
-
-  ngOnInit() {
-    this.cb.updateSelectedOption = (val: any): void =>{
-      this.cb.selectedOption = this.cb.findOption(val, this.cb.optionsToDisplay);
-      if (this.cb.autoDisplayFirst && !this.placeholder && !this.cb.selectedOption && this.cb.optionsToDisplay && this.cb.optionsToDisplay.length && !this.cb.editable) {
-          this.cb.selectedOption = this.cb.optionsToDisplay[0];
-      }
-      this.cb.selectedOptionUpdated = true;
-    }
-    super.ngOnInit();
-  }
 }

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/combobox.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/combobox.component.ts
@@ -82,7 +82,7 @@ export class ComboBox extends BaseControl<String> {
 
   ngOnInit() {
     this.cb.updateSelectedOption = (val: any): void =>{
-      this.cb.selectedOption = this.cb.findOption(val?val.toString():val, this.cb.optionsToDisplay);
+      this.cb.selectedOption = this.cb.findOption(val, this.cb.optionsToDisplay);
       if (this.cb.autoDisplayFirst && !this.placeholder && !this.cb.selectedOption && this.cb.optionsToDisplay && this.cb.optionsToDisplay.length && !this.cb.editable) {
           this.cb.selectedOption = this.cb.optionsToDisplay[0];
       }


### PR DESCRIPTION
# Description
Fixes #515 

Fixes an issue where `@ComboBox` was not retaining the value and the Search by Lookup function handler was assuming `code` needed to be treated as `String`.

# Type of Change
<!-- Please include the options below which are relevant. -->
<!--
- [ ] New feature
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

- [ ] Bug fix

# Test Details
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

See .java testcases

# Additional Notes
<!-- Please add any additional notes regarding this pull request here. -->

N/A
