### PR TITLE
primeng 7.1.1 + grid edit fix

### DIFF
--- a/nimbus-ui/nimbusui/package.json
+++ b/nimbus-ui/nimbusui/package.json
@@ -44,7 +44,7 @@
     "nimbus-sass-module": "^1.18.42",
     "popper.js": "^1.12.9",
     "primeicons": "^1.0.0-beta.10",
-    "primeng": "7.1.0",
+    "primeng": "7.1.1",
     "quill": "^1.3.6",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.0",

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
@@ -271,6 +271,9 @@ export class DataTable extends BaseTableElement
     } else {
       // TODO handle the pagination when server-side pagination is enabled
     }
+    if(!this.value) {
+      this.value = [];
+    }
     this.value.unshift({});
     this.dt.initRowEdit(this.value[0]);
     // TODO focus the first field


### PR DESCRIPTION
# Description
Primeng upgrade to 7.1.1 to fix grid edit issue

# Overview of Changes
When the grid is empty and add button clicked there is a nullpointer which is fixed with this.

# Type of Change
- [ ] Bug fix
