### PR TITLE
NIMBUS-298 :: Transient param persistance fix

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/EntityConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/EntityConfig.java
@@ -51,6 +51,9 @@ public interface EntityConfig<T> {
 		return null;
 	}
 
+	@JsonIgnore
+	public boolean isTransientData();
+	
 	public interface MappedConfig<T, M> extends EntityConfig<T> {
 		@Override
 		default boolean isMapped() {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/EntityConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/EntityConfig.java
@@ -50,9 +50,6 @@ public interface EntityConfig<T> {
 	default public MappedConfig<T, ?> findIfMapped() {
 		return null;
 	}
-
-	@JsonIgnore
-	public boolean isTransientData();
 	
 	public interface MappedConfig<T, M> extends EntityConfig<T> {
 		@Override

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/ParamConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/ParamConfig.java
@@ -57,6 +57,9 @@ public interface ParamConfig<P> extends EntityConfig<P>, Findable<String> {
 	
 	public AnnotationConfig getUiStyles();
 	
+	@JsonIgnore
+	public boolean isTransientData();
+	
 	// TODO Soham: change to list of notification handler annotations
 	public List<AnnotationConfig> getRules();
 	

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/builder/internal/AbstractEntityConfigBuilder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/builder/internal/AbstractEntityConfigBuilder.java
@@ -29,6 +29,7 @@ import javax.validation.Constraint;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Page;
 import org.springframework.util.ClassUtils;
 
@@ -457,6 +458,10 @@ abstract public class AbstractEntityConfigBuilder {
 			//List<ParamValue> values = srcValues.getValues(created.getCode());
 			created.setValues(aVal);
 			//created.setValues(values);
+		}
+		
+		if(AnnotatedElementUtils.isAnnotated(f, Transient.class)) {
+			created.setTransientData(true);
 		}
 		
 		if(AnnotatedElementUtils.isAnnotated(f, AssociatedEntity.class)) {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultModelConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultModelConfig.java
@@ -61,6 +61,8 @@ public class DefaultModelConfig<T> extends AbstractEntityConfig<T> implements Mo
 	
 	@JsonIgnore	private transient ParamConfig<?> versionParamConfig;
 	
+	@JsonIgnore private boolean transientData;
+	
 	@JsonIgnore
 	private final transient CollectionsTemplate<List<ParamConfig<?>>, ParamConfig<?>> templateParamConfigs = new CollectionsTemplate<>(
 			() -> getParamConfigs(), (p) -> setParamConfigs(p), () -> new LinkedList<>());

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultModelConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultModelConfig.java
@@ -61,8 +61,6 @@ public class DefaultModelConfig<T> extends AbstractEntityConfig<T> implements Mo
 	
 	@JsonIgnore	private transient ParamConfig<?> versionParamConfig;
 	
-	@JsonIgnore private boolean transientData;
-	
 	@JsonIgnore
 	private final transient CollectionsTemplate<List<ParamConfig<?>>, ParamConfig<?>> templateParamConfigs = new CollectionsTemplate<>(
 			() -> getParamConfigs(), (p) -> setParamConfigs(p), () -> new LinkedList<>());

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultParamConfig.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/config/internal/DefaultParamConfig.java
@@ -87,6 +87,9 @@ public class DefaultParamConfig<P> extends AbstractEntityConfig<P> implements Pa
 	@JsonIgnore @Setter 
 	private List<AssociatedEntity> associatedEntities;
 
+	@JsonIgnore 
+	private boolean transientData;
+	
 	protected DefaultParamConfig(String code) {
 		this(code, code, generateNextId());
 	}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
@@ -78,6 +78,10 @@ public class ParamStateAtomicPersistenceEventListener extends ParamStatePersiste
 			throw new InvalidConfigException("No repository implementation provided for the configured repository :"+repo.value().name()+ " for root model: "+p.getRootExecution());
 		}
 		
+		if(p.getConfig().isTransientData()) {
+			return false;
+		}
+		
 		Serializable coreStateId = (Serializable) rootModel.findParamByPath("/id").getState();
 		if(coreStateId == null) {
 			modelRepo._new((ModelConfig<Object>) rootModel.getConfig(), rootModel.getState());

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/repo/db/ParamStateAtomicPersistenceEventListener.java
@@ -78,10 +78,10 @@ public class ParamStateAtomicPersistenceEventListener extends ParamStatePersiste
 			throw new InvalidConfigException("No repository implementation provided for the configured repository :"+repo.value().name()+ " for root model: "+p.getRootExecution());
 		}
 		
-		if(p.getConfig().isTransientData()) {
+		if(p.getConfig().isTransientData() || checkIfAnyParentIsTransient(p)) {
 			return false;
 		}
-		
+	
 		Serializable coreStateId = (Serializable) rootModel.findParamByPath("/id").getState();
 		if(coreStateId == null) {
 			modelRepo._new((ModelConfig<Object>) rootModel.getConfig(), rootModel.getState());
@@ -99,6 +99,17 @@ public class ParamStateAtomicPersistenceEventListener extends ParamStatePersiste
 		
 		modelRepo._update(repoAlias, coreStateId, rootModel.getBeanPath(), rootModel.getState());
 		return true;
+	}
+	
+	private boolean checkIfAnyParentIsTransient(Param<?> p) {
+		if(p.getParentModel()!= null) { 
+			if(p.getParentModel().getAssociatedParam().getConfig().isTransientData()) {
+				return true;
+			} else {
+				return checkIfAnyParentIsTransient(p.getParentModel().getAssociatedParam());
+			}
+		}
+		return false;
 	}
 
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParamConfig.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParamConfig.java
@@ -62,7 +62,7 @@ public class MockParamConfig implements ParamConfig<Object> {
 	private List<AnnotationConfig> validations;
 	private Values values;
 	private List<AnnotationConfig> extensions;
-
+	private boolean transientData;
 	/*
 	 * (non-Javadoc)
 	 * @see com.anthem.oss.nimbus.core.domain.model.config.EntityConfig#findParamByPath(java.lang.String)

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/InnerTestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/InnerTestModel.java
@@ -33,4 +33,5 @@ public class InnerTestModel {
 
 	private String inner_attr2;
 
+	private SecondLevelNestedModel secondLevelNestedModel;
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/InnerTestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/InnerTestModel.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s0.core;
+
+import com.antheminc.oss.nimbus.domain.defn.Model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Sandeep Mantha
+ *
+ */
+
+@Model
+@Getter @Setter
+public class InnerTestModel {
+
+	private String inner_attr1;
+
+	private String inner_attr2;
+
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SecondLevelNestedModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/SecondLevelNestedModel.java
@@ -15,45 +15,23 @@
  */
 package com.antheminc.oss.nimbus.test.scenarios.s0.core;
 
-import org.springframework.data.annotation.Transient;
-
-import com.antheminc.oss.nimbus.domain.defn.Domain;
-import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
 import com.antheminc.oss.nimbus.domain.defn.Model;
-import com.antheminc.oss.nimbus.domain.defn.Repo;
-import com.antheminc.oss.nimbus.entity.AbstractEntity;
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 /**
  * @author Sandeep Mantha
  *
  */
 
-@Domain(value="testmodel_core", includeListeners={ListenerType.persistence, ListenerType.update})
-@Repo(value=Repo.Database.rep_mongodb)
-@Getter @Setter @ToString(callSuper=true)
-public class TestModel extends AbstractEntity.IdLong {
+@Model
+@Getter @Setter
+public class SecondLevelNestedModel {
+	
+	private String nested3_attr1;
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-
-	private String attr1;
-
-	private String attr2;
-
-	@Transient
-	private String attr3;
-
-	@Transient
-	private String attr4;
-
-	@Transient
-	private InnerTestModel innerTestModel;
+	private String nested3_attr2;
 	
 	
 }

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/TestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/core/TestModel.java
@@ -1,0 +1,56 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s0.core;
+
+import org.springframework.data.annotation.Transient;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.entity.AbstractEntity;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * @author Sandeep Mantha
+ *
+ */
+
+@Domain(value="testmodel_core", includeListeners={ListenerType.persistence, ListenerType.update})
+@Repo(value=Repo.Database.rep_mongodb)
+@Getter @Setter @ToString(callSuper=true)
+public class TestModel extends AbstractEntity.IdLong {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String attr1;
+
+	private String attr2;
+
+	@Transient
+	private String attr3;
+
+	@Transient
+	private String attr4;
+
+	@Transient
+	private InnerTestModel innerTestModel;
+}

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRTestModel.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/scenarios/s0/view/VRTestModel.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2016-2019 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.antheminc.oss.nimbus.test.scenarios.s0.view;
+
+import com.antheminc.oss.nimbus.domain.defn.Domain;
+import com.antheminc.oss.nimbus.domain.defn.Domain.ListenerType;
+import com.antheminc.oss.nimbus.domain.defn.MapsTo;
+import com.antheminc.oss.nimbus.domain.defn.Repo;
+import com.antheminc.oss.nimbus.domain.defn.ViewConfig.ViewRoot;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.TestModel;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Sandeep Mantha
+ *
+ */
+@Domain(value="testmodelview", includeListeners={ListenerType.websocket})
+@ViewRoot(layout = "")
+@Repo(value = Repo.Database.rep_none, cache = Repo.Cache.rep_device)
+@Getter @Setter
+@MapsTo.Type(TestModel.class)
+public class VRTestModel {
+
+
+}

--- a/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdateTest.java
+++ b/nimbus-test/src/test/java/com/antheminc/oss/nimbus/domain/cmd/exec/internal/DefaultActionExecutorUpdateTest.java
@@ -17,6 +17,7 @@ package com.antheminc.oss.nimbus.domain.cmd.exec.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -47,6 +48,7 @@ import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreLevel1_Entity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleCoreNestedEntity.Level1;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.SampleNoConversionEntity.NestedNoConversionLevel1;
+import com.antheminc.oss.nimbus.test.scenarios.s0.core.SecondLevelNestedModel;
 import com.antheminc.oss.nimbus.test.scenarios.s0.core.TestModel;
 import com.antheminc.oss.nimbus.test.scenarios.s0.view.VPSampleViewPageRed.Form_ConvertedNestedEntity;
 
@@ -563,6 +565,38 @@ public class DefaultActionExecutorUpdateTest extends AbstractFrameworkIngeration
 
 		TestModel core_afterUpdate = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
 		assertEquals(core.getLastModifiedDate(), core_afterUpdate.getLastModifiedDate());
+
+	}
+	
+	@Test
+	public void t14_transientNestedModelUpdate() {		
+		Long testDomainrefId  = createTestDomain();
+		TestModel core = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+	
+		SecondLevelNestedModel im = new SecondLevelNestedModel();
+		im.setNested3_attr1("test_attr1");
+		im.setNested3_attr2("test_attr2");
+
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(TEST_DOMAIN).addRefId(testDomainrefId)
+				.addNested("/innerTestModel/secondLevelNestedModel").addAction(Action._update).getMock();
+		Object resp = controller.handlePut(request, null, converter.toJson(im));
+
+		TestModel core_afterUpdate = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+		assertEquals(core.getLastModifiedDate(), core_afterUpdate.getLastModifiedDate());
+
+	}
+	
+	@Test
+	public void t15_ModelUpdate() {		
+		Long testDomainrefId  = createTestDomain();
+		TestModel core = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+
+		MockHttpServletRequest request = MockHttpRequestBuilder.withUri(TEST_DOMAIN).addRefId(testDomainrefId)
+				.addNested("/attr2").addAction(Action._update).getMock();
+		Object resp = controller.handlePut(request, null, converter.toJson("test 2"));
+
+		TestModel core_afterUpdate = mongo.findById(testDomainrefId, TestModel.class, "testmodel_core");
+		assertNotEquals(core.getLastModifiedDate(), core_afterUpdate.getLastModifiedDate());
 
 	}
 }


### PR DESCRIPTION
# Description
When a model attribute is marked @Transient the audit fields should not get updated.

# Overview of Changes
Added an attribute to ParamConfig to hold transient information

# Type of Change
- [ ] Bug fix

