### PR TITLE
NIMBUS-135: Active Task Synch Issue

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/BPMEngineConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/app/extension/config/BPMEngineConfig.java
@@ -193,7 +193,8 @@ public class BPMEngineConfig extends AbstractProcessEngineAutoConfiguration {
 	    	}
     }
    
-    @Bean
+
+    @Bean("default.processJdbcTemplate")
     public JdbcTemplate jdbcTemplate(@Qualifier("processDataSource")DataSource dataSource) {
         return new JdbcTemplate(dataSource);
     }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/bpm/activiti/ActivitiBPMGateway.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/bpm/activiti/ActivitiBPMGateway.java
@@ -33,6 +33,7 @@ import org.activiti.engine.task.Task;
 import org.activiti.spring.SpringProcessEngineConfiguration;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.app.extension.config.ActivitiProcessDefinitionCache;
@@ -58,7 +59,6 @@ import com.antheminc.oss.nimbus.domain.model.state.repo.ModelRepositoryFactory;
 import com.antheminc.oss.nimbus.entity.process.ProcessFlow;
 import com.antheminc.oss.nimbus.support.EnableAPIMetricCollection;
 import com.antheminc.oss.nimbus.support.EnableAPIMetricCollection.LogLevel;
-import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 import com.antheminc.oss.nimbus.support.JustLogit;
 import com.antheminc.oss.nimbus.support.expr.ExpressionEvaluator;
 
@@ -84,6 +84,8 @@ public class ActivitiBPMGateway implements BPMGateway {
 	private DomainConfigBuilder domainConfigBuilder;
 	private CommandExecutorGateway commandGateway;
 	private CommandPathVariableResolver pathVariableResolver;
+	private JdbcTemplate activitiJdbcTemplate;
+    private static final String ACT_TSK_LKUP_QRY = "select task_def_key_ from act_ru_task where proc_inst_id_=?"; 
 	
 	public ActivitiBPMGateway (BeanResolverStrategy beanResolver,Boolean supportStatefulProcesses) {
 		this.expressionEvaluator = beanResolver.find(ExpressionEvaluator.class);
@@ -95,6 +97,7 @@ public class ActivitiBPMGateway implements BPMGateway {
 		this.domainConfigBuilder = beanResolver.find(DomainConfigBuilder.class);	
 		this.commandGateway = beanResolver.find(CommandExecutorGateway.class);
 		this.pathVariableResolver = beanResolver.find(CommandPathVariableResolver.class);
+		this.activitiJdbcTemplate = beanResolver.find(JdbcTemplate.class, "processJdbcTemplate");
 	}
 	
 	@Override
@@ -131,8 +134,8 @@ public class ActivitiBPMGateway implements BPMGateway {
 	
 	@Override
 	public Object continueBusinessProcessExecution(Param<?> param, String processExecutionId) {
-		ActivitiProcessFlow processFlow = (ActivitiProcessFlow)((ExecutionEntity<?,?>)param.getRootExecution().getState()).getFlow();
-		List<String> activeTasks = processFlow.getActiveTasks();
+		String[] args = new String[] {processExecutionId};
+		List<String> activeTasks = activitiJdbcTemplate.queryForList(ACT_TSK_LKUP_QRY,args,String.class);
 		ProcessEngineContext context = new ProcessEngineContext(param);
 		Map<String, Object> executionVariables = new HashMap<String, Object>();
 		executionVariables.put(Constants.KEY_EXECUTE_PROCESS_CTX.code, context);		


### PR DESCRIPTION
# Description
Current version of the framework reads active task for an entity from the ProcessFlow instance. This runs into synch issue when a workflow is triggered asynchronously. Activiti commits  transaction once the request in processed. Before the transaction is committed, if another thread tries to execute the workflow then it can get incorrect value of the active tasks from ProcessFlow Instance.

# Overview of Changes
Change has been done in ActivitiBPMGateway to always read active tasks from the database

N/A

# Type of Change

- [ ] New feature
- [ X] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details
BPMGatewayTests

# Additional Notes

