### PR TITLE
NIMBUS-268: ParamValues Cache

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Constants.java
@@ -69,7 +69,10 @@ public enum Constants {
 	
 	CODE_VALUE_CONFIG_DELIMITER("-"),
 	PARAM_VALUES_URI_PREFIX("*/*/*/p/"),
-	PARAM_VALUES_URI_SUFFIX("/_lookup"),
+	PARAM_VALUES_LOOKUP_FN_KEY("lookup"),
+	PARAM_VALUES_URI_SUFFIX("/_" + Constants.PARAM_VALUES_LOOKUP_FN_KEY.code),
+	PARAM_VALUES_DOMAIN_ALIAS("staticCodeValue"),
+	PARAM_VALUES_CACHE_KEY("staticcodevalues"),
 	
 	KEY_FUNCTION("fn"),
 	KEY_FUNCTION_NAME("name"),

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Model.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/defn/Model.java
@@ -68,6 +68,17 @@ public @interface Model {
 			Class<? extends Source> value() default EMPTY.class;
 			
 			String url() default "staticCodeValue";
+			
+			/**
+			 * <p>When {@code true}, attempts to retrieve
+			 * {@code "staticCodeValue"} calls made with {@link #url()} from the
+			 * "staticcodevalues" cache. <p>Note: There are other layers of
+			 * caching defined within the {@link Command} execution lifecycle,
+			 * but enabling this property will result in a more aggressive cache
+			 * retrieval strategy by fetching from the cache before the
+			 * {@link Command} has a chance to execute.
+			 */
+			boolean useParamValuesCacheOnLoad() default true;
 		}
 
 	}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandler.java
@@ -31,6 +31,7 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandPathVariableResolver;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values;
+import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.CacheType;
 import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.EMPTY;
 import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.Source;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
@@ -83,16 +84,19 @@ public class DefaultParamValuesHandler implements ParamValuesOnLoadHandler {
 
 				// retrieve staticCodeValue lookup searches from cache if it
 				// exists, otherwise continue
-				if (null != this.cacheManager
-						&& cmd.getRootDomainAlias().equals(Constants.PARAM_VALUES_DOMAIN_ALIAS.code)
-						&& Action._search == cmd.getAction() && Constants.PARAM_VALUES_LOOKUP_FN_KEY.code
-								.equals(cmd.getFirstParameterValue(Constants.KEY_FUNCTION.code))) {
-					Cache cache = this.cacheManager.getCache(Constants.PARAM_VALUES_CACHE_KEY.code);
-					if (null != cache) {
-						ValueWrapper cacheValue = cache.get(cmd.getFirstParameterValue("where"));
-						if (null != cacheValue) {
-							return (List<ParamValue>) cacheValue.get();
+				if (cmd.getRootDomainAlias().equals(Constants.PARAM_VALUES_DOMAIN_ALIAS.code)
+						&& values.useParamValuesCacheOnLoad()) {
+					if (null != this.cacheManager) {
+						Cache cache = this.cacheManager.getCache(Constants.PARAM_VALUES_CACHE_KEY.code);
+						if (null != cache) {
+							ValueWrapper cacheValue = cache.get(cmd.getFirstParameterValue("where"));
+							if (null != cacheValue) {
+								return (List<ParamValue>) cacheValue.get();
+							}
 						}
+					} else {
+						logIt.warn(() -> "Param " + srcParam
+								+ " is configured with useCacheOnLoad, but the configured CacheManager is null.");
 					}
 				}
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandler.java
@@ -31,7 +31,6 @@ import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandPathVariableResolver;
 import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values;
-import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.CacheType;
 import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.EMPTY;
 import com.antheminc.oss.nimbus.domain.defn.Model.Param.Values.Source;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
@@ -43,17 +42,18 @@ import lombok.Getter;
 
 /**
  * @author Rakesh Patel
+ * @author Tony Lopez
  *
  */
 @Getter
 public class DefaultParamValuesHandler implements ParamValuesOnLoadHandler {
-	
+
 	private final JustLogit logIt = new JustLogit(DefaultParamValuesHandler.class);
 
 	protected final CommandPathVariableResolver pathVariableResolver;
 	protected final CommandExecutorGateway gateway;
 	private final CacheManager cacheManager;
-	
+
 	public DefaultParamValuesHandler(BeanResolverStrategy beanResolver) {
 		this.pathVariableResolver = beanResolver.get(CommandPathVariableResolver.class);
 		this.gateway = beanResolver.get(CommandExecutorGateway.class);
@@ -63,47 +63,67 @@ public class DefaultParamValuesHandler implements ParamValuesOnLoadHandler {
 	@Override
 	public void onStateLoad(Values configuredAnnotation, Param<?> param) {
 		List<ParamValue> result = buildParamValues(configuredAnnotation, param, param);
-		if(result != null)
+		if (result != null)
 			param.setValues(result);
 		else
-			logIt.warn(() -> "param values lookup returned null for param "+param+" with config "+configuredAnnotation);
+			logIt.warn(() -> "param values lookup returned null for param " + param + " with config "
+					+ configuredAnnotation);
 	}
-	
+
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<ParamValue> buildParamValues(Values values, Param<?> srcParam, Param<?> targetParam) {
-		if (values != null) {
-			if (values.value() != EMPTY.class) {
-				Source srcValues = ClassLoadUtils.newInstance(values.value());
-				return srcValues.getValues(targetParam.getConfig().getCode());
-			} else {
-				String valuesUrl = getPathVariableResolver().resolve(srcParam, values.url());
-				valuesUrl = srcParam.getRootExecution().getRootCommand().getRelativeUri(valuesUrl);
-				Command cmd = CommandBuilder.withUri(valuesUrl).getCommand();
-				cmd.setAction(Action._search);
+		if (values == null) {
+			return null;
+		}
 
-				// retrieve staticCodeValue lookup searches from cache if it
-				// exists, otherwise continue
-				if (cmd.getRootDomainAlias().equals(Constants.PARAM_VALUES_DOMAIN_ALIAS.code)
-						&& values.useParamValuesCacheOnLoad()) {
-					if (null != this.cacheManager) {
-						Cache cache = this.cacheManager.getCache(Constants.PARAM_VALUES_CACHE_KEY.code);
-						if (null != cache) {
-							ValueWrapper cacheValue = cache.get(cmd.getFirstParameterValue("where"));
-							if (null != cacheValue) {
-								return (List<ParamValue>) cacheValue.get();
-							}
-						}
-					} else {
-						logIt.warn(() -> "Param " + srcParam
-								+ " is configured with useCacheOnLoad, but the configured CacheManager is null.");
-					}
-				}
+		if (values.value() != EMPTY.class) {
+			return fromType(values, targetParam);
+		} else {
+			return fromCommandURL(values, srcParam);
+		}
+	}
 
-				MultiOutput multiOp = getGateway().execute(new CommandMessage(cmd, null));
-				return (List<ParamValue>) multiOp.getSingleResult();
+	protected List<ParamValue> fromType(Values values, Param<?> targetParam) {
+		Source srcValues = ClassLoadUtils.newInstance(values.value());
+		return srcValues.getValues(targetParam.getConfig().getCode());
+	}
+
+	@SuppressWarnings("unchecked")
+	protected List<ParamValue> fromCommandURL(Values values, Param<?> srcParam) {
+		String valuesUrl = getPathVariableResolver().resolve(srcParam, values.url());
+		valuesUrl = srcParam.getRootExecution().getRootCommand().getRelativeUri(valuesUrl);
+		Command cmd = CommandBuilder.withUri(valuesUrl).getCommand();
+		cmd.setAction(Action._search);
+
+		// retrieve staticCodeValue lookup searches from cache if it
+		// exists, otherwise continue
+		if (cmd.getRootDomainAlias().equals(Constants.PARAM_VALUES_DOMAIN_ALIAS.code)
+				&& values.useParamValuesCacheOnLoad()) {
+			List<ParamValue> cachedValue = getCachedParamValue(cmd);
+			if (null != cachedValue) {
+				return cachedValue;
 			}
 		}
-		return null;
+
+		MultiOutput multiOp = getGateway().execute(new CommandMessage(cmd, null));
+		return (List<ParamValue>) multiOp.getSingleResult();
+	}
+
+	@SuppressWarnings("unchecked")
+	protected List<ParamValue> getCachedParamValue(Command cmd) {
+		if (null == this.cacheManager) {
+			logIt.warn(() -> "Attempted to retrieve a cached value via command: " + cmd
+					+ ", but the configured CacheManager is null.");
+			return null;
+		}
+		Cache cache = this.cacheManager.getCache(Constants.PARAM_VALUES_CACHE_KEY.code);
+		if (null == cache) {
+			return null;
+		}
+		ValueWrapper cacheValue = cache.get(cmd.getFirstParameterValue("where"));
+		if (null == cacheValue) {
+			return null;
+		}
+		return (List<ParamValue>) cacheValue.get();
 	}
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VPSampleViewPageGreen.java
@@ -120,6 +120,10 @@ public class VPSampleViewPageGreen {
 		@Values(url = "a/b/p/sampletask/_search?fn=lookup&projection.mapsTo=code:taskName,label:taskName")
 		private String comboboxWithStringId;
 		
+		@ComboBox
+		@Values(url = "/p/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/foo')")
+		private String comboBoxStaticCodeValuesLookup;
+		
 		@TextBox(postEventOnChange = true)
 		@Path
 		@ActivateConditional(when = "state == 'showit'", targetPath = "/../unmappedNested")

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandlerTest.java
@@ -1,0 +1,91 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.domain.model.state.extension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.antheminc.oss.nimbus.domain.AbstractFrameworkIngerationPersistableTests;
+import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
+import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.entity.StaticCodeValue;
+import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.domain.support.utils.ParamUtils;
+
+
+/**
+ * @author Tony Lopez
+ *
+ */
+public class DefaultParamValuesHandlerTest extends AbstractFrameworkIngerationPersistableTests {
+
+	@Autowired
+	private CacheManager cacheManager;
+	
+	@Before
+	@Override
+	public void before() {
+		super.before();
+		// load static code values
+		mongo.insert(getSampleValues(), Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
+	}
+
+	private StaticCodeValue getSampleValues() {
+		StaticCodeValue foo = new StaticCodeValue("/foo", new ArrayList<>());
+		foo.setId(1L);
+		foo.getParamValues().add(new ParamValue());
+		foo.getParamValues().get(0).setCode("bar");
+		foo.getParamValues().get(0).setLabel("Bar");
+		return foo;
+	}
+	
+	@Test
+	public void testCommandDSLRetrieval() {
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
+		Object response = controller.handleGet(request, null);
+		
+		Param<String> viewRoot = ParamUtils.extractResponseByParamPath(response, "/sample_view");
+		Param<String> actual = viewRoot.findParamByPath("/page_green/tile/view_sample_form/comboBoxStaticCodeValuesLookup");
+		Assert.assertTrue(CollectionUtils.isEqualCollection(getSampleValues().getParamValues(), actual.getValues()));
+	}
+	
+	@Test
+	public void testCacheRetrieval() {
+		// populate the cache with the expected content
+		List<ParamValue> expected = new ArrayList<>();
+		expected.add(new ParamValue());
+		expected.get(0).setCode("baz");
+		expected.get(0).setLabel("Baz");
+		cacheManager.getCache(Constants.PARAM_VALUES_CACHE_KEY.code).put("staticCodeValue.paramCode.eq('/foo')", expected);
+		
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(VIEW_PARAM_ROOT).addAction(Action._new).getMock();
+		Object response = controller.handleGet(request, null);
+
+		Param<String> viewRoot = ParamUtils.extractResponseByParamPath(response, "/sample_view");
+		Param<String> actual = viewRoot.findParamByPath("/page_green/tile/view_sample_form/comboBoxStaticCodeValuesLookup"); 
+		Assert.assertTrue(CollectionUtils.isEqualCollection(expected, actual.getValues()));
+	}
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ValuesConditionalStateEventHandlerTest.java
@@ -344,6 +344,11 @@ public class ValuesConditionalStateEventHandlerTest {
 			public String url() {
 				return url;
 			}
+
+			@Override
+			public boolean useParamValuesCacheOnLoad() {
+				return true;
+			}
 			
 		};
 	}


### PR DESCRIPTION
# Description
Fixes #566 

# Overview of Changes
* Invokes the `staticCodeValues` cache prior to `@Config` execution
* Introduced new constants

# Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details

N/A

# Additional Notes

N/A
