### PR TITLE
NIMBUS-265: @PickList fix for filter

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/form-builder.service.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-builder.service.ts
@@ -78,20 +78,6 @@ export class FormElementsService {
           } else {
             // Adding this for picklist since form submit does not handle complex type - Revisit
             group[element.config.code] = this.createNewFormGroup(element);
-            const picklistparam: Param = element.type.model.params.find(
-              p => p.alias === ViewComponent.selectedPicklist.toString()
-            );
-            var leafState = this._getTypeSafeLeafState(picklistparam);
-            if (checks) {
-              group[picklistparam.config.code] = [
-                { value: leafState, disabled: !picklistparam.enabled },
-                checks
-              ];
-            } else {
-              group[picklistparam.config.code] = [
-                { value: leafState, disabled: !picklistparam.enabled }
-              ];
-            }
           }
           //create new formgroup and formcontrol to create checkboxes in form. this is for form binding. TODO validations binding
         } else {

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.html
@@ -35,10 +35,6 @@
          </nm-treegrid>
     </ng-template>
 
-    <ng-template ngFor let-msg [ngForOf]="elemMessages">
-        <nm-message id="{{element.config?.code}}" [messageContext]="msg.context"  [messageArray]="msg.messageArray" [life] = "msg.life" [styleClass]="msg.styleClass"></nm-message>
-    </ng-template>
-
     <ng-template [ngIf]="element?.config?.uiStyles?.attributes?.alias === viewComponent.picklist.toString()">
         <div [formGroup]="form.controls[element?.config?.code]">
             <ng-template ngFor let-selectededparam [ngForOf]="element?.type?.model?.params">
@@ -47,5 +43,9 @@
                 </ng-template>
             </ng-template>
         </div>                
+    </ng-template>
+
+    <ng-template ngFor let-msg [ngForOf]="elemMessages">
+        <nm-message id="{{element.config?.code}}" [messageContext]="msg.context"  [messageArray]="msg.messageArray" [life] = "msg.life" [styleClass]="msg.styleClass"></nm-message>
     </ng-template>
 </div>

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.html
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.html
@@ -40,10 +40,12 @@
     </ng-template>
 
     <ng-template [ngIf]="element?.config?.uiStyles?.attributes?.alias === viewComponent.picklist.toString()">
-        <ng-template ngFor let-selectededparam [ngForOf]="element?.type?.model?.params">
-            <ng-template [ngIf]= "selectededparam?.config?.uiStyles?.attributes?.alias === viewComponent.selectedPicklist.toString()">
-                <nm-pickList id="{{element.config?.code}}" [parent]="element" [selectedvalues]="selectededparam.values" [formControlName]="selectededparam.config?.code" ngDefaultControl [element]="selectededparam" [form]="form"></nm-pickList> 
+        <div [formGroup]="form.controls[element?.config?.code]">
+            <ng-template ngFor let-selectededparam [ngForOf]="element?.type?.model?.params">
+                <ng-template [ngIf]= "selectededparam?.config?.uiStyles?.attributes?.alias === viewComponent.selectedPicklist.toString()">
+                    <nm-pickList id="{{element.config?.code}}" [parent]="element" [selectedvalues]="selectededparam.values" [formControlName]="selectededparam.config?.code" ngDefaultControl [element]="selectededparam" [form]="form.controls[element?.config?.code]"></nm-pickList> 
+                </ng-template>
             </ng-template>
-        </ng-template>                
+        </div>                
     </ng-template>
 </div>

--- a/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form-element.component.ts
@@ -34,6 +34,7 @@ import { CounterMessageService } from './../../services/counter-message.service'
 import { Constraint } from './../../shared/param-config';
 import { ConstraintMapping } from './../../shared/validationconstraints.enum';
 import { BaseElement } from './base-element.component';
+import { ParamUtils } from '../../shared/param-utils';
 
 var counter = 0;
 
@@ -155,13 +156,21 @@ export class FormElement extends BaseElement {
    */
   updateErrorMessages() {
     var control: AbstractControl = this.form.controls[this.element.config.code];
+    // TODO needs to be removed when refactoring @PickList
+    // start REMOVE_ME
+    if (control instanceof FormGroup) {
+      control = control.controls[Object.keys(control.controls)[0]]
+    }
+    // end REMOVE_ME
     if (control.invalid) {
       let errs: ValidationErrors = control.errors;
       for (var key in errs) {
         let constraintName = ConstraintMapping.getConstraintValue(key);
-        let constraint: Constraint = this.element.config.validation.constraints.find(
-          v => v.name == constraintName
-        );
+        // TODO needs to be removed/refactored when refactoring @PickList
+        // start REFACTOR_ME
+        let constraintParam = !ParamUtils.isNested(this.element) ? this.element : this.element.type.model.params[0];
+        let constraint: Constraint = constraintParam.config.validation.constraints.find(v => v.name == constraintName);
+        // end REFACTOR_ME
         this.addErrorMessages(constraint.attribute.message);
         const index = this.componentClass.indexOf(this.errorStyles, 0);
         if (index < 0) {

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
@@ -117,16 +117,6 @@ export class OrderablePickList extends BaseElement
     this._disabled = value;
   }
 
-  get value() {
-    return this._value;
-  }
-
-  set value(val) {
-    this._value = val;
-    this.onChange(val);
-    this.onTouched();
-  }
-
   constructor(
     private pageService: PageService,
     private counterMessageService: CounterMessageService
@@ -274,6 +264,16 @@ export class OrderablePickList extends BaseElement
     this.value = newState;
     this.setState(newState, this);
     this.emitValueChangedEvent();
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(val) {
+    this._value = val;
+    this.onChange(val);
+    this.onTouched();
   }
 
   findIndexInList(item: Values, list: Values[]): number {

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
@@ -135,7 +135,8 @@ export class OrderablePickList extends BaseElement
   }
 
   ngOnInit() {
-    this.requiredCss = ValidationUtils.applyelementStyle(this.parent);
+    // this.requiredCss = ValidationUtils.applyelementStyle(this.parent);
+    super.ngOnInit();
     this.updateComponentLists();
     if (this.form != null) {
       const frmCtrl = this.form.controls[this.element.config.code];
@@ -154,17 +155,14 @@ export class OrderablePickList extends BaseElement
         this.subscribers.push(frmCtrl.valueChanges.subscribe($event => {
           this.setState($event, this);
           // setting parent Picklist value manually
-          if (!$event || !$event.config) {
-            return;
-          }
-          let frmCtrl = this.form.controls[$event.config.code];
+          let frmCtrl = this.form.controls[this.element.config.code];
           if (frmCtrl) {
             if (frmCtrl.valid && this.sendEvent) {
               this.counterMessageService.evalCounterMessage(true);
-              this.counterMessageService.evalFormParamMessages(this.element);
+              this.counterMessageService.evalFormParamMessages(this.parent);
               this.sendEvent = false;
             } else if (frmCtrl.invalid && !frmCtrl.pristine) {
-              this.counterMessageService.evalFormParamMessages(this.element);
+              this.counterMessageService.evalFormParamMessages(this.parent);
               this.counterMessageService.evalCounterMessage(true);
               this.sendEvent = true;
             }

--- a/nimbus-ui/nimbusui/src/app/shared/param-state.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-state.ts
@@ -240,6 +240,13 @@ export class Values implements Serializable<Values, string> {
     obj = Converter.convert(inJson, obj);
     return obj;
   }
+
+  static of(code: string, label: string): Values {
+    return new Values().deserialize({
+      code: code,
+      label: label
+    });
+  }
 }
 
 export class Model implements Serializable<Model, string> {

--- a/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
+++ b/nimbus-ui/nimbusui/src/app/shared/param-utils.ts
@@ -329,6 +329,10 @@ export class ParamUtils {
     return true;
   }
 
+  public static isNested(p: Param): boolean {
+    return p && p.type && p.type.model && p.type.model.params && p.type.model.params.length > 0;
+  }
+
   static getLabelConfig(labelConfigs: LabelConfig[]) {
     if (!labelConfigs || labelConfigs.length === 0) {
       return undefined;


### PR DESCRIPTION
# Description
Fixes #564 

# Overview of Changes
* Refactored the `@Picklist` typescript logic to be cleaner, more concise.
  * `sourceList` and `targetList` were incorrectly storing `string[]` in `onInit()`, instead of `Values[]`. This has been corrected and fixes the filter functionality.
  * the `leafState` from the server is converted to `Values` on the client side and converted back to `string[]` before being sent to the server.
* If `@Values` are not set for `@PickList` or `@PickListSelected`, and an existing state exists, the plain value of the state will be shown (previously was an empty string). Ideally, `@Values` should always be set.

# Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details
Functional testing in petclinic

# Additional Notes

N/A
