### PR TITLE
transient param fix

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/EntityConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/EntityConfig.java
@@ -33,7 +33,9 @@ public interface EntityConfig<T> {
 	
 	public <K> ParamConfig<K> findParamByPath(String path);
 	public <K> ParamConfig<K> findParamByPath(String[] pathArr);
-
+	
+	@JsonIgnore
+	public boolean isTransientData();
 	
 	default public boolean hasRules() {
 		return getRulesConfig()!=null;

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/builder/EntityConfigBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/builder/EntityConfigBuilder.java
@@ -24,7 +24,7 @@ public interface EntityConfigBuilder {
 
 	<T> ModelConfig<T> load(Class<T> clazz, EntityConfigVisitor visitedModels);
 
-	<T> ModelConfig<T> buildModel(Class<T> clazz, EntityConfigVisitor visitedModels);
+	<T> ModelConfig<T> buildModel(Class<T> clazz, EntityConfigVisitor visitedModels, ParamConfig<?> pConfig);
 
 	<T> ParamConfig<?> buildParam(ModelConfig<T> mConfig, Field f, EntityConfigVisitor visitedModels);
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/builder/internal/DefaultEntityConfigBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/builder/internal/DefaultEntityConfigBuilder.java
@@ -64,7 +64,7 @@ public class DefaultEntityConfigBuilder extends AbstractEntityConfigBuilder impl
 	 */
 	@Override
 	public <T> ModelConfig<T> load(Class<T> clazz, EntityConfigVisitor visitedModels) {
-		ModelConfig<T> mConfig = buildModel(clazz, visitedModels);
+		ModelConfig<T> mConfig = buildModel(clazz, visitedModels, null);
 		return mConfig;
 	}
 	
@@ -73,7 +73,7 @@ public class DefaultEntityConfigBuilder extends AbstractEntityConfigBuilder impl
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T> ModelConfig<T> buildModel(Class<T> clazz, EntityConfigVisitor visitedModels) {
+	public <T> ModelConfig<T> buildModel(Class<T> clazz, EntityConfigVisitor visitedModels, ParamConfig<?> pConfig) {
 		logit.trace(()->"building model for class: "+clazz);
 		
 		// skip if already built
@@ -81,7 +81,7 @@ public class DefaultEntityConfigBuilder extends AbstractEntityConfigBuilder impl
 			return (ModelConfig<T>)visitedModels.get(clazz);
 		
 		
-		DefaultModelConfig<T> mConfig = createModel(clazz, visitedModels);
+		DefaultModelConfig<T> mConfig = createModel(clazz, visitedModels, pConfig);
 		visitedModels.set(clazz, mConfig);
 
 		
@@ -89,7 +89,7 @@ public class DefaultEntityConfigBuilder extends AbstractEntityConfigBuilder impl
 		if(mConfig.isMapped()) {
 			
 			//ensure mapped class config is already loaded
-			buildModel(mConfig.findIfMapped().getMapsToConfig().getReferredClass(), visitedModels);
+			buildModel(mConfig.findIfMapped().getMapsToConfig().getReferredClass(), visitedModels, pConfig);
 		}
 		
 		List<Field> fields = FieldUtils.getAllFieldsList(clazz);
@@ -164,7 +164,7 @@ public class DefaultEntityConfigBuilder extends AbstractEntityConfigBuilder impl
 	@Override
 	protected <T, P> ParamConfigType buildParamType(ModelConfig<T> mConfig, ParamConfig<P> pConfig, ParamConfigType.CollectionType colType, Class<?> pDirectOrColElemType, /*MapsTo.Path mapsToPath, */EntityConfigVisitor visitedModels) {
 		if(ParamConfigType.CollectionType.array==colType && isPrimitive(pDirectOrColElemType)) { // handle primitive array first
-			ParamConfigType type = createParamType(true, pDirectOrColElemType, mConfig, visitedModels);
+			ParamConfigType type = createParamType(true, pDirectOrColElemType, mConfig, pConfig, visitedModels);
 			return type;
 			
 		} else if(colType!=null) { //handle collections second
@@ -180,13 +180,13 @@ public class DefaultEntityConfigBuilder extends AbstractEntityConfigBuilder impl
 			colModelType.setElementConfig(colElemParamConfig);
 
 			//create collection element type (and element model config)
-			ParamConfigType colElemType = createParamType(false, pDirectOrColElemType, colModelConfig, visitedModels);
+			ParamConfigType colElemType = createParamType(false, pDirectOrColElemType, colModelConfig, pConfig, visitedModels);
 			colElemParamConfig.setType(colElemType);
 			
 			return colModelType;
 			
 		} else {
-			ParamConfigType type = createParamType(false, pDirectOrColElemType, mConfig, visitedModels);
+			ParamConfigType type = createParamType(false, pDirectOrColElemType, mConfig, pConfig, visitedModels);
 			return type;
 		}
 	}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultModelConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultModelConfig.java
@@ -61,6 +61,8 @@ public class DefaultModelConfig<T> extends AbstractEntityConfig<T> implements Mo
 	
 	@JsonIgnore	private transient ParamConfig<?> versionParamConfig;
 	
+	@JsonIgnore private boolean transientData;
+	
 	@JsonIgnore
 	private final transient CollectionsTemplate<List<ParamConfig<?>>, ParamConfig<?>> templateParamConfigs = new CollectionsTemplate<>(
 			() -> getParamConfigs(), (p) -> setParamConfigs(p), () -> new LinkedList<>());

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultParamConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultParamConfig.java
@@ -84,6 +84,9 @@ public class DefaultParamConfig<P> extends AbstractEntityConfig<P> implements Pa
 	@JsonIgnore
 	private Set<Label> labels;
 	
+	@JsonIgnore 
+	private boolean transientData;
+
 	@JsonIgnore @Setter 
 	private List<AssociatedEntity> associatedEntities;
 

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
@@ -16,9 +16,11 @@
 package com.antheminc.oss.nimbus.domain.model.state.repo.db;
 
 import java.io.Serializable;
+import java.lang.reflect.Field;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.annotation.Transient;
 
 import com.antheminc.oss.nimbus.InvalidConfigException;
 import com.antheminc.oss.nimbus.domain.cmd.Action;
@@ -76,6 +78,10 @@ public class ParamStateAtomicPersistenceEventListener extends ParamStatePersiste
 		ModelRepository modelRepo = getRepoFactory().get(repo);
 		if(modelRepo == null) {
 			throw new InvalidConfigException("No repository implementation provided for the configured repository :"+repo.value().name()+ " for root model: "+p.getRootExecution());
+		}
+		
+		if(p.getConfig().isTransientData()) {
+			return false;
 		}
 		
 		Serializable coreStateId = (Serializable) rootModel.findParamByPath("/id").getState();

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParamConfig.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParamConfig.java
@@ -30,6 +30,7 @@ import com.antheminc.oss.nimbus.domain.model.config.ParamConfig;
 import com.antheminc.oss.nimbus.domain.model.config.ParamConfigType;
 import com.antheminc.oss.nimbus.domain.model.config.RulesConfig;
 import com.antheminc.oss.nimbus.test.domain.support.utils.PathUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -53,6 +54,7 @@ public class MockParamConfig implements ParamConfig<Object> {
 	private ExecutionConfig executionConfig;
 	private boolean leaf;
 	private Map<String, ParamConfig<?>> paramConfigMap;
+	private boolean transientData;
 	private Class<Object> referredClass;
 	private List<AnnotationConfig> rules;
 	private RulesConfig rulesConfig;

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/InnerTestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/InnerTestModel.java
@@ -1,0 +1,16 @@
+package com.antheminc.oss.nimbus.test.scenarios.s0.core;
+
+import com.antheminc.oss.nimbus.domain.defn.Model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Model
+@Getter @Setter
+public class InnerTestModel {
+
+	private String inner_attr1;
+	
+	private String inner_attr2;
+	
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/TestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/TestModel.java
@@ -1,0 +1,36 @@
+package com.antheminc.oss.nimbus.test.scenarios.s0.core;
+
+import org.springframework.data.annotation.Transient;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.entity.AbstractEntity;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Domain(value="testmodel_core", includeListeners={ListenerType.persistence, ListenerType.update})
+@Repo(value=Repo.Database.rep_mongodb)
+@Getter @Setter @ToString(callSuper=true)
+public class TestModel extends AbstractEntity.IdLong {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String attr1;
+	
+	private String attr2;
+	
+	@Transient
+	private String attr3;
+	
+	@Transient
+	private String attr4;
+	
+	@Transient
+	private InnerTestModel innerTestModel;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRTestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRTestModel.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s0.view;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Execution.Config;
+import com.antheminc.oss.nimbus.domain.defn.Executions.Configs;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.Page;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.ViewRoot;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.TestModel;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Sandeep Mantha
+ *
+ */
+@Domain(value="testmodelview", includeListeners={ListenerType.websocket})
+@ViewRoot(layout = "")
+@Repo(value = Repo.Database.rep_none, cache = Repo.Cache.rep_device)
+@Getter @Setter
+@MapsTo.Type(TestModel.class)
+public class VRTestModel {
+	
+	
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdateTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -41,12 +42,16 @@ import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ExtractResponseOutputUtils;
 import com.antheminc.oss.nimbus.test.domain.support.utils.MockHttpRequestBuilder;
 import com.antheminc.oss.nimbus.test.domain.support.utils.ParamUtils;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.InnerTestModel;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreLevel1_Entity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity.Level1;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleNoConversionEntity.NestedNoConversionLevel1;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.TestModel;
 import com.antheminc.oss.nimbus.test.scenarios.s0.view.VPSampleViewPageRed.Form_ConvertedNestedEntity;
+
+import junit.framework.Assert;
 
 /**
  * @author Soham Chakravarti, Tony Lopez
@@ -55,6 +60,10 @@ import com.antheminc.oss.nimbus.test.scenarios.s0.view.VPSampleViewPageRed.Form_
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DefaultActionExecutorUpdateTest extends AbstractFrameworkIngerationPersistableTests {
 	
+	protected static final String TEST_DOMAIN = PLATFORM_ROOT + "/testmodel_core";
+	protected static final String TEST_DOMAIN_VIEW = PLATFORM_ROOT + "/testmodelview";
+
+
 	@Test
 	public void t01_colElem_add() {
 		Long refId = createOrGetDomainRoot_RefId();
@@ -501,7 +510,7 @@ public class DefaultActionExecutorUpdateTest extends AbstractFrameworkIngeration
 		List<String> expected = Arrays.asList("field 1", "field 2");
 		
 		// Invoke _update on the list with "field 1"
-		Object response1 = controller.handlePut(request, null, converter.toJson(expected.get(0)));
+		Object response1 = controller.handlePut(request, null, 	converter.toJson(expected.get(0)));
 		
 		// Validate list should have "field 1" only
 		Param<List<String>> viewParam = ParamUtils.extractResponseByParamPath(response1, "/attr_list_2_simple");
@@ -513,6 +522,52 @@ public class DefaultActionExecutorUpdateTest extends AbstractFrameworkIngeration
 		// Validate list should have ["field 1", "field 2"]
 		viewParam = ParamUtils.extractResponseByParamPath(response2, "/attr_list_2_simple");
 		assertEquals(expected, viewParam.getState());
+	}
+	
+	private Long createTestDomain() {
+		MockHttpServletRequest home_newReq = MockHttpRequestBuilder.withUri(TEST_DOMAIN).addAction(Action._new).getMock();
+		Object home_newResp = controller.handleGet(home_newReq, null);
+		assertNotNull(home_newResp);
+		Long testDomainrefId = ExtractResponseOutputUtils.extractDomainRootRefId(home_newResp);	
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(TEST_DOMAIN).addRefId(testDomainrefId)
+				.addNested("/attr1").addAction(Action._update).getMock();
+		Object resp = controller.handlePut(request, null, converter.toJson("test"));
+		
+		return testDomainrefId;
+
+	}
+	
+	@Test
+	public void t13_transientUpdate() {		
+		Long testDomainrefId  = createTestDomain();
+		//String payload = "{ \"attr3\":\"test\" }";
+		TestModel core = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+		
+		MockHttpServletRequest request2 = MockHttpRequestBuilder.withUri(TEST_DOMAIN).addRefId(testDomainrefId)
+				.addNested("/attr3").addAction(Action._update).getMock();
+		Object resp2 = controller.handlePut(request2, null, converter.toJson("test"));
+		
+		TestModel core_afterUpdate = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+
+		assertEquals(core.getLastModifiedDate(), core_afterUpdate.getLastModifiedDate());
+		
+	}
+	
+	@Test
+	public void t14_transientModelUpdate() {		
+		Long testDomainrefId  = createTestDomain();
+		TestModel core = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+		InnerTestModel im = new InnerTestModel();
+		im.setInner_attr1("test_attr1");
+		im.setInner_attr2("test_attr2");
+		
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(TEST_DOMAIN).addRefId(testDomainrefId)
+				.addNested("/innerTestModel").addAction(Action._update).getMock();
+		Object resp = controller.handlePut(request, null, converter.toJson(im));
+		
+		TestModel core_afterUpdate = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+		assertEquals(core.getLastModifiedDate(), core_afterUpdate.getLastModifiedDate());
+		
 	}
 }
 


### PR DESCRIPTION
# Description
Param marked @Transient not to be saved in the db

# Overview of Changes
Collected the @Transient annotation and stopping the event at the atomic listener.
Have looked at 2.0.0 code and we are sending the root param to the model repo. Hence I did not pass event param as an argument to the model repo.

# Type of Change
- [ ] Bug fix
