### PR TITLE
NIMBUS-273: fix staticCodeValue caching issue

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProvider.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProvider.java
@@ -32,6 +32,7 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutor;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
 import com.antheminc.oss.nimbus.domain.model.state.HierarchyMatch;
@@ -50,7 +51,6 @@ public class ParamCodeValueProvider implements HierarchyMatch, CommandExecutor<L
 	
 	private static final String DEFAULT_KEY_ATTRIBUTE = "id";
 	private static final String KEY_VALUE_SEPERATOR = "&";
-	public static final String STATIC_CODE_VALUE = "staticCodeValue";
 	
 	DefaultActionExecutorSearch searchExecutor;
 	
@@ -76,7 +76,7 @@ public class ParamCodeValueProvider implements HierarchyMatch, CommandExecutor<L
 	public Output<List<ParamValue>> execute(Input input) {
 		CommandMessage cmdMsg = input.getContext().getCommandMessage();
 		final List<ParamValue> codeValues;
-		if(StringUtils.equalsIgnoreCase(cmdMsg.getCommand().getElementSafely(Type.DomainAlias).getAlias(), STATIC_CODE_VALUE)) {
+		if(StringUtils.equalsIgnoreCase(cmdMsg.getCommand().getElementSafely(Type.DomainAlias).getAlias(), Constants.PARAM_VALUES_DOMAIN_ALIAS.code)) {
 			codeValues = getStaticCodeValue(input);
 		}
 		else{

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/search/DefaultSearchFunctionHandlerLookup.java
@@ -72,7 +72,8 @@ public class DefaultSearchFunctionHandlerLookup<T, R> extends DefaultSearchFunct
 	@Override
 	@Cacheable(value="staticcodevalues", 
 		key = "#executionContext.getCommandMessage().getCommand().getFirstParameterValue(\"where\")", 
-		condition= "T(org.apache.commons.lang3.StringUtils).equalsIgnoreCase(#executionContext.getCommandMessage().getCommand().getElementSafely(T(com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type).DomainAlias).getAlias(), \"staticCodeValue\")")
+		condition = "T(org.apache.commons.lang3.StringUtils).equalsIgnoreCase(#executionContext.getCommandMessage().getCommand().getElementSafely(T(com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type).DomainAlias).getAlias(), \"staticCodeValue\")",
+		unless = "#result == null")
 	public R execute(ExecutionContext executionContext, Param<T> actionParameter) {
 		
 		ModelConfig<?> mConfig = getRootDomainConfig(executionContext);
@@ -80,7 +81,7 @@ public class DefaultSearchFunctionHandlerLookup<T, R> extends DefaultSearchFunct
 		List<?> searchResult = (List<?>)super.execute(executionContext, actionParameter);
 				
 		Command cmd = executionContext.getCommandMessage().getCommand();
-		if(StringUtils.equalsIgnoreCase(cmd.getElementSafely(Type.DomainAlias).getAlias(), "staticCodeValue")) {
+		if(StringUtils.equalsIgnoreCase(cmd.getElementSafely(Type.DomainAlias).getAlias(), Constants.PARAM_VALUES_DOMAIN_ALIAS.code)) {
 			return getStaticParamValues((List<StaticCodeValue>)searchResult, mConfig, cmd);
 		}
 		return getDynamicParamValues(mConfig, searchResult, cmd);

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProviderUnitTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/ParamCodeValueProviderUnitTest.java
@@ -34,6 +34,7 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Input;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.cmd.exec.ExecutionContext;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
 import com.antheminc.oss.nimbus.entity.StaticCodeValue;
 
@@ -72,7 +73,7 @@ public class ParamCodeValueProviderUnitTest {
 		Output<List<StaticCodeValue>> searchResultsOutput = Output.instantiate(input, eCtx);
 		searchResultsOutput.setValue(searchResults);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		Mockito.when(this.searchExecutor.execute(input)).thenReturn(searchResultsOutput);
 		
 		Assert.assertNull(this.testee.execute(input).getValue());
@@ -100,7 +101,7 @@ public class ParamCodeValueProviderUnitTest {
 		Output<List<StaticCodeValue>> searchResultsOutput = Output.instantiate(input, eCtx);
 		searchResultsOutput.setValue(searchResults);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		Mockito.when(this.searchExecutor.execute(input)).thenReturn(searchResultsOutput);
 		
 		Assert.assertEquals(expected, this.testee.execute(input).getValue());
@@ -129,7 +130,7 @@ public class ParamCodeValueProviderUnitTest {
 		Output<List<StaticCodeValue>> searchResultsOutput = Output.instantiate(input, eCtx);
 		searchResultsOutput.setValue(searchResults);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		Mockito.when(this.searchExecutor.execute(input)).thenReturn(searchResultsOutput);
 		
 		this.testee.execute(input).getValue();
@@ -160,7 +161,7 @@ public class ParamCodeValueProviderUnitTest {
 		values.put(codeKey, expected);
 		this.testee.setValues(values);
 	
-		Mockito.when(domainCmdElem.getAlias()).thenReturn(ParamCodeValueProvider.STATIC_CODE_VALUE);
+		Mockito.when(domainCmdElem.getAlias()).thenReturn(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		Mockito.when(commandMessage.getRawPayload()).thenReturn(rawPayload);
 		
 		Assert.assertEquals(expected, this.testee.execute(input).getValue());

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/builder/DefaultActionExecutorSearchTest.java
@@ -46,6 +46,7 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
 import com.antheminc.oss.nimbus.domain.cmd.CommandMessage;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
+import com.antheminc.oss.nimbus.domain.defn.Constants;
 import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecutorGateway;
 import com.antheminc.oss.nimbus.domain.model.config.ParamValue;
 import com.antheminc.oss.nimbus.domain.model.state.extension.StaticCodeValueBasedCodeToLabelConverter;
@@ -76,7 +77,6 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	protected static final String CLIENT_USER_ALIAS = "clientuser";
 	protected static final String CLIENT_USER_GROUP_ALIAS = "clientusergroup";
 	protected static final String QUEUE_ALIAS = "queue";
-	protected static final String STATIC_CODE_VALUE_ALIAS = "staticCodeValue";
 	
 	private static final String[] COLLECTIONS = {QUEUE_ALIAS, CLIENT_USER_ALIAS, CLIENT_USER_GROUP_ALIAS,SAMPLE_CORE_ENTITY_ACCESS_ALIAS};
 	
@@ -92,13 +92,13 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	
 	@Test
 	public void t1_testSearchByLookupStaticCodeValue() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue("code1", "label1", "desc1"));
 		final StaticCodeValue expected = new StaticCodeValue("/status0", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/status0')");
 		
@@ -122,14 +122,14 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	 */
 	@Test
 	public void t0_testSearchByLookupStaticCodeValue_inMemorySorted() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue(Long.valueOf(1), "label1", "desc1"));
 		expectedValues.add(new ParamValue(Long.valueOf(2), "label2", "desc2"));
 		final StaticCodeValue expected = new StaticCodeValue("/status1", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=lookup&where=staticCodeValue.paramCode.eq('/status1')&orderby=code.desc()");
 		
@@ -155,21 +155,21 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	 */
 	@Test
 	public void testSearchByLookupStaticCodeValue_dbsorted() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue(Long.valueOf(1), "slabel1", "sdesc1"));
 		expectedValues.add(new ParamValue(Long.valueOf(2), "slabel2", "sdesc2"));
 		final StaticCodeValue expected = new StaticCodeValue("/status1", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		final List<ParamValue> expectedValues2 = new ArrayList<>();
 		expectedValues2.add(new ParamValue(Long.valueOf(1), "clabel1", "cdesc1"));
 		expectedValues2.add(new ParamValue(Long.valueOf(2), "clabel2", "cdesc2"));
 		final StaticCodeValue expected2 = new StaticCodeValue("/category", expectedValues);
 		expected2.setId(new Random().nextLong());
-		this.mongoOps.insert(expected2, "staticCodeValue");
+		this.mongoOps.insert(expected2, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&orderby=staticCodeValue.paramCode.desc()");
 		
@@ -199,12 +199,12 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	
 	@Test
 	public void t11_testSearchByLookupStaticCodeValueElemMatch() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue("ACL", "Anticardiolpin Antibodies", null));
 		final StaticCodeValue expected = new StaticCodeValue("anything", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		assertEquals("Anticardiolpin Antibodies", this.labelConverter.serialize("ACL"));
 	}
@@ -277,12 +277,12 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 
 	@Test
 	public void t5_testSearchByQueryWithProjection() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		final List<ParamValue> expectedValues = new ArrayList<>();
 		expectedValues.add(new ParamValue("code1", "label1", "desc1"));
 		final StaticCodeValue expected = new StaticCodeValue("/status", expectedValues);
 		expected.setId(new Random().nextLong());
-		this.mongoOps.insert(expected, "staticCodeValue");
+		this.mongoOps.insert(expected, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&where=staticCodeValue.paramCode.eq('/status')&projection.alias=vstaticCodeValue");
 		
@@ -445,13 +445,13 @@ public class DefaultActionExecutorSearchTest extends AbstractFrameworkIntegratio
 	
 	@Test
 	public void t6_testSearchByQueryWithCountAggregation() {
-		this.mongoOps.dropCollection("staticCodeValue");
+		this.mongoOps.dropCollection(Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		StaticCodeValue scv = new StaticCodeValue("/status", null);
 		scv.setId(new Random().nextLong());
 		StaticCodeValue scv2 = new StaticCodeValue("/status", null);
 		scv2.setId(new Random().nextLong());
-		this.mongoOps.insert(scv, "staticCodeValue");
-		this.mongoOps.insert(scv2, "staticCodeValue");
+		this.mongoOps.insert(scv, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
+		this.mongoOps.insert(scv2, Constants.PARAM_VALUES_DOMAIN_ALIAS.code);
 		
 		CommandMessage cmdMsg = build(PLATFORM_ROOT+"/staticCodeValue/_search?fn=query&where=staticCodeValue.paramCode.eq('/status')&aggregate=count");
 		

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandlerTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/DefaultParamValuesHandlerTest.java
@@ -69,6 +69,7 @@ public class DefaultParamValuesHandlerTest extends AbstractFrameworkIngerationPe
 		
 		Param<String> viewRoot = ParamUtils.extractResponseByParamPath(response, "/sample_view");
 		Param<String> actual = viewRoot.findParamByPath("/page_green/tile/view_sample_form/comboBoxStaticCodeValuesLookup");
+		Assert.assertNotNull(actual.getValues());
 		Assert.assertTrue(CollectionUtils.isEqualCollection(getSampleValues().getParamValues(), actual.getValues()));
 	}
 	


### PR DESCRIPTION
# Description
Supplemental change for #566. Fixes test case failure introduced from #569

# Overview of Changes
* Skips cache retrieval for `null` entries in the `staticCodeValue` cache abstraction
* Polish (`"staticCodeValue"` constant replacements) 

# Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details
* `DefaultParamValuesHandlerTest`

# Additional Notes

N/A
