### PR TITLE
NIMBUS-280: fix for button submit error

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/button.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/button.component.ts
@@ -378,7 +378,7 @@ export class Button extends BaseElement {
     Object.keys(item).forEach(key => {
       if(item[key]) {
         let associatedParamConfig: ParamConfig = this.form.paramConfigs.find(config => config.code == key);
-        if (associatedParamConfig && ParamUtils.isKnownDateType(associatedParamConfig.type.name)) {
+        if (associatedParamConfig && ParamUtils.isKnownDateType(associatedParamConfig.type.name) && (item[key] instanceof Date)) {
           item[key] = ParamUtils.convertDateToServerDate(item[key], associatedParamConfig.type.name);
         }
       }


### PR DESCRIPTION
# Description

Related to #585 and #591

Fixes an issue where clicking a submit button that submits a form that has already had it's `Date` transformed into a `string` was inappropriately trying to transform the date again.
