### PR TITLE
NIMBUS-275: clear files on changes to fileupload

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/fileupload/file-upload.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/fileupload/file-upload.component.ts
@@ -36,6 +36,8 @@ import { CounterMessageService } from './../../../services/counter-message.servi
 import { FileService } from './../../../services/file.service';
 import { LoggerService } from './../../../services/logger.service';
 import { ServiceConstants } from './../../../services/service.constants';
+import { PageService } from './../../../services/page.service';
+import { FileUpload } from 'primeng/primeng';
 
 export const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -78,11 +80,12 @@ export class FileUploadComponent extends BaseElement
   @Input('value') _value;
   selectedFiles: File[];
   multipleFiles: boolean = false;
-  @ViewChild('pfu') pfu;
+  @ViewChild('pfu') pfu: FileUpload;
   sendEvent: boolean = true;
 
   constructor(
     private fileService: FileService,
+    private pageService: PageService,
     private logger: LoggerService,
     private counterMessageService: CounterMessageService
   ) {
@@ -142,6 +145,15 @@ export class FileUploadComponent extends BaseElement
   }
 
   ngAfterViewInit() {
+    this.subscribers.push(this.pageService.eventUpdate$.subscribe(event => {
+        if (event.path == this.element.path) {
+          this.selectedFiles = [];
+          this.value = [];
+          this.pfu.clear();
+        }
+      })
+    );
+
     if (
       this.form != undefined &&
       this.form.controls[this.element.config.code] != null
@@ -173,7 +185,7 @@ export class FileUploadComponent extends BaseElement
           this.selectedFiles = [];
           this.value = this.selectedFiles;
         }
-        if (this.pfu.isFileTypeValid(files[p])) {
+        if (this.pfu.validate(files[p])) {
           let file = files[p];
           this.selectedFiles.push(file);
           this.value = this.selectedFiles;


### PR DESCRIPTION
# Description
Fixes #572 

Reset the files that are temporarily added(upload not yet clicked) when visibility of the fileupload component changes.

# Overview of Changes
Invoked the clear() method to reset the files when server sends an update to the fileupload parameter.

# Type of Change
- [ ] Bug fix