### PR TITLE
NIMBUS-269: Relational DB Testing

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/CommandExecution.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/CommandExecution.java
@@ -185,10 +185,10 @@ public final class CommandExecution {
 			return result;
 		}
 		
-		@SuppressWarnings("unchecked")
 		@JsonIgnore
 		public <T> Output<T> findFirstParamOutputEndingWithPath(String path) {
-			return Optional.ofNullable((Output<T>) findParamOutputsEndingWithPath(path).get(0)).orElse(null);
+			List<Output<T>> results = findParamOutputsEndingWithPath(path);
+			return !CollectionUtils.isEmpty(results) ? results.get(0) : null;
 		}
 		
 	}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/core/AddressJPACoreEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/core/AddressJPACoreEntity.java
@@ -1,0 +1,81 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core;
+
+import static com.antheminc.oss.nimbus.domain.model.state.repo.db.rdbms.JPAConstants.SEQ_GEN_NAME;
+import static com.antheminc.oss.nimbus.domain.model.state.repo.db.rdbms.JPAConstants.SEQ_GEN_PARAM_K_NM;
+import static com.antheminc.oss.nimbus.domain.model.state.repo.db.rdbms.JPAConstants.SEQ_GEN_STRATEGY;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Domain(value = "address", includeListeners = { ListenerType.persistence })
+@Repo(Database.rep_rdbms)
+@Entity
+@Table(name = "ADDRESS")
+@Data
+@EqualsAndHashCode(callSuper=false)
+public class AddressJPACoreEntity extends IdLong {
+
+	private static final long serialVersionUID = 1L;
+
+	public AddressJPACoreEntity() {
+		
+	}
+	
+	public AddressJPACoreEntity(String line1) {
+		this.line1 = line1;
+	}
+	
+	@Id
+	@GeneratedValue(generator = SEQ_GEN_NAME)
+	@GenericGenerator(name = SEQ_GEN_NAME, strategy = SEQ_GEN_STRATEGY, parameters = @Parameter(name = SEQ_GEN_PARAM_K_NM, value = "SEQ_SAMPLE"))
+	@Override
+	public Long getId() {
+		return super.getId();
+	}
+	
+	private String line1;
+	private String line2;
+	private String line3;
+	private String zip;
+	private String zipExtn;
+	private String city;
+	private String state;
+	private String country;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/core/PersonJPACoreEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/core/PersonJPACoreEntity.java
@@ -1,0 +1,87 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core;
+
+import static com.antheminc.oss.nimbus.domain.model.state.repo.db.rdbms.JPAConstants.SEQ_GEN_NAME;
+import static com.antheminc.oss.nimbus.domain.model.state.repo.db.rdbms.JPAConstants.SEQ_GEN_PARAM_K_NM;
+import static com.antheminc.oss.nimbus.domain.model.state.repo.db.rdbms.JPAConstants.SEQ_GEN_STRATEGY;
+
+import java.util.List;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@Domain(value = "person", includeListeners = { ListenerType.persistence })
+@Repo(Database.rep_rdbms)
+@Entity
+@Table(name = "PERSON")
+@Data
+@EqualsAndHashCode(callSuper=false)
+public class PersonJPACoreEntity extends IdLong {
+
+	private static final long serialVersionUID = 1L;
+
+	public PersonJPACoreEntity() {
+		
+	}
+	
+	public PersonJPACoreEntity(String firstName, String lastName) {
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+	
+	@Id
+	@GeneratedValue(generator = SEQ_GEN_NAME)
+	@GenericGenerator(name = SEQ_GEN_NAME, strategy = SEQ_GEN_STRATEGY, parameters = @Parameter(name = SEQ_GEN_PARAM_K_NM, value = "SEQ_SAMPLE"))
+	@Override
+	public Long getId() {
+		return super.getId();
+	}
+
+	@Column
+	private String firstName;
+
+	@Column
+	private String lastName;
+	
+	@ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@JoinColumn(name = "address_id")
+	private AddressJPACoreEntity address;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/core/SampleJPARootCoreEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/core/SampleJPARootCoreEntity.java
@@ -22,6 +22,7 @@ import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
 import com.antheminc.oss.nimbus.entity.AbstractEntity.IdLong;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -35,10 +36,11 @@ import lombok.ToString;
 @Entity
 @Table(name="SAMPLE_JPA_CORE")
 @Getter @Setter @ToString
-public class SampleJPARootCoreEntity  extends IdLong {
+@EqualsAndHashCode(callSuper = false)
+public class SampleJPARootCoreEntity extends IdLong {
 
 	private static final long serialVersionUID = 1L;
-
+	
 	@Id
 	@GeneratedValue(generator=SEQ_GEN_NAME)
 	@GenericGenerator(name=SEQ_GEN_NAME, strategy=SEQ_GEN_STRATEGY, parameters=@Parameter(name=SEQ_GEN_PARAM_K_NM, value="SEQ_SAMPLE"))
@@ -49,4 +51,7 @@ public class SampleJPARootCoreEntity  extends IdLong {
 	
 	@Column
 	private String a1;
+	
+	@Column
+	private String a2;
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/view/PersonLineItem.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/view/PersonLineItem.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.view;
+
+import com.antheminc.oss.nimbus.domain.defn.MapsTo;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo.Path;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.GridColumn;
+import com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core.PersonJPACoreEntity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Tony Lopez
+ *
+ */
+@MapsTo.Type(PersonJPACoreEntity.class)
+@Getter @Setter
+public class PersonLineItem {
+
+	@GridColumn
+	@Path
+	private String firstName;
+	
+	@GridColumn
+	@Path
+	private String lastName;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/view/VRSampleJPARootViewEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/repo/rdbms/view/VRSampleJPARootViewEntity.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.view;
+
+import java.util.List;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo.Path;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Grid;
+import com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core.SampleJPARootCoreEntity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 
+ * @author Tony Lopez
+ *
+ */
+@Domain(value = "sample_jpa_view", includeListeners = { ListenerType.websocket })
+@MapsTo.Type(SampleJPARootCoreEntity.class)
+@Repo(Database.rep_none)
+@Getter
+@Setter
+public class VRSampleJPARootViewEntity {
+
+	@Grid
+	@Config(url = "/p/person/_search?fn=query&where=<!filterCriteria!>")
+	@Path(linked = false)
+	private List<PersonLineItem> people;
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/rdbms/DefaultJPAModelRepositoryTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/rdbms/DefaultJPAModelRepositoryTest.java
@@ -178,6 +178,11 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 		assertThat(_newResponse).isNotNull();
 		Long refId = _newResponse.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
 		assertThat(refId).isNotNull();
+		
+		MultiOutput _saveResponse = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse).isNotNull();
 
 		StringBuilder query = new StringBuilder(FH_SEARCH_BY_QUERY).append("&where=")
 				.append("person.lastName.eq('Doe-BasicQuery')");
@@ -210,6 +215,12 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 		Param<PersonJPACoreEntity> pPerson = (Param<PersonJPACoreEntity>) _newResponse.getSingleResult();
 		assertThat(pPerson).isNotNull();
 		assertThat(pPerson.getState()).isEqualTo(expectedPerson);
+		Long refId = _newResponse.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		
+		MultiOutput _saveResponse = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse).isNotNull();
 
 		// retrieve nested entity by domain _get
 		Long addressId = pPerson.getState().getAddress().getId();
@@ -242,10 +253,20 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person1));
 		assertThat(_newResponse1).isNotNull();
+		Long refId = _newResponse1.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse1 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse1).isNotNull();
 		MultiOutput _newResponse2 = commandGateway.execute(
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person2));
 		assertThat(_newResponse2).isNotNull();
+		refId = _newResponse2.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse2 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				jsonUtils.convert(person2));
+		assertThat(_saveResponse2).isNotNull();
 
 		// do tuple retrieval
 		StringBuilder query = new StringBuilder(FH_SEARCH_BY_QUERY)
@@ -279,19 +300,34 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person1));
 		assertThat(_newResponse1).isNotNull();
+		Long refId = _newResponse1.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse1 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse1).isNotNull();
 		MultiOutput _newResponse2 = commandGateway.execute(
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person2));
 		assertThat(_newResponse2).isNotNull();
+		refId = _newResponse2.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse2 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse2).isNotNull();
 		MultiOutput _newResponse3 = commandGateway.execute(
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person3));
 		assertThat(_newResponse3).isNotNull();
+		refId = _newResponse3.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse3 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse3).isNotNull();
 
 		// do page 1 retrieval
 		Command cmdPage1 = CommandBuilder
 				.withUri(PLATFORM_ROOT
-						+ "/person/_search?fn=query&where=person.lastName.eq('Doe-Paginate')&page=0&pageSize=2&b=$state")
+						+ "/person/_search?fn=query&where=person.lastName.eq('Doe-Paginate')&page=0&pageSize=2")
 				.getCommand();
 		MultiOutput respPage1 = commandGateway.execute(cmdPage1, null);
 		assertThat(respPage1).isNotNull();
@@ -302,7 +338,7 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 		// do page 2 retrieval
 		Command cmdPage2 = CommandBuilder
 				.withUri(PLATFORM_ROOT
-						+ "/person/_search?fn=query&where=person.lastName.eq('Doe-Paginate')&page=1&pageSize=2&b=$state")
+						+ "/person/_search?fn=query&where=person.lastName.eq('Doe-Paginate')&page=1&pageSize=2")
 				.getCommand();
 		MultiOutput respPage2 = commandGateway.execute(cmdPage2, null);
 		assertThat(respPage2).isNotNull();
@@ -331,14 +367,29 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person1));
 		assertThat(_newResponse1).isNotNull();
+		Long refId = _newResponse1.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse1 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse1).isNotNull();
 		MultiOutput _newResponse2 = commandGateway.execute(
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person2));
 		assertThat(_newResponse2).isNotNull();
+		refId = _newResponse2.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse2 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse2).isNotNull();
 		MultiOutput _newResponse3 = commandGateway.execute(
 				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
 				jsonUtils.convert(person3));
 		assertThat(_newResponse3).isNotNull();
+		refId = _newResponse3.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		MultiOutput _saveResponse3 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person:" + refId).setAction(Action._save).getCommand(),
+				null);
+		assertThat(_saveResponse3).isNotNull();
 
 		// create a new view, get the refId
 		Command cmdNewView = CommandBuilder.withUri(VIEW_DOMAIN_ROOT).setAction(Action._new).getCommand();
@@ -352,10 +403,7 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 		MultiOutput respFilterA = commandGateway.execute(cmdFilterA,
 				"{ \"filters\": [ { \"code\": \"lastName\", \"value\": \"Filter-A\" } ] }");
 		assertThat(respFilterA).isNotNull();
-		List<Param<PersonLineItem>> gridResultsFilterA = (List<Param<PersonLineItem>>) respFilterA.getSingleResult();
-		List<PersonJPACoreEntity> actualResults1 = gridResultsFilterA.stream()
-				.map(a -> new PersonJPACoreEntity(a.getState().getFirstName(), a.getState().getLastName()))
-				.collect(Collectors.toList());
+		List<PersonJPACoreEntity> actualResults1 = (List<PersonJPACoreEntity>) respFilterA.getSingleResult();
 		assertThat(actualResults1).isNotNull();
 		assertThat(CollectionUtils.isEqualCollection(actualResults1, expectedResults1)).isTrue();
 
@@ -364,10 +412,7 @@ public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
 		MultiOutput respFilterB = commandGateway.execute(cmdFilterB,
 				"{ \"filters\": [ { \"code\": \"lastName\", \"value\": \"Filter-B\" } ] }");
 		assertThat(respFilterB).isNotNull();
-		List<Param<PersonLineItem>> gridResultsFilterB = (List<Param<PersonLineItem>>) respFilterB.getSingleResult();
-		List<PersonJPACoreEntity> actualResults2 = gridResultsFilterB.stream()
-				.map(a -> new PersonJPACoreEntity(a.getState().getFirstName(), a.getState().getLastName()))
-				.collect(Collectors.toList());
+		List<PersonJPACoreEntity> actualResults2 = (List<PersonJPACoreEntity>) respFilterB.getSingleResult();
 		assertThat(actualResults2).isNotNull();
 		assertThat(CollectionUtils.isEqualCollection(actualResults2, expectedResults2)).isTrue();
 	}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/rdbms/DefaultJPAModelRepositoryTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/rdbms/DefaultJPAModelRepositoryTest.java
@@ -3,92 +3,372 @@
  */
 package com.antheminc.oss.nimbus.domain.model.state.repo.db.rdbms;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 
+import com.antheminc.oss.nimbus.FrameworkRuntimeException;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
+import com.antheminc.oss.nimbus.domain.cmd.Command;
+import com.antheminc.oss.nimbus.domain.cmd.CommandBuilder;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.MultiOutput;
+import com.antheminc.oss.nimbus.domain.cmd.exec.CommandExecution.Output;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
+import com.antheminc.oss.nimbus.support.Holder;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
+import com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core.AddressJPACoreEntity;
+import com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core.PersonJPACoreEntity;
 import com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core.SampleJPARootCoreEntity;
+import com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.view.PersonLineItem;
 
 /**
  * @author Soham Chakravarti
+ * @author Tony Lopez
  *
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DefaultJPAModelRepositoryTest extends AbstractRdbmsTest {
-	
+
+	public static final String FH_SEARCH_BY_QUERY = "/_search?fn=query";
+
 	private SimpleJpaRepository<SampleJPARootCoreEntity, Long> jpaRepo;
-	
+
 	@Before
 	public void test_context_load() {
 		assertNotNull(repo);
 		assertNotNull(em);
-		
+
 		jpaRepo = new SimpleJpaRepository<>(SampleJPARootCoreEntity.class, em);
 	}
-	
+
 	@Test
 	public void t01_simple_jpa() {
 		SampleJPARootCoreEntity core = new SampleJPARootCoreEntity();
 		core.setId(1L);
-		core.setA1("a1 "+new Date());
-		
+		core.setA1("a1 " + new Date());
+
 		repo._save("core", core);
-		
+
 		SampleJPARootCoreEntity actual = jpaRepo.findById(core.getId()).get();
 		assertEquals(core.getA1(), actual.getA1());
 	}
-	
+
 	@Test
 	public void t02_simple_cmd() {
-		HttpServletRequest req_new = MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT)
-										.addAction(Action._new)
-										.getMock();
+		HttpServletRequest req_new = MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT).addAction(Action._new).getMock();
 
 		// id generation
 		Object resp_new = controller.handleGet(req_new, null);
 		assertNotNull(resp_new);
-		
+
 		Param<SampleJPARootCoreEntity> pCore = ExtractResponseOutputUtils.extractOutput(resp_new);
 		assertNotNull(pCore);
-		
+
 		Long id = pCore.findStateByPath("/id");
 		assertNotNull(id);
-		
-		
+
 		// update attribute
 		String a1 = "a1 @" + new Date();
-		Object resp_update_a1 = controller.handlePost(MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT)
-										.addRefId(id)
-										.addNested("/a1")
-										.addAction(Action._update)
-										.getMock(), jsonUtils.convert(a1));
+		Object resp_update_a1 = controller.handlePost(MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT).addRefId(id)
+				.addNested("/a1").addAction(Action._update).getMock(), jsonUtils.convert(a1));
 		assertNotNull(resp_update_a1);
-		
-		
+
 		// save to db
-		Object resp_save = controller.handleGet(MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT)
-				.addRefId(id)
-				.addAction(Action._save)
-				.getMock(), null);
+		Object resp_save = controller.handleGet(
+				MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT).addRefId(id).addAction(Action._save).getMock(), null);
 		assertNotNull(resp_save);
-		
+
 		SampleJPARootCoreEntity core = pCore.getState();
 		SampleJPARootCoreEntity actual = jpaRepo.findById(core.getId()).get();
-		
+
 		assertEquals(id, actual.getId());
 		assertEquals(a1, actual.getA1());
+	}
+
+	@SuppressWarnings("unchecked")
+	private Output<SampleJPARootCoreEntity> createNewCore(SampleJPARootCoreEntity value) {
+		HttpServletRequest newRequest = MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT).addAction(Action._new)
+				.getMock();
+		MultiOutput respNew = ((Holder<MultiOutput>) controller.handleGet(newRequest, jsonUtils.convert(value)))
+				.getState();
+		assertThat(respNew).isNotNull();
+		return respNew.findFirstParamOutputEndingWithPath(CORE_ALIAS);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t03_get() {
+		// create expected entity
+		SampleJPARootCoreEntity expected = new SampleJPARootCoreEntity();
+		expected.setA1("getting it");
+
+		// create core and get id
+		Output<SampleJPARootCoreEntity> respNew = createNewCore(expected);
+		assertThat(respNew).isNotNull();
+		Long id = respNew.getRootDomainId();
+		assertThat(id).isNotNull();
+
+		// invoke _get on the new domain entity
+		MultiOutput respGet = ((Holder<MultiOutput>) controller.handleGet(
+				MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT).addRefId(id).addAction(Action._get).getMock(), null))
+						.getState();
+		assertThat(respGet).isNotNull();
+		Param<SampleJPARootCoreEntity> pActual = (Param<SampleJPARootCoreEntity>) respGet.getSingleResult();
+		assertThat(pActual.getState()).isEqualTo(expected);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void t04_delete() {
+		// create expected entity
+		SampleJPARootCoreEntity expected = new SampleJPARootCoreEntity();
+		expected.setA1("deleting it");
+		
+		// create core and get id
+		Output<SampleJPARootCoreEntity> respNew = createNewCore(expected);
+		assertThat(respNew).isNotNull();
+		Long id = respNew.getRootDomainId();
+		assertThat(id).isNotNull();
+
+		// invoke _delete on the new domain entity
+		MultiOutput respDelete = ((Holder<MultiOutput>) controller.handleDelete(
+				MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT).addRefId(id).addAction(Action._delete).getMock(), null))
+						.getState();
+		assertNotNull(respDelete);
+		assertThat(respDelete.getSingleResult()).isEqualTo(true);
+		
+		// invoke _get on the new domain entity, it should not be found.
+		try {
+			controller.handleGet(
+				MockHttpRequestBuilder.withUri(CORE_DOMAIN_ROOT).addRefId(id).addAction(Action._get).getMock(), null);
+		} catch (FrameworkRuntimeException e) {
+			assertThat(e.getMessage()).contains("Entity not found for /sample_jpa_core:" + id);
+		}
+	}
+
+	/**
+	 * Showcases: Search By Query for JPA
+	 * /p/sample_jpa_core/_search?fn=query&where=sample_jpa_core.a1.eq('John')
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testBasicQuery() {
+		// create expected entity
+		PersonJPACoreEntity expected = new PersonJPACoreEntity("John", "Doe-BasicQuery");
+
+		// save to db
+		MultiOutput _newResponse = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(expected));
+		assertThat(_newResponse).isNotNull();
+		Long refId = _newResponse.findFirstParamOutputEndingWithPath("/person").getRootDomainId();
+		assertThat(refId).isNotNull();
+
+		StringBuilder query = new StringBuilder(FH_SEARCH_BY_QUERY).append("&where=")
+				.append("person.lastName.eq('Doe-BasicQuery')");
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/person" + query.toString()).getCommand();
+		MultiOutput response = commandGateway.execute(cmd, null);
+		assertThat(response).isNotNull();
+
+		List<Param<PersonJPACoreEntity>> result = (List<Param<PersonJPACoreEntity>>) response.getSingleResult();
+		assertThat(CollectionUtils.isNotEmpty(result)).isTrue();
+		assertThat(CollectionUtils.isEqualCollection(result, Stream.of(expected).collect(Collectors.toList())))
+				.isTrue();
+	}
+
+	/**
+	 * Showcase: Create a new persistable entity with a nested persistable
+	 * domain entity Person -> Address
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testNewNestedEntity() {
+		PersonJPACoreEntity expectedPerson = new PersonJPACoreEntity("Homer", "Simpson");
+		AddressJPACoreEntity expectedAddress = new AddressJPACoreEntity("742 Evergreen Terrace");
+		expectedPerson.setAddress(expectedAddress);
+
+		// save to db
+		MultiOutput _newResponse = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(expectedPerson));
+		assertThat(_newResponse).isNotNull();
+		Param<PersonJPACoreEntity> pPerson = (Param<PersonJPACoreEntity>) _newResponse.getSingleResult();
+		assertThat(pPerson).isNotNull();
+		assertThat(pPerson.getState()).isEqualTo(expectedPerson);
+
+		// retrieve nested entity by domain _get
+		Long addressId = pPerson.getState().getAddress().getId();
+		assertThat(addressId).isNotNull();
+		Command cmdGetAddress = CommandBuilder.withUri(PLATFORM_ROOT + "/address:" + addressId + "/_get").getCommand();
+		MultiOutput respGetAddress = commandGateway.execute(cmdGetAddress, null);
+		assertThat(respGetAddress).isNotNull();
+		Param<AddressJPACoreEntity> pAddress = (Param<AddressJPACoreEntity>) respGetAddress.getSingleResult();
+		assertThat(pAddress).isNotNull();
+		assertThat(pAddress.getState()).isEqualTo(expectedAddress);
+	}
+
+	/**
+	 * Showcase projection the result set via "tuple"
+	 * /p/person/_search?fn=query&select=(firstName)&where=person.lastName.eq('Doe')
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testTuple() {
+		// create expected entities
+		PersonJPACoreEntity person1 = new PersonJPACoreEntity("John", "Doe-Tuple");
+		PersonJPACoreEntity person2 = new PersonJPACoreEntity("Jane", "Doe-Tuple");
+		// (just collect the first names of any entities added to "person" to
+		// create the expected result set)
+		List<PersonJPACoreEntity> expected = Stream.of(person1, person2)
+				.map(p -> new PersonJPACoreEntity(p.getFirstName(), null)).collect(Collectors.toList());
+
+		// save to db
+		MultiOutput _newResponse1 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person1));
+		assertThat(_newResponse1).isNotNull();
+		MultiOutput _newResponse2 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person2));
+		assertThat(_newResponse2).isNotNull();
+
+		// do tuple retrieval
+		StringBuilder query = new StringBuilder(FH_SEARCH_BY_QUERY)
+				.append("&select=(firstName)&where=person.lastName.eq('Doe-Tuple')");
+		Command cmd = CommandBuilder.withUri(PLATFORM_ROOT + "/person" + query.toString()).getCommand();
+		MultiOutput response = commandGateway.execute(cmd, null);
+		assertThat(response).isNotNull();
+
+		// validate
+		List<Param<PersonJPACoreEntity>> result = (List<Param<PersonJPACoreEntity>>) response.getSingleResult();
+		assertThat(CollectionUtils.isNotEmpty(result)).isTrue();
+		assertThat(CollectionUtils.isEqualCollection(result, expected)).isTrue();
+	}
+
+	/**
+	 * Showcase server-side pagination
+	 * /p/person/_search?fn=query&page=0&pageSize=5
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testPagination() {
+		// create expected entities
+		PersonJPACoreEntity person1 = new PersonJPACoreEntity("John", "Doe-Paginate");
+		PersonJPACoreEntity person2 = new PersonJPACoreEntity("Jane", "Doe-Paginate");
+		PersonJPACoreEntity person3 = new PersonJPACoreEntity("Jack", "Doe-Paginate");
+		List<PersonJPACoreEntity> expectedPage1 = Stream.of(person1, person2).collect(Collectors.toList());
+		List<PersonJPACoreEntity> expectedPage2 = Stream.of(person3).collect(Collectors.toList());
+
+		// save to db
+		MultiOutput _newResponse1 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person1));
+		assertThat(_newResponse1).isNotNull();
+		MultiOutput _newResponse2 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person2));
+		assertThat(_newResponse2).isNotNull();
+		MultiOutput _newResponse3 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person3));
+		assertThat(_newResponse3).isNotNull();
+
+		// do page 1 retrieval
+		Command cmdPage1 = CommandBuilder
+				.withUri(PLATFORM_ROOT
+						+ "/person/_search?fn=query&where=person.lastName.eq('Doe-Paginate')&page=0&pageSize=2&b=$state")
+				.getCommand();
+		MultiOutput respPage1 = commandGateway.execute(cmdPage1, null);
+		assertThat(respPage1).isNotNull();
+		List<PersonJPACoreEntity> resultPage1 = (List<PersonJPACoreEntity>) respPage1.getSingleResult();
+		assertThat(resultPage1).isNotNull();
+		assertThat(CollectionUtils.isEqualCollection(resultPage1, expectedPage1));
+
+		// do page 2 retrieval
+		Command cmdPage2 = CommandBuilder
+				.withUri(PLATFORM_ROOT
+						+ "/person/_search?fn=query&where=person.lastName.eq('Doe-Paginate')&page=1&pageSize=2&b=$state")
+				.getCommand();
+		MultiOutput respPage2 = commandGateway.execute(cmdPage2, null);
+		assertThat(respPage2).isNotNull();
+		List<PersonJPACoreEntity> resultPage2 = (List<PersonJPACoreEntity>) respPage2.getSingleResult();
+		assertThat(resultPage2).isNotNull();
+		assertThat(CollectionUtils.isEqualCollection(resultPage2, expectedPage2));
+	}
+
+	/**
+	 * Showcase server-side filtering
+	 * /p/person/_search?fn=query&where=<!filterCriteria!> Payload: filters: [ {
+	 * "code": "firstName", "value": "bob" } ]
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testFiltering() {
+		// create expected entities
+		PersonJPACoreEntity person1 = new PersonJPACoreEntity("Alpha", "Filter-A");
+		PersonJPACoreEntity person2 = new PersonJPACoreEntity("Beta", "Filter-A");
+		PersonJPACoreEntity person3 = new PersonJPACoreEntity("Gamma", "Filter-B");
+		List<PersonJPACoreEntity> expectedResults1 = Stream.of(person1, person2).collect(Collectors.toList());
+		List<PersonJPACoreEntity> expectedResults2 = Stream.of(person3).collect(Collectors.toList());
+
+		// save to db
+		MultiOutput _newResponse1 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person1));
+		assertThat(_newResponse1).isNotNull();
+		MultiOutput _newResponse2 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person2));
+		assertThat(_newResponse2).isNotNull();
+		MultiOutput _newResponse3 = commandGateway.execute(
+				CommandBuilder.withUri(PLATFORM_ROOT + "/person").setAction(Action._new).getCommand(),
+				jsonUtils.convert(person3));
+		assertThat(_newResponse3).isNotNull();
+
+		// create a new view, get the refId
+		Command cmdNewView = CommandBuilder.withUri(VIEW_DOMAIN_ROOT).setAction(Action._new).getCommand();
+		MultiOutput respNewView = commandGateway.execute(cmdNewView, null);
+		assertNotNull(respNewView);
+		Long viewRefId = respNewView.findFirstParamOutputEndingWithPath(VIEW_ALIAS).getRootDomainId();
+		assertNotNull(viewRefId);
+
+		// retrieve "Filter-A" and validate results are equal to expected
+		Command cmdFilterA = CommandBuilder.withUri(VIEW_DOMAIN_ROOT + ":" + viewRefId + "/people/_get").getCommand();
+		MultiOutput respFilterA = commandGateway.execute(cmdFilterA,
+				"{ \"filters\": [ { \"code\": \"lastName\", \"value\": \"Filter-A\" } ] }");
+		assertThat(respFilterA).isNotNull();
+		List<Param<PersonLineItem>> gridResultsFilterA = (List<Param<PersonLineItem>>) respFilterA.getSingleResult();
+		List<PersonJPACoreEntity> actualResults1 = gridResultsFilterA.stream()
+				.map(a -> new PersonJPACoreEntity(a.getState().getFirstName(), a.getState().getLastName()))
+				.collect(Collectors.toList());
+		assertThat(actualResults1).isNotNull();
+		assertThat(CollectionUtils.isEqualCollection(actualResults1, expectedResults1)).isTrue();
+
+		// retrieve "Filter-B" and validate results are equal to expected
+		Command cmdFilterB = CommandBuilder.withUri(VIEW_DOMAIN_ROOT + ":" + viewRefId + "/people/_get").getCommand();
+		MultiOutput respFilterB = commandGateway.execute(cmdFilterB,
+				"{ \"filters\": [ { \"code\": \"lastName\", \"value\": \"Filter-B\" } ] }");
+		assertThat(respFilterB).isNotNull();
+		List<Param<PersonLineItem>> gridResultsFilterB = (List<Param<PersonLineItem>>) respFilterB.getSingleResult();
+		List<PersonJPACoreEntity> actualResults2 = gridResultsFilterB.stream()
+				.map(a -> new PersonJPACoreEntity(a.getState().getFirstName(), a.getState().getLastName()))
+				.collect(Collectors.toList());
+		assertThat(actualResults2).isNotNull();
+		assertThat(CollectionUtils.isEqualCollection(actualResults2, expectedResults2)).isTrue();
 	}
 }

--- a/nimbus-test/src/test/resources/application-rdbms-test.yml
+++ b/nimbus-test/src/test/resources/application-rdbms-test.yml
@@ -30,6 +30,7 @@ nimbus:
       basePackages:
         - com.antheminc.oss.nimbus.entity
         - com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.core
+        - com.antheminc.oss.nimbus.test.scenarios.repo.rdbms.view
         - com.antheminc.oss.nimbus.domain.bpm
         - com.antheminc.oss.nimbus.domain.rules
       persistence:


### PR DESCRIPTION
# Description
Testing for RDBMS implementation

# Overview of Changes
* Refactoring existing test case to be reusable
* Modified `CommandExecution` `findFirstParamOutputEndingWithPath` to return generic type
* Added a QueryDSL specific test class

# Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [X] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details

N/A

# Additional Notes

N/A
