### PR TITLE
NIMBUS-241: Nested collection blank rows fix

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandExecutorGateway.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultCommandExecutorGateway.java
@@ -70,6 +70,7 @@ import com.antheminc.oss.nimbus.domain.model.state.ParamEvent;
 import com.antheminc.oss.nimbus.domain.model.state.StateEventListener;
 import com.antheminc.oss.nimbus.domain.model.state.extension.ChangeLogCommandEventHandler;
 import com.antheminc.oss.nimbus.domain.model.state.internal.BaseStateEventListener;
+import com.antheminc.oss.nimbus.domain.model.state.internal.DefaultStateEventDelegator;
 import com.antheminc.oss.nimbus.support.EnableAPIMetricCollection;
 import com.antheminc.oss.nimbus.support.EnableAPIMetricCollection.LogLevel;
 import com.antheminc.oss.nimbus.support.InjectSelf;
@@ -390,8 +391,10 @@ public class DefaultCommandExecutorGateway extends BaseCommandExecutorStrategies
 			StateEventListener cmdListener = new BaseStateEventListener() {
 
 				@Override
-				public void onEvent(ExecutionTxnContext txnCtx, ParamEvent event) { 
-					_aggregatedEvents.add(event);
+				public void onEvent(ExecutionTxnContext txnCtx, ParamEvent pe) {
+					Param<?> colParent = DefaultStateEventDelegator.findFirstCollectionNode(pe.getParam());
+					ParamEvent resolved = (colParent==null) ? pe : new ParamEvent(pe.getAction(), colParent);
+					_aggregatedEvents.add(resolved);
 				}
 				
 				@Override

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultListParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultListParamState.java
@@ -266,7 +266,7 @@ public class DefaultListParamState<T> extends AbstractListPaginatedParam<T> impl
 		return mapsToParam.findIfCollectionElem();	
 	}
 	
-	private boolean affectRemoveIfMappedOrUnMapped(ListElemParam<T> pElem) {
+	protected boolean affectRemoveIfMappedOrUnMapped(ListElemParam<T> pElem) {
 		// remove from collection entity state
 		List<T> currList = getState();//instantiateOrGet();
 		
@@ -281,7 +281,7 @@ public class DefaultListParamState<T> extends AbstractListPaginatedParam<T> impl
 		
 		
 		T elemToRemove = pElem.getState();
-		boolean isRemoved = currList.remove(elemToRemove);
+		boolean isRemoved = (elemToRemove==null) ? true : currList.remove(elemToRemove);
 		
 		// remove from collection model state
 		String elemId = pElem.getElemId();

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
@@ -487,7 +487,31 @@ public class DefaultParamState<T> extends AbstractEntityState<T> implements Para
 	
 	@Override
 	public boolean deregisterConsumer(MappedParam<?, T> subscriber) {
+		boolean startNodeRemoved = degisterThis(subscriber);
+		
+//		traverse(subscriber);
+		return startNodeRemoved;
+	}
+	
+	private boolean degisterThis(MappedParam<?, ?> subscriber) {
 		return getEventSubscribers().remove(subscriber);
+	}
+	
+	private void traverse(Param<?> p) {
+		if(!p.isNested())
+			return;
+		
+		if(p.findIfNested().templateParams().isNullOrEmpty())
+			return;
+		
+		p.findIfNested().getParams().stream()
+			.forEach(cp->{
+				if(cp.isMapped()) 
+					degisterThis(p.findIfMapped());
+					
+				traverse(cp);
+				
+			});
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultStateEventDelegator.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultStateEventDelegator.java
@@ -190,7 +190,7 @@ public class DefaultStateEventDelegator implements StateEventDelegator {
 		return root;
 	} 
 	
-	private static Param<?> findFirstCollectionNode(Param<?> currParam) {
+	public static Param<?> findFirstCollectionNode(Param<?> currParam) {
 		if(currParam.isCollection())
 			return currParam;
 		

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/MappedDefaultListParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/MappedDefaultListParamState.java
@@ -22,7 +22,9 @@ import com.antheminc.oss.nimbus.domain.model.config.ParamConfig;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState;
 import com.antheminc.oss.nimbus.domain.model.state.EntityStateAspectHandlers;
 import com.antheminc.oss.nimbus.domain.model.state.Notification;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.ListElemParam;
 import com.antheminc.oss.nimbus.domain.model.state.Notification.ActionType;
+import com.antheminc.oss.nimbus.support.pojo.LockTemplate;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.Getter;
@@ -101,13 +103,18 @@ public class MappedDefaultListParamState<T, M> extends DefaultListParamState<T> 
 					String elemId = event.getEventParam().findIfCollectionElem().getElemId();
 					
 					ListModel<T> mappedColModel = (ListModel<T>)getType().findIfNested().getModel().findIfListModel();
-					Param<?> mappedParamElem = mappedColModel.templateParams().remove(elemId);
+//					Param<?> mappedParamElem = mappedColModel.templateParams().remove(elemId);
+					Param<?> mappedParamElem = mappedColModel.templateParams().find(elemId);
 					
-					emitNotification(new Notification<>(mappedColModel.getAssociatedParam(), ActionType._deleteElem, mappedParamElem));
+					removeMappedWithoutPropagation(event.getEventParam(), (ListElemParam<T>)mappedParamElem.findIfCollectionElem());
+//					// deregister mapped from mapsTo
+//					event.getEventParam().deregisterConsumer((MappedParam)mappedParamElem);
 					
-					if(getRootExecution().getExecutionRuntime().isStarted())
-						emitEvent(Action._delete, mappedParamElem);
-					
+//					emitNotification(new Notification<>(mappedColModel.getAssociatedParam(), ActionType._deleteElem, mappedParamElem));
+//					
+//					if(getRootExecution().getExecutionRuntime().isStarted())
+//						emitEvent(Action._delete, mappedParamElem);
+//					
 					logit.trace(()->"[onEventDeleteElem] removed mapped.ListParamElem: "+mappedParamElem.getPath());
 				});	
 			}
@@ -146,6 +153,34 @@ public class MappedDefaultListParamState<T, M> extends DefaultListParamState<T> 
 		};
 
 		getMapsTo().registerConsumer(this);
+	}
+	
+	private boolean removeMappedWithoutPropagation(Param<?> mapsTo, final ListElemParam<T> pElem) {
+		clearPageMeta();
+		final LockTemplate rLockTemplate = isMapped() ? findIfMapped().getMapsTo().getLockTemplate() : getLockTemplate();
+		
+		return rLockTemplate.execute(()->{
+			
+			return changeStateTemplate((rt, h, lockId) -> {
+				boolean isRemoved =  affectRemoveIfMappedOrUnMapped(pElem);
+
+				// deregister mapped from mapsTo
+				mapsTo.deregisterConsumer((MappedParam)pElem);
+
+				if(isRemoved) {
+					// notify state
+					emitNotification(new Notification<>(this, ActionType._deleteElem, pElem));
+					
+					// emit event
+					if(rt.isStarted())
+						emitEvent(Action._delete, pElem);
+					
+					return true;
+				}
+
+				return false;
+			});
+		});
 	}
 	
 	@Override


### PR DESCRIPTION
# Description
Fixes #531 

# Overview of Changes
* Added deregisterConsumer for mappedParams onDelete

# Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other

# Test Details

N/A

# Additional Notes

Commits were previously added directly into support branch. They have been reverted and added back for the sake of the release notes.
