### PR TITLE
Conditional annotation refactor

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/LabelConditional.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/LabelConditional.java
@@ -139,5 +139,5 @@ public @interface LabelConditional {
 	 * <p>Path of param to enable when condition is satisfied relative to param
 	 * on which this annotation is declared
 	 */
-	String targetPath();
+	String[] targetPath();
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/StyleConditional.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/StyleConditional.java
@@ -150,5 +150,5 @@ public @interface StyleConditional {
 	 * <p>Path of param to apply styles to when condition is satisfied. The path
 	 * is relative to param on which this annotation is declared.
 	 */
-	String targetPath();
+	String[] targetPath();
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/ValuesConditional.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/extension/ValuesConditional.java
@@ -147,5 +147,5 @@ public @interface ValuesConditional {
 	/**
 	 * <p>The target path relative to the this annotated field to update.
 	 */
-	String targetPath();
+	String[] targetPath();
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AbstractConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AbstractConditionalStateEventHandler.java
@@ -16,46 +16,114 @@
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
 import java.lang.annotation.Annotation;
+import java.util.EnumSet;
 import java.util.Optional;
 
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.ExecutionTxnContext;
+import com.antheminc.oss.nimbus.domain.model.state.ParamEvent;
 import com.antheminc.oss.nimbus.domain.model.state.StateHolder.ParamStateHolder;
+import com.antheminc.oss.nimbus.support.JustLogit;
 import com.antheminc.oss.nimbus.support.expr.ExpressionEvaluator;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
 
 /**
+ * <p>A conditional state event handler support class that aids in performing
+ * subclass logic depending on the result of the conditional evaluation.
+ * 
  * @author Soham Chakravarti
+ * @author Tony Lopez
+ * @since 1.0
  *
  */
 @Getter(AccessLevel.PROTECTED)
-public abstract class AbstractConditionalStateEventHandler<A extends Annotation> extends AbstractEventHandlerSupport<A> {
+public abstract class AbstractConditionalStateEventHandler<A extends Annotation>
+		extends AbstractEventHandlerSupport<A> {
 
-	protected BeanResolverStrategy beanResolver;
-	protected ExpressionEvaluator expressionEvaluator;
-	@Setter(AccessLevel.PROTECTED)
-	protected StateEventType stateEventType;
-	
-	public static enum StateEventType {
-		ON_LOAD,
-		ON_CHANGE;
-	}
-	
+	private static final JustLogit LOG = new JustLogit(AbstractConditionalStateEventHandler.class);
+
+	protected final BeanResolverStrategy beanResolver;
+	protected final ExpressionEvaluator expressionEvaluator;
+
 	public AbstractConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
 		this.beanResolver = beanResolver;
 		this.expressionEvaluator = beanResolver.get(ExpressionEvaluator.class);
 	}
-	
-	protected boolean evalWhen(Param<?> onChangeParam, String whenExpr) {
-		return getExpressionEvaluator().getValue(whenExpr, new ParamStateHolder<>(onChangeParam), Boolean.class);
+
+	@Override
+	public void onStateChange(A configuredAnnotation, ExecutionTxnContext txnCtx, ParamEvent event) {
+		EnumSet<Action> validSet = EnumSet.of(Action._new, Action._update, Action._replace, Action._delete);
+
+		if (!validSet.contains(event.getAction()))
+			return;
+
+		conditionalLogWrapper(configuredAnnotation, StateChangeEventType.ON_CHANGE,
+				() -> handleInternal(event.getParam(), configuredAnnotation, StateChangeEventType.ON_CHANGE));
 	}
-	
-	protected Param<?> retrieveParamByPath(Param<?> baseParam, String targetPath) {
-		return Optional.ofNullable(baseParam.findParamByPath(targetPath))
-				.orElseThrow(() -> new InvalidConfigException("Target param lookup returned null for targetPath: " + targetPath + " on param: " + baseParam));
+
+	@Override
+	public void onStateLoad(A configuredAnnotation, Param<?> param) {
+		conditionalLogWrapper(configuredAnnotation, StateChangeEventType.ON_LOAD,
+				() -> handleInternal(param, configuredAnnotation, StateChangeEventType.ON_LOAD));
+	}
+
+	@Override
+	public void onStateLoadNew(A configuredAnnotation, Param<?> param) {
+		conditionalLogWrapper(configuredAnnotation, StateChangeEventType.ON_LOAD_NEW,
+				() -> handleInternal(param, configuredAnnotation, StateChangeEventType.ON_LOAD_NEW));
+	}
+
+	private void conditionalLogWrapper(A configuredAnnotation, StateChangeEventType eventType, Runnable r) {
+		LOG.trace(
+				() -> "=== START conditional " + eventType.name() + " handler execution for: " + configuredAnnotation);
+		r.run();
+		LOG.trace(() -> "=== END conditional " + eventType.name() + " handler execution for: " + configuredAnnotation);
+	}
+
+	/**
+	 * <p>Evaluate the given expression using the {@contextParam} as the
+	 * context, or the relative param this expression will be executed from.
+	 * @param expression the expression to evaluate
+	 * @param contextParam the relative param to execute the expression from
+	 * @return the result of the expression evaluation
+	 */
+	protected boolean evaluate(String expression, Param<?> contextParam) {
+		boolean result = getExpressionEvaluator().getValue(expression, new ParamStateHolder<>(contextParam),
+				Boolean.class);
+		LOG.trace(() -> "\"" + expression + "\" evaluated to " + String.valueOf(result).toUpperCase()
+				+ ". Context param: " + contextParam);
+		return result;
+	}
+
+	/**
+	 * <p>Execute the logic for this state event handler.
+	 * @param onChangeParam the param that for which te state event handler has
+	 *            been triggered
+	 * @param configuredAnnotation the state change handler annotation
+	 */
+	protected abstract void handleInternal(Param<?> onChangeParam, A configuredAnnotation);
+
+	protected void handleInternal(Param<?> onChangeParam, A configuredAnnotation,
+			StateChangeEventType stateChangeEventType) {
+		setStateChangeEventType(stateChangeEventType);
+		handleInternal(onChangeParam, configuredAnnotation);
+	}
+
+	/**
+	 * <p>Find the param from the given {@code targetPath} relative to the
+	 * {@code contextParam}.
+	 * @param contextParam the relative param to retrieve the target param from
+	 * @param targetPath the path to the param
+	 * @return the param
+	 */
+	protected Param<?> retrieveParamByPath(Param<?> contextParam, String targetPath) {
+		return Optional.ofNullable(contextParam.findParamByPath(targetPath))
+				.orElseThrow(() -> new InvalidConfigException("Target param lookup returned null for targetPath: "
+						+ targetPath + " on param: " + contextParam));
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AbstractConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AbstractConditionalStateEventHandler.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Annotation;
 import java.util.EnumSet;
 import java.util.Optional;
 
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
@@ -93,11 +94,16 @@ public abstract class AbstractConditionalStateEventHandler<A extends Annotation>
 	 * @return the result of the expression evaluation
 	 */
 	protected boolean evaluate(String expression, Param<?> contextParam) {
-		boolean result = getExpressionEvaluator().getValue(expression, new ParamStateHolder<>(contextParam),
-				Boolean.class);
-		LOG.trace(() -> "\"" + expression + "\" evaluated to " + String.valueOf(result).toUpperCase()
-				+ ". Context param: " + contextParam);
-		return result;
+		try {
+			boolean result = getExpressionEvaluator().getValue(expression, new ParamStateHolder<>(contextParam),
+					Boolean.class);
+			LOG.trace(() -> "\"" + expression + "\" evaluated to " + String.valueOf(result).toUpperCase()
+					+ ". Context param: " + contextParam);
+			return result;
+		} catch (Exception e) {
+			throw new FrameworkRuntimeException("Encountered an exception evaluating the expression \"" + expression
+					+ "\" + for param: " + contextParam, e);
+		}
 	}
 
 	/**

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AbstractEventHandlerSupport.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AbstractEventHandlerSupport.java
@@ -27,6 +27,10 @@ import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnSt
 import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnStateLoadHandler;
 import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnStateLoadNewHandler;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * <p>Abstract (base) event handler implementation for specific event annotation handler(s) to extend from.
  * <p>This class provides abstraction to all the event handler interfaces and would contain common behavior applicable to all event handlers,
@@ -40,6 +44,16 @@ import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnSt
 public abstract class AbstractEventHandlerSupport<A extends Annotation>
 		implements OnStateLoadHandler<A>, OnStateLoadGetHandler<A>, OnStateLoadNewHandler<A> , OnStateChangeHandler<A> {
 
+	@Setter(AccessLevel.PROTECTED)
+	@Getter
+	protected StateChangeEventType stateChangeEventType;
+	
+	public enum StateChangeEventType {
+		ON_CHANGE,
+		ON_LOAD,
+		ON_LOAD_NEW;
+	}
+	
 	@Override
 	public void onStateLoad(A configuredAnnotation, Param<?> param) {
 		throw new InvalidConfigException("OnStateLoadHandler is not implemented for "+configuredAnnotation+ " on param "+param);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalStateEventHandler.java
@@ -15,11 +15,10 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
-import java.util.Arrays;
-
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.defn.extension.ActivateConditional;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.IfElseConditionalStateEventHandler;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 /**
@@ -27,27 +26,20 @@ import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
  *
  */
 @EnableLoggingInterceptor
-public class ActivateConditionalStateEventHandler extends EvalExprWithCrudActions<ActivateConditional> {
+public class ActivateConditionalStateEventHandler extends IfElseConditionalStateEventHandler<ActivateConditional> {
 
 	public ActivateConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
 	}
-	
-	@Override
-	protected void handleInternal(Param<?> onChangeParam, ActivateConditional configuredAnnotation) {
-		boolean isTrue = evalWhen(onChangeParam, configuredAnnotation.when());
-		
-		// validate target param to activate
-		String[] targetPaths = configuredAnnotation.targetPath();
 
-		Arrays.asList(targetPaths).stream()
-			.forEach(targetPath -> handleInternal(onChangeParam, targetPath, (targetParam->{
-				if(isTrue)
-					targetParam.activate();
-				else
-					targetParam.deactivate();
-			})));
-		
+	@Override
+	protected void whenFalse(ActivateConditional configuredAnnotation, Param<?> onChangeParam, Param<?> targetParam) {
+		targetParam.deactivate();
 	}
-	
+
+	@Override
+	protected void whenTrue(ActivateConditional configuredAnnotation, Param<?> onChangeParam, Param<?> targetParam) {
+		targetParam.activate();
+	}
+
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ConfigConditionalStateChangeHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ConfigConditionalStateChangeHandler.java
@@ -28,8 +28,6 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContextLoader;
 import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
 import com.antheminc.oss.nimbus.domain.defn.extension.ConfigConditional;
-import com.antheminc.oss.nimbus.domain.model.state.ExecutionTxnContext;
-import com.antheminc.oss.nimbus.domain.model.state.ParamEvent;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
@@ -69,10 +67,11 @@ public class ConfigConditionalStateChangeHandler extends EvalExprWithCrudActions
 	protected void handleInternal(Param<?> onChangeParam, ConfigConditional configuredAnnotation) {
 		init();
 		
-		boolean isTrue = evalWhen(onChangeParam, configuredAnnotation.when());
+		boolean result = evaluate(configuredAnnotation.when(), onChangeParam);
 		
-		if(!isTrue)
+		if(!result) {
 			return;
+		}
 		
 		Config[] configs = configuredAnnotation.config();
 		if (ArrayUtils.isEmpty(configs)) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EnableConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EnableConditionalStateEventHandler.java
@@ -15,11 +15,12 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
-import java.util.Arrays;
+import java.util.function.Consumer;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.defn.extension.EnableConditional;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.BooleanSetterConditionalHandler;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 /**
@@ -27,21 +28,14 @@ import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
  *
  */
 @EnableLoggingInterceptor
-public class EnableConditionalStateEventHandler extends EvalExprWithCrudActions<EnableConditional> {
+public class EnableConditionalStateEventHandler extends BooleanSetterConditionalHandler<EnableConditional> {
 
 	public EnableConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
 	}
-	
-	@Override	
-	protected void handleInternal(Param<?> onChangeParam, EnableConditional configuredAnnotation) {
-		boolean isTrue = evalWhen(onChangeParam, configuredAnnotation.when());
-		
-		// validate target param to enable
-		String[] targetPaths = configuredAnnotation.targetPath();
 
-		Arrays.asList(targetPaths).stream()
-			.forEach(targetPath -> handleInternal(onChangeParam, targetPath, targetParam->targetParam.setEnabled(isTrue)));
-		
+	@Override
+	protected Consumer<Boolean> setter(Param<?> targetParam) {
+		return targetParam::setEnabled;
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EvalExprWithCrudActions.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EvalExprWithCrudActions.java
@@ -24,13 +24,18 @@ import com.antheminc.oss.nimbus.domain.cmd.Action;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.ExecutionTxnContext;
 import com.antheminc.oss.nimbus.domain.model.state.ParamEvent;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.AssignThenToTargetCaseConditionalHandler;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.BooleanSetterConditionalHandler;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 
 /**
  * @author Soham Chakravarti
- *
+ * @deprecated This class will likely be removed in the future. Consider
+ *             replacing implementations with:
+ *             <ul><li>{@link AssignThenToTargetCaseConditionalHandler}</li>
+ *             <li>{@link BooleanSetterConditionalHandler}</li></ul>
  */
 @Getter(AccessLevel.PROTECTED)
 public abstract class EvalExprWithCrudActions<A extends Annotation> extends AbstractConditionalStateEventHandler<A> {
@@ -41,7 +46,7 @@ public abstract class EvalExprWithCrudActions<A extends Annotation> extends Abst
 	
 	@Override
 	public void onStateLoad(A configuredAnnotation, Param<?> param) {
-		handleInternal(param, configuredAnnotation, StateEventType.ON_LOAD);
+		handleInternal(param, configuredAnnotation, StateChangeEventType.ON_LOAD);
 	}
 	
 	@Override
@@ -56,11 +61,11 @@ public abstract class EvalExprWithCrudActions<A extends Annotation> extends Abst
 		if(!validSet.contains(event.getAction()))
 			return;
 		
-		handleInternal(event.getParam(), configuredAnnotation, StateEventType.ON_CHANGE);
+		handleInternal(event.getParam(), configuredAnnotation, StateChangeEventType.ON_CHANGE);
 	}
 	
-	protected void handleInternal(Param<?> onChangeParam, A configuredAnnotation, StateEventType stateEventType) {
-		setStateEventType(stateEventType);
+	protected void handleInternal(Param<?> onChangeParam, A configuredAnnotation, StateChangeEventType stateEventType) {
+		setStateChangeEventType(stateEventType);
 		handleInternal(onChangeParam, configuredAnnotation);
 	}
 	
@@ -70,5 +75,9 @@ public abstract class EvalExprWithCrudActions<A extends Annotation> extends Abst
 		Param<?> targetParam = retrieveParamByPath(onChangeParam, targetPath);
 
 		executeCb.accept(targetParam);
+	}
+	
+	protected boolean evalWhen(Param<?> onChangeParam, String expr) {
+		return evaluate(expr, onChangeParam);
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EvalExprWithCrudDefaults.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/EvalExprWithCrudDefaults.java
@@ -20,6 +20,8 @@ import java.lang.annotation.Annotation;
 import com.antheminc.oss.nimbus.AnnotationUtil;
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.AssignThenToTargetCaseConditionalHandler;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.BooleanSetterConditionalHandler;
 
 /**
  * <p>This class can be used for conditional event handlers that need the
@@ -33,7 +35,11 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
  * @since 1.1
  *
  * @param <A> the annotation to provide support for
+ * @deprecated This class will likely be removed in the future. Consider
+ *             replacing implementations
+ *             with:<ul><li>{@link AssignThenToTargetCaseConditionalHandler}</li><li>{@link BooleanSetterConditionalHandler}</li></ul>
  */
+@Deprecated
 public abstract class EvalExprWithCrudDefaults<A extends Annotation> extends EvalExprWithCrudActions<A> {
 
 	private static final String ATTR_TARGET_PATH = "targetPath";

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ExpressionConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ExpressionConditionalStateEventHandler.java
@@ -39,23 +39,15 @@ public class ExpressionConditionalStateEventHandler extends EvalExprWithCrudActi
 	
 	@Override
 	protected void handleInternal(Param<?> onChangeParam, ExpressionConditional configuredAnnotation) {
-		boolean isExecuteThen = evalWhen(onChangeParam, configuredAnnotation.when());
+		boolean result = evaluate(configuredAnnotation.when(), onChangeParam);
 		
-		if(isExecuteThen) {
+		if(result) {
 			String thenExpr = Optional.ofNullable(configuredAnnotation.then())
 								.filter(StringUtils::isNotEmpty)
 								.orElseThrow(()->new InvalidConfigException(configuredAnnotation+" must have valid expression to execute."));
 			
 			execute(onChangeParam, thenExpr);
-			return;
-		} 
-
-//		// else expression
-//		String elseExpr = StringUtils.trimToNull(configuredAnnotation.elseThen());
-//		if(elseExpr == null) 
-//			return;
-//		
-//		execute(onChangeParam, elseExpr);
+		}
 	}
 	
 	private void execute(Param<?> onChangeParam, String expr) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/MessageConditionalHandler.java
@@ -25,7 +25,7 @@ public class MessageConditionalHandler extends EvalExprWithCrudActions<MessageCo
 	}
 	@Override
 	protected void handleInternal(Param<?> onChangeParam, MessageConditional configuredAnnotation) {
-		boolean isValid = this.evalWhen(onChangeParam, configuredAnnotation.when());
+		boolean isValid = this.evaluate(configuredAnnotation.when(), onChangeParam);
 		// Evaluate the msg as a spel expression
 		String evaluatedMessage = expressionEvaluator.getValue(configuredAnnotation.message(), new ParamStateHolder<>(onChangeParam), String.class);
 		

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/RuleStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/RuleStateEventHandler.java
@@ -24,8 +24,6 @@ import com.antheminc.oss.nimbus.domain.defn.extension.Rule;
 import com.antheminc.oss.nimbus.domain.model.config.RulesConfig;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.RulesRuntime;
-import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnStateChangeHandler;
-import com.antheminc.oss.nimbus.domain.model.state.event.StateEventHandlers.OnStateLoadHandler;
 import com.antheminc.oss.nimbus.domain.rules.RulesEngineFactory;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
@@ -54,7 +52,6 @@ public class RuleStateEventHandler extends EvalExprWithCrudActions<Rule> {
 
 	@Override
 	protected void handleInternal(Param<?> onChangeParam, Rule configuredAnnotation) {
-		
 		for(final String ruleAlias: configuredAnnotation.value()) {
 			
 			// Build the rules runtime

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ScriptEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ScriptEventHandler.java
@@ -36,7 +36,6 @@ import com.antheminc.oss.nimbus.domain.defn.extension.Script.Type;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.StateHolder.ParamStateHolder;
 import com.antheminc.oss.nimbus.support.JustLogit;
-import com.antheminc.oss.nimbus.support.expr.ExpressionEvaluator;
 
 import lombok.Getter;
 
@@ -45,9 +44,7 @@ import lombok.Getter;
  *
  */
 @Getter
-public class ScriptEventHandler extends EvalExprWithCrudActions<Script> {
-
-	private ExpressionEvaluator expressionEvaluator;
+public class ScriptEventHandler extends AbstractConditionalStateEventHandler<Script> {
 	
 	private static final ScriptEngine groovyEngine = new ScriptEngineManager().getEngineByName("groovy");
 	
@@ -55,7 +52,6 @@ public class ScriptEventHandler extends EvalExprWithCrudActions<Script> {
 	
 	public ScriptEventHandler(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
-		this.expressionEvaluator = beanResolver.get(ExpressionEvaluator.class);
 	}
 	
 	@Override

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/StyleConditionalStateEventHandler.java
@@ -15,18 +15,22 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.defn.extension.Style;
 import com.antheminc.oss.nimbus.domain.defn.extension.StyleConditional;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param.StyleState;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.AssignThenToTargetCaseConditionalHandler;
 import com.antheminc.oss.nimbus.support.JustLogit;
 
 /**
  * @author Tony Lopez
  *
  */
-public class StyleConditionalStateEventHandler extends EvalExprWithCrudDefaults<StyleConditional> {
+public class StyleConditionalStateEventHandler extends AssignThenToTargetCaseConditionalHandler<StyleConditional> {
 
 	public static final JustLogit LOG = new JustLogit();
 
@@ -34,22 +38,18 @@ public class StyleConditionalStateEventHandler extends EvalExprWithCrudDefaults<
 		super(beanResolver);
 	}
 
-	protected void applyStyleToState(Param<?> onChangeParam, Param<?> targetParam,
-			Style style) {
+	@Override
+	protected void executeElse(Param<?> onChangeParam, Annotation configuredAnnotation, Set<Param<?>> targetParams) {
+		for(Param<?> targetParam : targetParams) {
+			targetParam.setStyle(null);
+		}
+	}
+
+	@Override
+	protected void whenConditionTrue(Object thenValue, Param<?> onChangeParam, Param<?> targetParam) {
+		Style thenAnnotation = (Style) thenValue;
 		StyleState styleState = new StyleState();
-		styleState.setCssClass(style.cssClass());
+		styleState.setCssClass(thenAnnotation.cssClass());
 		targetParam.setStyle(styleState);
-	}
-
-	@Override
-	protected void executeDefault(Param<?> onChangeParam, Param<?> targetParam) {
-		targetParam.setStyle(null);
-	}
-
-	@Override
-	protected void executeOnWhenConditionTrue(Object payload, Param<?> onChangeParam, Param<?> targetParam) {
-		// Convert the payload into the expected parameter type.
-		Style style = (Style) payload;
-		this.applyStyleToState(onChangeParam, targetParam, style);
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValidateConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValidateConditionalStateEventHandler.java
@@ -41,7 +41,7 @@ public class ValidateConditionalStateEventHandler extends EvalExprWithCrudAction
 	@Override
 	protected void handleInternal(Param<?> onChangeParam, ValidateConditional configuredAnnotation) {
 		
-		boolean isTrue = this.evalWhen(onChangeParam, configuredAnnotation.when());
+		boolean result = this.evaluate(configuredAnnotation.when(), onChangeParam);
 		
 		// retrieve the validation assignment strategy
 		ValidationAssignmentStrategy strategy = this.getValidationAssignmentStrategy(configuredAnnotation);
@@ -49,7 +49,7 @@ public class ValidateConditionalStateEventHandler extends EvalExprWithCrudAction
 		if (null == configuredAnnotation.targetPath() || configuredAnnotation.targetPath().length == 0) {
 			
 			// single scenario execution
-			strategy.execute(isTrue, onChangeParam, configuredAnnotation.targetGroup());
+			strategy.execute(result, onChangeParam, configuredAnnotation.targetGroup());
 		} else {
 			
 			// multiple scenario execution
@@ -58,10 +58,9 @@ public class ValidateConditionalStateEventHandler extends EvalExprWithCrudAction
 				if (null == targetParam) {
 					throw new InvalidConfigException("Failed to locate param with path: " + path);
 				}
-				strategy.execute(isTrue, targetParam, configuredAnnotation.targetGroup());
+				strategy.execute(result, targetParam, configuredAnnotation.targetGroup());
 			}
 		}
-		
 	}
 	
 	private ValidationAssignmentStrategy getValidationAssignmentStrategy(ValidateConditional configuredAnnotation) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/VisibleConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/VisibleConditionalStateEventHandler.java
@@ -15,11 +15,12 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.extension;
 
-import java.util.Arrays;
+import java.util.function.Consumer;
 
 import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
 import com.antheminc.oss.nimbus.domain.defn.extension.VisibleConditional;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.extension.conditionals.BooleanSetterConditionalHandler;
 import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
 
 /**
@@ -27,21 +28,14 @@ import com.antheminc.oss.nimbus.support.EnableLoggingInterceptor;
  *
  */
 @EnableLoggingInterceptor
-public class VisibleConditionalStateEventHandler extends EvalExprWithCrudActions<VisibleConditional> {
+public class VisibleConditionalStateEventHandler extends BooleanSetterConditionalHandler<VisibleConditional> {
 
 	public VisibleConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
 		super(beanResolver);
 	}
-	
-	@Override	
-	protected void handleInternal(Param<?> onChangeParam, VisibleConditional configuredAnnotation) {
-		boolean isTrue = evalWhen(onChangeParam, configuredAnnotation.when());
-		
-		// validate target param to enable
-		String[] targetPaths = configuredAnnotation.targetPath();
 
-		Arrays.asList(targetPaths).stream()
-			.forEach(targetPath -> handleInternal(onChangeParam, targetPath, targetParam->targetParam.setVisible(isTrue)));
-		
+	@Override
+	protected Consumer<Boolean> setter(Param<?> targetParam) {
+		return targetParam::setVisible;
 	}
 }

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/conditionals/AssignThenToTargetCaseConditionalHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/conditionals/AssignThenToTargetCaseConditionalHandler.java
@@ -1,0 +1,153 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension.conditionals;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import com.antheminc.oss.nimbus.AnnotationUtil;
+import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.support.JustLogit;
+
+/**
+ * <p>A conditional state event handler support class that executes one or more
+ * conditional statements and depending on the outcome of the executed
+ * conditional statement(s), performs some action with a configured value
+ * (typically into a {@link Param} object).
+ * 
+ * <p>This conditional state event handler is similar to an if/else if/else or
+ * case block in the Java programming language. The provided conditional
+ * annotations will be evaluated and when one is {@code true}, support is
+ * included to set the value provided for {@code then} into the target
+ * {@link Param}.
+ * 
+ * <p>"Case" like behavior can be achieved by setting the {@code exclusive} to
+ * {@code false}, which allows for attribute on the configured annotation. By
+ * default this value is {@code true}, so providing multiple conditions will
+ * result in logic being executed in "else if" fashion.
+ * 
+ * @author Tony Lopez
+ * @since 1.3
+ *
+ * @param <A> the annotation to provide support for
+ */
+public abstract class AssignThenToTargetCaseConditionalHandler<A extends Annotation>
+		extends IfElseConditionalStateEventHandler<A> {
+
+	private static final JustLogit LOG = new JustLogit(AssignThenToTargetCaseConditionalHandler.class);
+	public static final String ATTR_CONDITION = "condition";
+	public static final String ATTR_THEN = "then";
+	public static final String ATTR_EXCLUSIVE = "exclusive";
+
+	public AssignThenToTargetCaseConditionalHandler(BeanResolverStrategy beanResolver) {
+		super(beanResolver);
+	}
+
+	/**
+	 * <p>Execute the default logic for this handler. <p>Logic defined within
+	 * overridden methods will execute once if and only any of the provided
+	 * conditions do not execute.
+	 * @param onChangeParam the source parameter (annotated field)
+	 * @param configuredAnnotation the conditional annotation decorating
+	 *            {@code onChangeParam}
+	 * @param targetParams the target parameter(s) to execute against
+	 */
+	protected void executeElse(Param<?> onChangeParam, Annotation configuredAnnotation, Set<Param<?>> targetParams) {
+		// Do nothing by default
+	}
+
+	/**
+	 * <p>Retrieve the {@code condition} attribute from the provided
+	 * {@code configuredAnnotation}.<p>Uses annotation reflection support to
+	 * retrieve the {@code condition} attribute. If the attribute is not
+	 * present, an exception will be thrown.
+	 * @param configuredAnnotation the conditional annotation
+	 * @return the attribute value
+	 */
+	protected Annotation[] getAttributeCondition(Annotation configuredAnnotation) {
+		return AnnotationUtil.safelyRetrieveAnnotationAttribute(configuredAnnotation, ATTR_CONDITION,
+				Annotation[].class);
+	}
+	
+	/**
+	 * <p>Retrieve the {@code exclusive} attribute from the provided
+	 * {@code configuredAnnotation}.<p>Uses annotation reflection support to
+	 * retrieve the {@code exclusive} attribute. If the attribute is not
+	 * present, an exception will be thrown.
+	 * @param configuredAnnotation the conditional annotation
+	 * @return the attribute value
+	 */
+	protected boolean getAttributeExclusive(Annotation configuredAnnotation) {
+		return AnnotationUtil.safelyRetrieveAnnotationAttribute(configuredAnnotation, ATTR_EXCLUSIVE, Boolean.class);
+	}
+
+	/**
+	 * <p>Retrieve the {@code then} attribute from the provided
+	 * {@code configuredAnnotation}.<p>Uses annotation reflection support to
+	 * retrieve the {@code then} attribute. If the attribute is not present, an
+	 * exception will be thrown.
+	 * @param configuredAnnotation the conditional annotation
+	 * @return the attribute value
+	 */
+	protected Object getAttributeThen(Annotation configuredAnnotation) {
+		return AnnotationUtil.safelyRetrieveAnnotationAttribute(configuredAnnotation, ATTR_THEN, Object.class);
+	}
+
+	@Override
+	protected void handleInternal(Param<?> onChangeParam, A configuredAnnotation) {
+		boolean isMutuallyExclusive = getAttributeExclusive(configuredAnnotation);
+		Annotation[] conditions = getAttributeCondition(configuredAnnotation);
+		Set<Param<?>> targetParams = getTargetPathParams(configuredAnnotation, onChangeParam);
+
+		boolean executed = false;
+		for (final Annotation condition : conditions) {
+			boolean result = handleConditionalExecution(onChangeParam, condition, targetParams);
+			if (result) {
+				if (isMutuallyExclusive) {
+					return;
+				}
+				executed = true;
+			}
+		}
+
+		if (!executed) {
+			LOG.trace(() -> "Executing default expression for " + configuredAnnotation);
+			executeElse(onChangeParam, configuredAnnotation, targetParams);
+		}
+	}
+
+	/**
+	 * <p>Execute the logic that should occur when this a conditional execution
+	 * evaluates to {@code true}.
+	 * @param thenValue the attribute value for {@code then} from the configured
+	 *            conditional annotation
+	 * @param onChangeParam the source parameter (annotated field)
+	 * @param targetParam the param to execute the logic on
+	 */
+	protected abstract void whenConditionTrue(Object thenValue, Param<?> onChangeParam, Param<?> targetParam);
+
+	@Override
+	protected void whenFalse(A configuredAnnotation, Param<?> onChangeParam, Param<?> targetParam) {
+		// do nothing, delegates execution to whether or not
+		// configuredAnnotation is mutually exclusive, and if so executes {@link #executeElse}
+	}
+
+	@Override
+	protected void whenTrue(A conditionalAnnotation, Param<?> onChangeParam, Param<?> targetParam) {
+		whenConditionTrue(getAttributeThen(conditionalAnnotation), onChangeParam, targetParam);
+	}
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/conditionals/BooleanSetterConditionalHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/conditionals/BooleanSetterConditionalHandler.java
@@ -1,0 +1,65 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension.conditionals;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Consumer;
+
+import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+
+/**
+ * <p>A very simple conditional state event handler support class that sets a
+ * boolean value to the target {@link Param} object when the provided condition
+ * evaluates to {@code true} and performs the inverse action when the condition
+ * evaluates to {@code false}. Subclasses can control which property of the
+ * {@link Param} object is set.
+ * 
+ * <p>The execution offered by extending this class similar to a simple if/else
+ * block in the Java programming language.
+ * 
+ * @author Tony Lopez
+ * @since 1.3
+ *
+ */
+public abstract class BooleanSetterConditionalHandler<A extends Annotation>
+		extends IfElseConditionalStateEventHandler<A> {
+
+	public BooleanSetterConditionalHandler(BeanResolverStrategy beanResolver) {
+		super(beanResolver);
+	}
+
+	/**
+	 * <p>Get the setter method to invoke on {@code targetParam} when this
+	 * conditional state event handler is {@code true} or {@code false}.
+	 * @param configuredAnnotation the conditional annotation decorating
+	 *            {@code onChangeParam}
+	 * @param onChangeParam the source parameter (annotated field)
+	 * @param targetParam the target parameter to invoke the action on
+	 * @return the setter method to invoke
+	 */
+	protected abstract Consumer<Boolean> setter(Param<?> targetParam);
+
+	@Override
+	protected void whenFalse(A configuredAnnotation, Param<?> onChangeParam, Param<?> targetParam) {
+		setter(targetParam).accept(false);
+	}
+
+	@Override
+	protected void whenTrue(A configuredAnnotation, Param<?> onChangeParam, Param<?> targetParam) {
+		setter(targetParam).accept(true);
+	}
+}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/conditionals/IfElseConditionalStateEventHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/conditionals/IfElseConditionalStateEventHandler.java
@@ -1,0 +1,158 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension.conditionals;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.util.TriConsumer;
+
+import com.antheminc.oss.nimbus.AnnotationUtil;
+import com.antheminc.oss.nimbus.InvalidConfigException;
+import com.antheminc.oss.nimbus.context.BeanResolverStrategy;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.domain.model.state.extension.AbstractConditionalStateEventHandler;
+import com.antheminc.oss.nimbus.support.JustLogit;
+
+/**
+ * <p>A conditional state event handler support class that performs subclass
+ * logic depending on the result of the conditional evaluation.
+ * 
+ * <p>The execution offered by extending this class similar to a simple if/else
+ * block in the Java programming language. Subclasses are able to define the
+ * logic that should be executed when the condition evaluates to {@code true}
+ * and similarly when the condition evaluates to {@code false}.
+ * 
+ * @author Tony Lopez
+ * @since 1.3
+ *
+ */
+public abstract class IfElseConditionalStateEventHandler<A extends Annotation>
+		extends AbstractConditionalStateEventHandler<A> {
+
+	public static final String ATTR_TARGET_PATH = "targetPath";
+	public static final String ATTR_WHEN = "when";
+
+	public IfElseConditionalStateEventHandler(BeanResolverStrategy beanResolver) {
+		super(beanResolver);
+	}
+
+	/**
+	 * <p>Evaluate the {@code when} expression given in the the
+	 * {@code configuredAnnotation} using the {@contextParam} as the context, or
+	 * the relative param this expression will be executed from.
+	 * @param expression the expression to evaluate
+	 * @param contextParam the relative param to execute the expression from
+	 * @return the result of the expression evaluation
+	 */
+	protected boolean evaluateWhen(Annotation configuredAnnotation, Param<?> contextParam) {
+		return evaluate(getAttributeWhen(configuredAnnotation), contextParam);
+	}
+
+	/**
+	 * <p>Retrieve the {@code targetPath} attribute from the provided
+	 * {@code configuredAnnotation}.<p>Uses annotation reflection support to
+	 * retrieve the {@code targetPath} attribute. If the attribute is not
+	 * present, an exception will be thrown.
+	 * @param configuredAnnotation the conditional annotation
+	 * @return the attribute value
+	 */
+	protected String[] getAttributeTargetPath(Annotation configuredAnnotation) {
+		return AnnotationUtil.safelyRetrieveAnnotationAttribute(configuredAnnotation, ATTR_TARGET_PATH, String[].class);
+	}
+
+	/**
+	 * <p>Retrieve the {@code when} attribute from the provided
+	 * {@code configuredAnnotation}.<p>Uses annotation reflection support to
+	 * retrieve the {@code when} attribute. If the attribute is not present, an
+	 * exception will be thrown.
+	 * @param configuredAnnotation the conditional annotation
+	 * @return the attribute value
+	 */
+	protected String getAttributeWhen(Annotation configuredAnnotation) {
+		return AnnotationUtil.safelyRetrieveAnnotationAttribute(configuredAnnotation, ATTR_WHEN, String.class);
+	}
+
+	/**
+	 * <p>Retrieve the params relative to {@code contextParam} from the provided
+	 * {@code targetPath} attribute of {@code configuredAnnotation}.<p>Uses
+	 * annotation reflection support to retrieve the {@code targetPath}
+	 * attribute. If the attribute is not present, an exception will be thrown.
+	 * @param configuredAnnotation the conditional annotation
+	 * @param contextParam the relative param to retrieve target params from
+	 * @return the relative target params
+	 */
+	protected Set<Param<?>> getTargetPathParams(Annotation configuredAnnotation, Param<?> contextParam) {
+		return Stream.of(getAttributeTargetPath(configuredAnnotation))
+				.map(targetPath -> retrieveParamByPath(contextParam, targetPath)).collect(Collectors.toSet());
+	}
+
+	/**
+	 * <p>Execute the conditional logic provided in {@code configuredAnnotation}
+	 * and based on it's result, execute subclass logic for each target param
+	 * also provided in {@code configuredAnnotation}. <p>This method is
+	 * effectively the same as an if/else block, where the logic to execute when
+	 * a condition is true is delegated to subclasses.
+	 * @param onChangeParam the source parameter (annotated field)
+	 * @param configuredAnnotation the conditional annotation decorating
+	 *            {@code onChangeParam}
+	 * @return the result of the conditional evaluation
+	 */
+	@SuppressWarnings("unchecked")
+	protected boolean handleConditionalExecution(Param<?> onChangeParam, Annotation configuredAnnotation,
+			Set<Param<?>> targetParams) {
+		boolean result = evaluateWhen(configuredAnnotation, onChangeParam);
+		TriConsumer<A, Param<?>, Param<?>> consumer = this::whenFalse;
+		if (result) {
+			consumer = this::whenTrue;
+		}
+
+		for (Param<?> targetParam : targetParams) {
+			consumer.accept((A) configuredAnnotation, onChangeParam, targetParam);
+		}
+
+		return result;
+	}
+
+	@Override
+	protected void handleInternal(Param<?> onChangeParam, A configuredAnnotation) {
+		handleConditionalExecution(onChangeParam, configuredAnnotation,
+				this.getTargetPathParams(configuredAnnotation, onChangeParam));
+	}
+
+	/**
+	 * <p>Execute the logic that should occur when this conditional state event
+	 * handler evaluates to {@code false}.
+	 * @param configuredAnnotation the conditional annotation decorating
+	 *            {@code onChangeParam}
+	 * @param onChangeParam the source parameter (annotated field)
+	 * @param targetParam the param to execute the logic on
+	 */
+	protected abstract void whenFalse(A configuredAnnotation, Param<?> onChangeParam, Param<?> targetParam);
+
+	/**
+	 * <p>Execute the logic that should occur when this conditional state event
+	 * handler evaluates to {@code true}.
+	 * @param configuredAnnotation the conditional annotation decorating
+	 *            {@code onChangeParam}
+	 * @param onChangeParam the source parameter (annotated field)
+	 * @param targetParam the param to execute the logic on
+	 */
+	protected abstract void whenTrue(A configuredAnnotation, Param<?> onChangeParam, Param<?> targetParam);
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
@@ -99,7 +99,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t1_useDefault_handleResetOnChange() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, true, new String[] { "../targetParam" });
 		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -123,7 +123,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t2_useDefault_handleDontResetOnChange_noDefaultValues() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, new String[] {"../targetParam"});
 		
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -144,7 +144,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t3_useDefault_handleDontResetOnChange_stateIsAlreadyNull() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, new String[] {"../targetParam"});
 		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -169,7 +169,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t4_useDefault_handleDontResetOnChange_previousStateNotFoundInNewValues() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, new String[] {"../targetParam"});
 		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -194,7 +194,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	
 	@Test
 	public void t5_useDefault_handleDontResetOnChange_preservePreviousState() {
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{}, true, Event.DEFAULT_ORDER_NUMBER, false, new String[] {"../targetParam"});
 		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -221,7 +221,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	public void t6_exclusive_handleResetOnChange() {
 		final Condition condition1 = createCondition("condition1expr", createValues(SAMPLE_VALUES.class, null));
 		final Condition condition2 = createCondition("condition2expr", createValues(SAMPLE_VALUES.class, null));
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1, condition2 }, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1, condition2 }, true, Event.DEFAULT_ORDER_NUMBER, true, new String[] {"../targetParam"});
 		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -250,7 +250,7 @@ public class ValuesConditionalStateEventHandlerTest {
 		final Condition condition1 = createCondition("condition1expr", createValues(SAMPLE_VALUES.class, null));
 		final Condition condition2 = createCondition("condition2expr", createValues(SAMPLE_VALUES.class, null));
 		final Condition condition3 = createCondition("condition3expr", createValues(SAMPLE_VALUES.class, null));
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1, condition2, condition3 }, false, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1, condition2, condition3 }, false, Event.DEFAULT_ORDER_NUMBER, true, new String[] {"../targetParam"});
 		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -279,7 +279,7 @@ public class ValuesConditionalStateEventHandlerTest {
 	@Test
 	public void t8_useDefault_targetParamDisabled() {
 		final Condition condition1 = createCondition("condition1expr", createValues(SAMPLE_VALUES.class, null));
-		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1 }, true, Event.DEFAULT_ORDER_NUMBER, true, "../targetParam");
+		final ValuesConditional configuredAnnotation = createValuesConditional(new Condition[]{ condition1 }, true, Event.DEFAULT_ORDER_NUMBER, true, new String[] {"../targetParam"});
 		final Values defaultValues = createValues(SAMPLE_VALUES.class, null);
 		final ParamEvent event = Mockito.mock(ParamEvent.class);
 		final MockParam decoratedParam = new MockParam();
@@ -348,7 +348,7 @@ public class ValuesConditionalStateEventHandlerTest {
 		};
 	}
 	
-	private ValuesConditional createValuesConditional(Condition[] condition, boolean exclusive, int order, boolean resetOnChange, String targetPath) {
+	private ValuesConditional createValuesConditional(Condition[] condition, boolean exclusive, int order, boolean resetOnChange, String[] targetPath) {
 		return new ValuesConditional() {
 
 			@Override
@@ -377,7 +377,7 @@ public class ValuesConditionalStateEventHandlerTest {
 			}
 
 			@Override
-			public String targetPath() {
+			public String[] targetPath() {
 				return targetPath;
 			}
 			


### PR DESCRIPTION
# Description
Refactored the conditional annotation support classes for cleaner code and better extensible support.

# Overview of Changes
* `@LabelConditional`, `@StyleConditional`, `@ValuesConditional` now accept `targetPath` as a `String[]` (previously was `String`).
* Deprecated `EvalExprWithCrudActions` and `EvalExprWithCrudDefaults`
* Introduced new core conditional state event handler support classes
  * `IfElseConditionalStateEventHandler`
  * `AssignThenToTargetCaseConditionalHandler`
* Minor support changes
  * Added trace logging to monitor evaluation logic for `com.antheminc.oss.nimbus.domain.model.state.extension` classes.
  * Enhanced error messages
* Fixed an issue where `ParamStateHolder` was being wrapped around a `Param` more than once in some annotation handlers.

# Type of Change
- [ ] New feature
- [ ] Bug fix
- [X] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details
Conditional test cases

# Additional Notes

N/A
