### PR TITLE
build fix for javadocs @Transactional issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1015,6 +1015,16 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven-javadoc-plugin.version}</version>
+                        <configuration>
+							<!-- Silence error javax.interceptor.InterceptorBinding not found -->
+							<additionalDependencies>
+							    <additionalDependency>
+							        <groupId>javax.interceptor</groupId>
+							        <artifactId>javax.interceptor-api</artifactId>
+							        <version>1.2</version>
+							    </additionalDependency>
+							</additionalDependencies>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
# Description

Fixes an issue where the build would fail to publish javadocs due to the issue outlined here:
https://stackoverflow.com/questions/27808734/jdk8-error-class-file-for-javax-interceptor-interceptorbinding-not-found-whe/47889602

# Overview of Changes

Dependency addition.

# Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details
run the build

```bash
mvn clean install -DskipTests -P cicdbuild
```

# Additional Notes

N/A
