### PR TITLE
De-registration of mapped audit view entities from core param

### DIFF
--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/Notification.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/Notification.java
@@ -58,6 +58,8 @@ public class Notification<T> {
 		public void registerConsumer(MappedParam<?, T> consumer);
 		
 		public boolean deregisterConsumer(MappedParam<?, T> consumer);
+		
+		public boolean deregisterConsumer(MappedParam<?, T> consumer, boolean traverseToLeaf);
 	}
 	
 	public interface Dispatcher<T> {

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/StateHolder.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/StateHolder.java
@@ -437,6 +437,11 @@ public class StateHolder {
 		}
 		
 		@Override
+		public boolean deregisterConsumer(MappedParam<?, T> consumer, boolean traverseToLeaf) {
+			throw throwEx();
+		}
+		
+		@Override
 		public void emitNotification(Notification<T> event) {
 			throw throwEx();	
 		}

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AuditViewHandler.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/extension/AuditViewHandler.java
@@ -27,6 +27,7 @@ import com.antheminc.oss.nimbus.domain.cmd.CommandElement.Type;
 import com.antheminc.oss.nimbus.domain.defn.extension.AuditView;
 import com.antheminc.oss.nimbus.domain.model.config.ModelConfig;
 import com.antheminc.oss.nimbus.domain.model.config.ModelConfig.MappedModelConfig;
+import com.antheminc.oss.nimbus.domain.model.state.EntityState.MappedParam;
 import com.antheminc.oss.nimbus.domain.model.state.EntityState.Param;
 import com.antheminc.oss.nimbus.domain.model.state.QuadModel;
 import com.antheminc.oss.nimbus.domain.model.state.builder.QuadModelBuilder;
@@ -64,6 +65,9 @@ public class AuditViewHandler implements OnPersistHandler<AuditView> {
 		
 		QuadModel<?, ?> q = getQuadModelBuilder().build(cmd, mappedEntity, coreParam);
 		Object populatedMappedEntity = q.getView().getLeafState();
+		
+		MappedParam auditViewParam = q.getView().getAssociatedParam().findIfMapped();
+		coreParam.deregisterConsumer(auditViewParam, true);
 		
 		ModelRepository mRepo = getRepo(mappedModelConfig);
 		mRepo._save(mappedModelConfig.getAlias(), populatedMappedEntity);

--- a/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
+++ b/nimbus-core/src/main/java/com/antheminc/oss/nimbus/domain/model/state/internal/DefaultParamState.java
@@ -487,9 +487,15 @@ public class DefaultParamState<T> extends AbstractEntityState<T> implements Para
 	
 	@Override
 	public boolean deregisterConsumer(MappedParam<?, T> subscriber) {
+		return deregisterConsumer(subscriber, false);
+	}
+	
+	@Override
+	public boolean deregisterConsumer(MappedParam<?, T> subscriber, boolean traverseToLeaf) {
 		boolean startNodeRemoved = degisterThis(subscriber);
 		
-//		traverse(subscriber);
+		if(traverseToLeaf)
+			traverse(subscriber);
 		return startNodeRemoved;
 	}
 	

--- a/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParam.java
+++ b/nimbus-test/src/main/java/com/antheminc/oss/nimbus/test/domain/mock/MockParam.java
@@ -122,6 +122,11 @@ public class MockParam implements Param<Object> {
 	public boolean deregisterConsumer(MappedParam<?, Object> consumer) {
 		return this.consumers.remove(consumer);
 	}
+	
+	@Override
+	public boolean deregisterConsumer(MappedParam<?, Object> consumer, boolean traverseToLeaf) {
+		return this.consumers.remove(consumer);
+	}
 
 	/* (non-Javadoc)
 	 * @see com.anthem.oss.nimbus.core.domain.model.state.Notification.Dispatcher#emitNotification(com.anthem.oss.nimbus.core.domain.model.state.Notification)


### PR DESCRIPTION
# Description
De-registration of mapped audit view entities from core param, post audit entry within AuditViewHandler.

# Overview of Changes
Changes made in AuditViewHandler

# Type of Change
<!--
- [ ] New feature
- [ ] Bug fix
- [x ] Refactor/Technical Debt
- [ ] Documentation Update
- [ ] Test case change
- [ ] This change requires a documentation update
- [ ] Other
-->

