### PR TITLE
NIMBUS-696 :: enable controls when recreated

### DIFF
--- a/nimbus-ui/nimbusui/src/app/components/platform/fileupload/file-upload.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/fileupload/file-upload.component.ts
@@ -169,6 +169,15 @@ export class FileUploadComponent extends BaseElement
       this.form.controls[this.element.config.code] != null
     ) {
       let frmCtrl = this.form.controls[this.element.config.code];
+      if(frmCtrl.status === "DISABLED") {
+        if (this.element.enabled && this.element.visible) {
+          frmCtrl.enable();
+          this.counterMessageService.evalCounterMessage(true);
+          this.counterMessageService.evalFormParamMessages(this.element);
+        } else {
+          frmCtrl.disable();
+        }
+      }
       this.subscribers.push(
         frmCtrl.valueChanges.subscribe($event => {
           if (frmCtrl.valid && this.sendEvent) {

--- a/nimbus-ui/nimbusui/src/app/components/platform/fileupload/file-upload.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/fileupload/file-upload.component.ts
@@ -174,8 +174,6 @@ export class FileUploadComponent extends BaseElement
           frmCtrl.enable();
           this.counterMessageService.evalCounterMessage(true);
           this.counterMessageService.evalFormParamMessages(this.element);
-        } else {
-          frmCtrl.disable();
         }
       }
       this.subscribers.push(

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
@@ -125,8 +125,6 @@ export abstract class BaseControl<T> extends BaseControlValueAccessor<T> {
           frmCtrl.enable();
           this.counterMessageService.evalCounterMessage(true);
           this.counterMessageService.evalFormParamMessages(this.element);
-        } else {
-          frmCtrl.disable();
         }
       }
       this.subscribers.push(

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/base-control.component.ts
@@ -120,6 +120,15 @@ export abstract class BaseControl<T> extends BaseControlValueAccessor<T> {
       this.form.controls[this.element.config.code] != null
     ) {
       let frmCtrl = this.form.controls[this.element.config.code];
+      if(frmCtrl.status === "DISABLED") {
+        if (this.element.enabled && this.element.visible) {
+          frmCtrl.enable();
+          this.counterMessageService.evalCounterMessage(true);
+          this.counterMessageService.evalFormParamMessages(this.element);
+        } else {
+          frmCtrl.disable();
+        }
+      }
       this.subscribers.push(
         frmCtrl.valueChanges.subscribe($event => {
           this.setState($event, this);

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/checkbox-group.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/checkbox-group.component.ts
@@ -157,8 +157,6 @@ export class CheckBoxGroup extends BaseElement implements ControlValueAccessor {
         frmCtrl.enable();
         this.counterMessageService.evalCounterMessage(true);
         this.counterMessageService.evalFormParamMessages(this.element);
-      } else {
-        frmCtrl.disable();
       }
     }
     //rebind the validations as there are dynamic validations along with the static validations

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/checkbox-group.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/checkbox-group.component.ts
@@ -152,6 +152,15 @@ export class CheckBoxGroup extends BaseElement implements ControlValueAccessor {
   ngOnInit() {
     super.ngOnInit();
     let frmCtrl = this.form.controls[this.element.config.code];
+    if(frmCtrl != null && frmCtrl.status === "DISABLED") {
+      if (this.element.enabled && this.element.visible) {
+        frmCtrl.enable();
+        this.counterMessageService.evalCounterMessage(true);
+        this.counterMessageService.evalFormParamMessages(this.element);
+      } else {
+        frmCtrl.disable();
+      }
+    }
     //rebind the validations as there are dynamic validations along with the static validations
     if (
       frmCtrl != null &&

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/multi-select-card.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/multi-select-card.component.ts
@@ -156,8 +156,6 @@ export class MultiselectCard extends BaseElement
           frmCtrl.enable();
           this.counterMessageService.evalCounterMessage(true);
           this.counterMessageService.evalFormParamMessages(this.element);
-        } else {
-          frmCtrl.disable();
         }
       }
       frmCtrl.valueChanges.subscribe($event => {

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/multi-select-card.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/multi-select-card.component.ts
@@ -151,6 +151,15 @@ export class MultiselectCard extends BaseElement
       this.form.controls[this.element.config.code] != null
     ) {
       let frmCtrl = this.form.controls[this.element.config.code];
+      if(frmCtrl.status === "DISABLED") {
+        if (this.element.enabled && this.element.visible) {
+          frmCtrl.enable();
+          this.counterMessageService.evalCounterMessage(true);
+          this.counterMessageService.evalFormParamMessages(this.element);
+        } else {
+          frmCtrl.disable();
+        }
+      }
       frmCtrl.valueChanges.subscribe($event => {
         this.setState($event);
         if (frmCtrl.valid && this.sendEvent) {

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
@@ -151,8 +151,6 @@ export class OrderablePickList extends BaseElement
               frmCtrl.enable();
               this.counterMessageService.evalCounterMessage(true);
               this.counterMessageService.evalFormParamMessages(this.element);
-            } else {
-              frmCtrl.disable();
             }
           }
           if (frmCtrl) {

--- a/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/form/elements/picklist.component.ts
@@ -146,6 +146,15 @@ export class OrderablePickList extends BaseElement
           this.setState($event, this);
           // setting parent Picklist value manually
           let frmCtrl = this.form.controls[this.element.config.code];
+          if(frmCtrl!=null && frmCtrl.status === "DISABLED") {
+            if (this.element.enabled && this.element.visible) {
+              frmCtrl.enable();
+              this.counterMessageService.evalCounterMessage(true);
+              this.counterMessageService.evalFormParamMessages(this.element);
+            } else {
+              frmCtrl.disable();
+            }
+          }
           if (frmCtrl) {
             if (frmCtrl.valid && this.sendEvent) {
               this.counterMessageService.evalCounterMessage(true);

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
@@ -487,6 +487,15 @@ export class DataTable extends BaseTableElement
       this.form.controls[this.element.config.code] != null
     ) {
       let frmCtrl = this.form.controls[this.element.config.code];
+      if(frmCtrl.status === "DISABLED") {
+        if (this.element.enabled && this.element.visible) {
+          frmCtrl.enable();
+          this.counterMessageService.evalCounterMessage(true);
+          this.counterMessageService.evalFormParamMessages(this.element);
+        } else {
+          frmCtrl.disable();
+        }
+      }
       this.subscribers.push(
         frmCtrl.valueChanges.subscribe($event => {
           if (frmCtrl.valid && this.sendEvent) {

--- a/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/grid/table.component.ts
@@ -492,8 +492,6 @@ export class DataTable extends BaseTableElement
           frmCtrl.enable();
           this.counterMessageService.evalCounterMessage(true);
           this.counterMessageService.evalFormParamMessages(this.element);
-        } else {
-          frmCtrl.disable();
         }
       }
       this.subscribers.push(

--- a/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.ts
@@ -145,8 +145,6 @@ export class TreeGrid extends BaseTableElement implements ControlValueAccessor {
           frmCtrl.enable();
           this.counterMessageService.evalCounterMessage(true);
           this.counterMessageService.evalFormParamMessages(this.element);
-        } else {
-          frmCtrl.disable();
         }
       }
       this.subscribers.push(

--- a/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.ts
+++ b/nimbus-ui/nimbusui/src/app/components/platform/tree-grid/tree-grid.component.ts
@@ -140,6 +140,15 @@ export class TreeGrid extends BaseTableElement implements ControlValueAccessor {
       this.form.controls[this.element.config.code] != null
     ) {
       let frmCtrl = this.form.controls[this.element.config.code];
+      if(frmCtrl.status === "DISABLED") {
+        if (this.element.enabled && this.element.visible) {
+          frmCtrl.enable();
+          this.counterMessageService.evalCounterMessage(true);
+          this.counterMessageService.evalFormParamMessages(this.element);
+        } else {
+          frmCtrl.disable();
+        }
+      }
       this.subscribers.push(
         frmCtrl.valueChanges.subscribe($event => {
           if (frmCtrl.valid && this.sendEvent) {


### PR DESCRIPTION
# Description
Form controls were not participating in the validations when recreated

# Overview of Changes
formControl.enable() called explicitly

# Type of Change
- [x] Bug fix
