### PR TITLE
Bugfix/audit

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
@@ -928,7 +928,7 @@ public class DefaultParamState<T> extends AbstractEntityState<T> implements Para
 	}
 	
 	private boolean isPrimitive() {
-		return ClassUtils.isPrimitiveOrWrapper(getConfig().getReferredClass());
+		return getConfig().getReferredClass().isPrimitive();
 	}
 
 	@Override

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreEntity.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SampleCoreEntity.java
@@ -25,6 +25,8 @@ import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
 import com.antheminc.oss.nimbus.domain.defn.Model;
 import com.antheminc.oss.nimbus.domain.defn.Repo;
 import com.antheminc.oss.nimbus.domain.defn.Repo.Database;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.CheckBox;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.ComboBox;
 import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Modal;
 import com.antheminc.oss.nimbus.domain.defn.extension.ActivateConditional;
 import com.antheminc.oss.nimbus.domain.defn.extension.ActivateConditionals;
@@ -153,6 +155,12 @@ public class SampleCoreEntity extends IdLong {
 	public static class SampleForm {
 //		@ActivateConditional(when="state=='Y'", targetPath="../nc_nested_level1")
 //		private String nc_attr1;
+		
+		@ActivateConditional(targetPath = { "../sample_checkBox"}, when = "state == 'Yes'")
+		private String sample_activate;
+		
+		private Boolean sample_checkBox;
+
 		
 		private SampleNoConversionEntity nc_nested0_Details;
 	}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalNoConversionTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/model/state/extension/ActivateConditionalNoConversionTest.java
@@ -237,4 +237,23 @@ public class ActivateConditionalNoConversionTest extends AbstractStateEventHandl
 		checkIsInactive(p3);
 		assertEquals(Integer.valueOf(0), p3.getState());
 	}
+	
+	@Test
+	public void test_activateConditionalOnPrimitives() {
+		Param<?> view_nc_form = _q.getRoot().findParamByPath(VIEW_PARAM_nc_form);
+		assertNotNull(view_nc_form);
+		Param<String> p1 = view_nc_form.findParamByPath("/sample_activate");
+		Param<Boolean> p2 = view_nc_form.findParamByPath("/sample_checkBox");
+		//show the checkbox by setting the value to 'Yes'
+		p1.setState("Yes");
+		checkIsActive(p2);
+		//set the checkboxv value
+		p2.setState(true);
+		//trigger activate conditional on p1 to reset state of p2
+		p1.setState("No");
+		
+		checkIsInactive(p2);
+		assertNull(p2.getState());
+	
+	}
 }		


### PR DESCRIPTION
# Description
State reset not working for primitives on activate conditional.

# Overview of Changes
Changed the check for the state reset

# Type of Change
- [ ] Bug fix

# Test Details
test_activateConditionalOnPrimitives
